### PR TITLE
Reveal routes progressively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.1
+
+- Start videos with a clean map instead of drawing the entire future route.
+- Reveal the traveled route progressively behind the moving position marker.
+- Keep the stronger recent trail, stabilized camera, and long-distance tracking.
+
 ## 1.6.0
 
 - Continue video creation in a foreground media-processing service when the user

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@ JSON 파일과 영상 렌더링은 휴대전화 안에서 처리됩니다.
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v1.6.0.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v1.6.1.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ an MP4 ready to share.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v1.6.0.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v1.6.1.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7
-        versionName = "1.6.0"
+        versionCode = 8
+        versionName = "1.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -231,8 +231,6 @@ class TimelinePainter {
         val screen = prepared.projected.mapIndexed { index, point ->
             worldToScreen(WorldPoint(prepared.unwrappedX[index], point.y), viewport, width, height)
         }
-        drawSamplePath(canvas, screen.indices, screen, routePaint)
-
         val current = journey.positionAt(progress)
         val traveledEnd = prepared.upperBound(current.distanceKm)
         val traveledIndices = if (traveledEnd >= 0) 0..traveledEnd else IntRange.EMPTY

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
@@ -1,0 +1,62 @@
+package dev.mahlernim.timelinevisualizer.render
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import dev.mahlernim.timelinevisualizer.model.GeoPoint
+import dev.mahlernim.timelinevisualizer.model.Journey
+import java.time.Instant
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TimelinePainterTest {
+    @Test
+    fun routeStartsEmptyAndAppearsOnlyAsJourneyAdvances() {
+        val points = listOf(
+            GeoPoint(Instant.parse("2025-01-01T00:00:00Z"), 37.45, 126.75),
+            GeoPoint(Instant.parse("2025-04-01T00:00:00Z"), 37.65, 127.20),
+            GeoPoint(Instant.parse("2025-08-01T00:00:00Z"), 37.35, 127.55),
+            GeoPoint(Instant.parse("2025-12-01T00:00:00Z"), 37.75, 127.90),
+        )
+        val journey = Journey.from(points, 2025)
+        val start = render(journey, 0f)
+        val halfway = render(journey, 0.5f)
+
+        val startRoutePixels = countRouteColoredPixels(start)
+        val halfwayRoutePixels = countRouteColoredPixels(halfway)
+
+        assertTrue("The initial marker used $startRoutePixels route-colored pixels", startRoutePixels < 500)
+        assertTrue(
+            "The traveled route should be visibly longer ($startRoutePixels vs $halfwayRoutePixels pixels)",
+            halfwayRoutePixels > startRoutePixels * 2,
+        )
+    }
+
+    private fun render(journey: Journey, progress: Float): Bitmap {
+        val bitmap = Bitmap.createBitmap(SIZE, SIZE, Bitmap.Config.ARGB_8888)
+        TimelinePainter().draw(Canvas(bitmap), SIZE, SIZE, journey, progress, "Timeline") { null }
+        return bitmap
+    }
+
+    private fun countRouteColoredPixels(bitmap: Bitmap): Int {
+        var count = 0
+        for (y in 0 until bitmap.height) {
+            for (x in 0 until bitmap.width) {
+                val color = bitmap.getPixel(x, y)
+                if (Color.red(color) > 180 && Color.green(color) < 190 && Color.blue(color) < 210) count++
+            }
+        }
+        return count
+    }
+
+    companion object {
+        private const val SIZE = 360
+    }
+}

--- a/docs/release-notes-v1.6.1.md
+++ b/docs/release-notes-v1.6.1.md
@@ -1,0 +1,22 @@
+# Timeline Visualizer 1.6.1
+
+## A cleaner beginning
+
+Videos now begin with a clean map and reveal the route as the position marker
+moves. The full future route is no longer drawn before the journey starts.
+
+The recent part of the journey remains brighter and easier to follow. Camera
+stabilization, smooth long-distance travel, background video creation, and
+completion notifications continue to work as before.
+
+---
+
+# 타임라인 비주얼라이저 1.6.1
+
+## 더 깔끔해진 영상 시작 화면
+
+이제 영상은 이동 예정 경로가 미리 표시되지 않은 깔끔한 지도에서 시작합니다.
+위치 마커가 움직이면 지나온 경로만 자연스럽게 나타납니다.
+
+최근 이동 구간은 계속 더 선명하게 표시됩니다. 카메라 안정화, 부드러운 장거리 이동,
+백그라운드 영상 만들기와 완성 알림은 이전과 동일하게 작동합니다.

--- a/tests/test_play_store_materials.py
+++ b/tests/test_play_store_materials.py
@@ -46,6 +46,6 @@ def test_phone_screenshots_are_current_play_recommended_size():
 
 def test_play_release_metadata_is_consistent():
     build_file = (ROOT / "app" / "build.gradle.kts").read_text(encoding="utf-8")
-    assert 'versionCode = 7' in build_file
-    assert 'versionName = "1.6.0"' in build_file
-    assert (ROOT / "docs" / "release-notes-v1.6.0.md").is_file()
+    assert 'versionCode = 8' in build_file
+    assert 'versionName = "1.6.1"' in build_file
+    assert (ROOT / "docs" / "release-notes-v1.6.1.md").is_file()


### PR DESCRIPTION
## What changed

- stop drawing the entire future route on the opening frame
- reveal only the traveled path behind the moving marker
- retain the stronger recent trail and existing camera behavior
- add a native-rendering pixel regression test
- bump the app to v1.6.1 with concise English and Korean release notes

## Why

The shared preview and MP4 renderer deliberately drew every route segment before playback began. This made the opening frame cluttered and revealed the full journey in advance.

## Validation

- native-rendering regression test comparing opening and halfway frames
- installed preview smoke test
- generated 30-second MP4 with extracted opening and halfway frame inspection
- full Gradle tests and lint
- Python parser and Play-material tests
- signed GitHub APK and Play AAB
- package, version, and production signing-certificate verification