### PR TITLE
Release Timeline Visualizer 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.1
+
+- Parse current Timeline path points that store a minute offset from the segment
+  start instead of an absolute timestamp.
+- Prefer valid absolute path timestamps and safely ignore invalid, negative, or
+  out-of-range offsets.
+- Distinguish malformed JSON, older Google Takeout formats, raw-only exports,
+  and exports without usable locations.
+- Keep Android and Python Timeline parsing behavior aligned.
+- Correct the Play submission checklist and English privacy-policy wording.
+- Set Android version code 14 and version name 2.0.1.
+
 ## 2.0.0
 
 - Add bottom navigation for My videos, Create video, and Settings while preserving unfinished creation state.

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@ Google マップから書き出した Timeline JSON を使い、Android 端末�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.0.0.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.0.1.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,7 +15,7 @@ JSON 파일과 영상 렌더링은 휴대전화 안에서 처리됩니다.
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.0.0.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.0.1.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ exact dates, preview the Journey, and create an MP4 ready to watch or share.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.0.0.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.0.1.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 13
-        versionName = "2.0.0"
+        versionCode = 14
+        versionName = "2.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -38,6 +38,8 @@ import androidx.media3.exoplayer.ExoPlayer
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.snackbar.Snackbar
+import dev.mahlernim.timelinevisualizer.data.TimelineParseException
+import dev.mahlernim.timelinevisualizer.data.TimelineParseReason
 import dev.mahlernim.timelinevisualizer.data.TimelineParser
 import dev.mahlernim.timelinevisualizer.data.TimelineSourceStore
 import dev.mahlernim.timelinevisualizer.databinding.ActivityMainBinding
@@ -471,6 +473,18 @@ class MainActivity : AppCompatActivity() {
                 if (!remembered) rememberTimelineSource(uri)
             } catch (cancelled: CancellationException) {
                 throw cancelled
+            } catch (error: TimelineParseException) {
+                Log.e(TAG, "Timeline import failed", error)
+                timeline = null
+                if (remembered) {
+                    timelineSourceStore.clear()
+                    releaseUriAccess(uri)
+                    editor.statusText.setText(R.string.timeline_file_unavailable)
+                    Snackbar.make(binding.root, R.string.choose_timeline_again, Snackbar.LENGTH_LONG).show()
+                } else {
+                    editor.statusText.setText(timelineParseMessage(error.reason))
+                    Snackbar.make(binding.root, R.string.import_failed, Snackbar.LENGTH_LONG).show()
+                }
             } catch (error: Throwable) {
                 Log.e(TAG, "Timeline import failed", error)
                 timeline = null
@@ -488,6 +502,14 @@ class MainActivity : AppCompatActivity() {
                 importJob = null
             }
         }
+    }
+
+    private fun timelineParseMessage(reason: TimelineParseReason): Int = when (reason) {
+        TimelineParseReason.MALFORMED_JSON -> R.string.timeline_error_malformed
+        TimelineParseReason.LEGACY_FORMAT -> R.string.timeline_error_legacy
+        TimelineParseReason.RAW_SIGNALS_ONLY -> R.string.timeline_error_raw_only
+        TimelineParseReason.NO_USABLE_LOCATIONS -> R.string.timeline_error_no_locations
+        TimelineParseReason.UNSUPPORTED_FORMAT -> R.string.import_failed_detail
     }
 
     private fun setTimelineLoading(loading: Boolean, stage: Int = R.string.opening_timeline) {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
@@ -2,8 +2,10 @@ package dev.mahlernim.timelinevisualizer.data
 
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
+import com.google.gson.stream.MalformedJsonException
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Timeline
+import java.io.EOFException
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.time.Instant
@@ -11,14 +13,29 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeParseException
 
 class TimelineParser {
-    fun parse(input: InputStream): Timeline {
+    fun parse(input: InputStream): Timeline = try {
+        parseSupportedTimeline(input)
+    } catch (error: TimelineParseException) {
+        throw error
+    } catch (error: MalformedJsonException) {
+        throw TimelineParseException(TimelineParseReason.MALFORMED_JSON, "Timeline JSON is malformed", error)
+    } catch (error: EOFException) {
+        throw TimelineParseException(TimelineParseReason.MALFORMED_JSON, "Timeline JSON is incomplete", error)
+    } catch (error: IllegalStateException) {
+        throw TimelineParseException(TimelineParseReason.MALFORMED_JSON, "Timeline JSON has an invalid structure", error)
+    }
+
+    private fun parseSupportedTimeline(input: InputStream): Timeline {
         val points = mutableListOf<GeoPoint>()
         JsonReader(InputStreamReader(input, Charsets.UTF_8)).use { reader ->
             reader.isLenient = true
             when (reader.peek()) {
                 JsonToken.BEGIN_ARRAY -> readSegments(reader, points)
                 JsonToken.BEGIN_OBJECT -> readRootObject(reader, points)
-                else -> throw TimelineParseException("Timeline JSON must start with an object or array")
+                else -> throw TimelineParseException(
+                    TimelineParseReason.UNSUPPORTED_FORMAT,
+                    "Timeline JSON must start with an object or array",
+                )
             }
         }
 
@@ -30,13 +47,18 @@ class TimelineParser {
             .toList()
 
         if (normalized.isEmpty()) {
-            throw TimelineParseException("No supported location points were found in this export")
+            throw TimelineParseException(
+                TimelineParseReason.NO_USABLE_LOCATIONS,
+                "No supported location points were found in this export",
+            )
         }
         return Timeline(normalized)
     }
 
     private fun readRootObject(reader: JsonReader, points: MutableList<GeoPoint>) {
         var foundSegments = false
+        var foundRawSignals = false
+        var foundLegacyFormat = false
         reader.beginObject()
         while (reader.hasNext()) {
             when (reader.nextName()) {
@@ -44,12 +66,25 @@ class TimelineParser {
                     foundSegments = true
                     readSegments(reader, points)
                 }
+                "rawSignals" -> {
+                    foundRawSignals = true
+                    reader.skipValue()
+                }
+                "timelineObjects", "locations" -> {
+                    foundLegacyFormat = true
+                    reader.skipValue()
+                }
                 else -> reader.skipValue()
             }
         }
         reader.endObject()
         if (!foundSegments) {
-            throw TimelineParseException("This JSON does not contain semanticSegments")
+            val reason = when {
+                foundLegacyFormat -> TimelineParseReason.LEGACY_FORMAT
+                foundRawSignals -> TimelineParseReason.RAW_SIGNALS_ONLY
+                else -> TimelineParseReason.UNSUPPORTED_FORMAT
+            }
+            throw TimelineParseException(reason, "This JSON does not contain semanticSegments")
         }
     }
 
@@ -88,6 +123,7 @@ class TimelineParser {
 
         path.forEach { timed ->
             val instant = parseInstant(timed.time)
+                ?: parseOffsetInstant(startTime, endTime, timed.offsetMinutes)
             val coordinate = parseCoordinate(timed.coordinate)
             if (instant != null && coordinate != null) {
                 output += GeoPoint(instant, coordinate.first, coordinate.second)
@@ -108,6 +144,7 @@ class TimelineParser {
         while (reader.hasNext()) {
             var point: String? = null
             var time: String? = null
+            var offsetMinutes: Long? = null
             if (reader.peek() != JsonToken.BEGIN_OBJECT) {
                 reader.skipValue()
                 continue
@@ -117,11 +154,14 @@ class TimelineParser {
                 when (reader.nextName()) {
                     "point" -> point = reader.readCoordinateValue()
                     "time" -> time = reader.readStringOrNull()
+                    "durationMinutesOffsetFromStartTime" -> offsetMinutes = reader.readLongOrNull()
                     else -> reader.skipValue()
                 }
             }
             reader.endObject()
-            if (point != null && time != null) output += TimedCoordinate(point, time)
+            if (point != null && (time != null || offsetMinutes != null)) {
+                output += TimedCoordinate(point, time, offsetMinutes)
+            }
         }
         reader.endArray()
     }
@@ -200,6 +240,18 @@ class TimelineParser {
         }
     }
 
+    private fun JsonReader.readLongOrNull(): Long? = when (peek()) {
+        JsonToken.STRING, JsonToken.NUMBER -> nextString().toLongOrNull()
+        JsonToken.NULL -> {
+            nextNull()
+            null
+        }
+        else -> {
+            skipValue()
+            null
+        }
+    }
+
     private fun addPoint(output: MutableList<GeoPoint>, time: String?, rawCoordinate: String?) {
         val instant = parseInstant(time)
         val coordinate = parseCoordinate(rawCoordinate)
@@ -240,7 +292,34 @@ class TimelineParser {
         }
     }
 
-    private data class TimedCoordinate(val coordinate: String, val time: String)
+    private fun parseOffsetInstant(startRaw: String?, endRaw: String?, offsetMinutes: Long?): Instant? {
+        if (offsetMinutes == null || offsetMinutes < 0) return null
+        val start = parseInstant(startRaw) ?: return null
+        val instant = runCatching {
+            start.plusSeconds(Math.multiplyExact(offsetMinutes, 60L))
+        }.getOrNull() ?: return null
+        val end = parseInstant(endRaw)
+        if (end != null && instant.isAfter(end.plusSeconds(60))) return null
+        return instant
+    }
+
+    private data class TimedCoordinate(
+        val coordinate: String,
+        val time: String?,
+        val offsetMinutes: Long?,
+    )
 }
 
-class TimelineParseException(message: String) : Exception(message)
+enum class TimelineParseReason {
+    MALFORMED_JSON,
+    LEGACY_FORMAT,
+    RAW_SIGNALS_ONLY,
+    UNSUPPORTED_FORMAT,
+    NO_USABLE_LOCATIONS,
+}
+
+class TimelineParseException(
+    val reason: TimelineParseReason,
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -23,6 +23,10 @@
     <string name="share_travel_video">Teilen Sie Reisevideos</string>
     <string name="import_failed">Timeline konnte nicht geladen werden</string>
     <string name="import_failed_detail">Diese Datei konnte nicht gelesen werden. Wählen Sie einen unterstützten Timeline JSON-Export aus.</string>
+    <string name="timeline_error_malformed">Diese Datei enthält kein gültiges oder vollständiges JSON.</string>
+    <string name="timeline_error_legacy">Dies ist ein älteres Google Takeout-Format. Exportieren Sie die Timeline-Daten stattdessen vom Telefon.</string>
+    <string name="timeline_error_raw_only">Dieser Export enthält Rohsignale, aber keine rekonstruierten Timeline-Reisen.</string>
+    <string name="timeline_error_no_locations">Dieser Timeline-Export enthält keine verwendbaren Standortpunkte.</string>
     <string name="remembered_timeline_unavailable">Der bisher verwendete Timeline ist nicht mehr verfügbar.</string>
     <string name="choose_timeline_again">Wählen Sie erneut die Datei Timeline.json.</string>
     <string name="video_export_failed">Video konnte nicht erstellt werden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -23,6 +23,10 @@
     <string name="share_travel_video">Compartir vídeo de viaje</string>
     <string name="import_failed">No se pudo cargar Timeline</string>
     <string name="import_failed_detail">Este archivo no se pudo leer. Seleccione una exportación JSON Timeline compatible.</string>
+    <string name="timeline_error_malformed">Este archivo no es un JSON válido o completo.</string>
+    <string name="timeline_error_legacy">Este es un formato antiguo de Google Takeout. Exporte los datos de Timeline desde su teléfono.</string>
+    <string name="timeline_error_raw_only">Esta exportación contiene señales sin procesar, pero no viajes reconstruidos de Timeline.</string>
+    <string name="timeline_error_no_locations">Esta exportación de Timeline no contiene puntos de ubicación utilizables.</string>
     <string name="remembered_timeline_unavailable">El modelo Timeline usado anteriormente ya no está disponible.</string>
     <string name="choose_timeline_again">Elija el archivo Timeline.json nuevamente.</string>
     <string name="video_export_failed">No se pudo crear el vídeo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -23,6 +23,10 @@
     <string name="share_travel_video">Partager une vidéo de voyage</string>
     <string name="import_failed">Impossible de charger Timeline</string>
     <string name="import_failed_detail">Ce fichier n\'a pas pu être lu. Sélectionnez une exportation JSON Timeline prise en charge.</string>
+    <string name="timeline_error_malformed">Ce fichier ne contient pas de JSON valide ou complet.</string>
+    <string name="timeline_error_legacy">Il s\'agit d\'un ancien format Google Takeout. Exportez les données Timeline depuis votre téléphone.</string>
+    <string name="timeline_error_raw_only">Cette exportation contient des signaux bruts, mais aucun trajet Timeline reconstruit.</string>
+    <string name="timeline_error_no_locations">Cette exportation Timeline ne contient aucun point de localisation utilisable.</string>
     <string name="remembered_timeline_unavailable">Le Timeline précédemment utilisé n’est plus disponible.</string>
     <string name="choose_timeline_again">Choisissez à nouveau le fichier Timeline.json.</string>
     <string name="video_export_failed">Impossible de créer une vidéo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -22,6 +22,10 @@
     <string name="share_travel_video">旅行動画を共有</string>
     <string name="import_failed">読み込みに失敗しました</string>
     <string name="import_failed_detail">このファイルを読み取れませんでした。対応する Timeline JSON の書き出しファイルを選択してください。</string>
+    <string name="timeline_error_malformed">有効または完全な JSON ファイルではありません。</string>
+    <string name="timeline_error_legacy">以前の Google Takeout 形式です。端末からタイムライン データを書き出してください。</string>
+    <string name="timeline_error_raw_only">この書き出しには生の信号だけがあり、再構成された移動経路がありません。</string>
+    <string name="timeline_error_no_locations">このタイムラインの書き出しには使用できる位置情報がありません。</string>
     <string name="remembered_timeline_unavailable">前回使用したタイムラインを開けなくなりました。</string>
     <string name="choose_timeline_again">Timeline.jsonをもう一度選択してください。</string>
     <string name="video_export_failed">動画を作成できませんでした</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -22,6 +22,10 @@
     <string name="share_travel_video">여행 영상 공유</string>
     <string name="import_failed">파일을 불러오지 못했습니다</string>
     <string name="import_failed_detail">이 파일을 읽을 수 없습니다. 지원되는 Timeline JSON 내보내기 파일을 선택해 주세요.</string>
+    <string name="timeline_error_malformed">올바르거나 완전한 JSON 파일이 아닙니다.</string>
+    <string name="timeline_error_legacy">이 파일은 이전 Google 테이크아웃 형식입니다. 휴대전화에서 타임라인 데이터를 내보내 주세요.</string>
+    <string name="timeline_error_raw_only">이 내보내기에는 원시 신호만 있고 재구성된 타임라인 이동 경로가 없습니다.</string>
+    <string name="timeline_error_no_locations">이 타임라인 내보내기에는 사용할 수 있는 위치 지점이 없습니다.</string>
     <string name="remembered_timeline_unavailable">이전에 사용한 타임라인 파일을 더 이상 열 수 없습니다.</string>
     <string name="choose_timeline_again">Timeline.json 파일을 다시 선택해 주세요.</string>
     <string name="video_export_failed">영상을 만들지 못했습니다</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -23,6 +23,10 @@
     <string name="share_travel_video">Compartilhe vídeo de viagem</string>
     <string name="import_failed">Não foi possível carregar Timeline</string>
     <string name="import_failed_detail">Este arquivo não pôde ser lido. Selecione uma exportação JSON Timeline compatível.</string>
+    <string name="timeline_error_malformed">Este arquivo não contém um JSON válido ou completo.</string>
+    <string name="timeline_error_legacy">Este é um formato antigo do Google Takeout. Exporte os dados do Timeline pelo telefone.</string>
+    <string name="timeline_error_raw_only">Esta exportação contém sinais brutos, mas não contém viagens reconstruídas do Timeline.</string>
+    <string name="timeline_error_no_locations">Esta exportação do Timeline não contém pontos de localização utilizáveis.</string>
     <string name="remembered_timeline_unavailable">O Timeline usado anteriormente não está mais disponível.</string>
     <string name="choose_timeline_again">Escolha o arquivo Timeline.json novamente.</string>
     <string name="video_export_failed">Não foi possível criar o vídeo</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -23,6 +23,10 @@
     <string name="share_travel_video">分享旅游视频</string>
     <string name="import_failed">无法加载Timeline</string>
     <string name="import_failed_detail">无法读取该文件。选择支持的 Timeline JSON 导出。</string>
+    <string name="timeline_error_malformed">此文件不是有效或完整的 JSON。</string>
+    <string name="timeline_error_legacy">这是旧版 Google Takeout 格式。请改为从手机导出 Timeline 数据。</string>
+    <string name="timeline_error_raw_only">此导出仅包含原始信号，没有重建的 Timeline 行程。</string>
+    <string name="timeline_error_no_locations">此 Timeline 导出不包含可用的位置点。</string>
     <string name="remembered_timeline_unavailable">之前使用的Timeline不再可用。</string>
     <string name="choose_timeline_again">再次选择 Timeline.json 文件。</string>
     <string name="video_export_failed">无法创建视频</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -23,6 +23,10 @@
     <string name="share_travel_video">分享旅遊視頻</string>
     <string name="import_failed">無法載入Timeline</string>
     <string name="import_failed_detail">無法讀取該檔案。選擇支援的 Timeline JSON 匯出。</string>
+    <string name="timeline_error_malformed">此檔案不是有效或完整的 JSON。</string>
+    <string name="timeline_error_legacy">這是舊版 Google Takeout 格式。請改為從手機匯出 Timeline 資料。</string>
+    <string name="timeline_error_raw_only">此匯出僅包含原始訊號，沒有重建的 Timeline 行程。</string>
+    <string name="timeline_error_no_locations">此 Timeline 匯出不包含可用的位置點。</string>
     <string name="remembered_timeline_unavailable">之前使用的Timeline不再可用。</string>
     <string name="choose_timeline_again">再次選擇 Timeline.json 檔案。</string>
     <string name="video_export_failed">無法創建視頻</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,10 @@
     <string name="share_travel_video">Share travel video</string>
     <string name="import_failed">Could not load Timeline</string>
     <string name="import_failed_detail">This file could not be read. Select a supported Timeline JSON export.</string>
+    <string name="timeline_error_malformed">This file is not valid or complete JSON.</string>
+    <string name="timeline_error_legacy">This is an older Google Takeout format. Export Timeline data from your phone instead.</string>
+    <string name="timeline_error_raw_only">This export contains raw signals but no reconstructed Timeline journeys.</string>
+    <string name="timeline_error_no_locations">This Timeline export contains no usable location points.</string>
     <string name="remembered_timeline_unavailable">The previously used Timeline is no longer available.</string>
     <string name="choose_timeline_again">Choose the Timeline.json file again.</string>
     <string name="video_export_failed">Could not create video</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
+import java.time.Instant
 
 class TimelineParserTest {
     private val parser = TimelineParser()
@@ -82,6 +83,87 @@ class TimelineParserTest {
         assertEquals(null, parser.parseCoordinate("geo:91,127"))
     }
 
+    @Test
+    fun parsesStringAndNumericOffsetsFromSegmentStart() {
+        val timeline = parse(
+            """
+            [{
+              "startTime": "2026-01-01T00:00:00Z",
+              "endTime": "2026-01-01T02:00:00Z",
+              "timelinePath": [
+                {"point": "37.0,127.0", "durationMinutesOffsetFromStartTime": "15"},
+                {"point": "37.1,127.1", "durationMinutesOffsetFromStartTime": 60}
+              ]
+            }]
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            listOf(Instant.parse("2026-01-01T00:15:00Z"), Instant.parse("2026-01-01T01:00:00Z")),
+            timeline.points.map { it.instant },
+        )
+    }
+
+    @Test
+    fun validAbsolutePathTimeTakesPriorityOverOffset() {
+        val timeline = parse(
+            """
+            [{
+              "startTime": "2026-01-01T00:00:00Z",
+              "endTime": "2026-01-01T02:00:00Z",
+              "timelinePath": [{
+                "point": "37.0,127.0",
+                "time": "2026-01-01T01:30:00Z",
+                "durationMinutesOffsetFromStartTime": "5"
+              }]
+            }]
+            """.trimIndent(),
+        )
+
+        assertEquals(Instant.parse("2026-01-01T01:30:00Z"), timeline.points.single().instant)
+    }
+
+    @Test
+    fun ignoresInvalidAndOutOfRangeOffsets() {
+        val timeline = parse(
+            """
+            [{
+              "startTime": "2026-01-01T00:00:00Z",
+              "endTime": "2026-01-01T01:00:00Z",
+              "timelinePath": [
+                {"point": "37.0,127.0", "durationMinutesOffsetFromStartTime": "-1"},
+                {"point": "37.1,127.1", "durationMinutesOffsetFromStartTime": "unknown"},
+                {"point": "37.2,127.2", "durationMinutesOffsetFromStartTime": "120"}
+              ],
+              "visit": {"topCandidate": {"placeLocation": "37.3,127.3"}}
+            }]
+            """.trimIndent(),
+        )
+
+        assertEquals(1, timeline.points.size)
+        assertEquals(37.3, timeline.points.single().latitude, 0.00001)
+    }
+
+    @Test
+    fun classifiesUnsupportedTimelineFormats() {
+        assertEquals(
+            TimelineParseReason.LEGACY_FORMAT,
+            parseFailure("""{"timelineObjects": []}""").reason,
+        )
+        assertEquals(
+            TimelineParseReason.RAW_SIGNALS_ONLY,
+            parseFailure("""{"rawSignals": []}""").reason,
+        )
+        assertEquals(
+            TimelineParseReason.NO_USABLE_LOCATIONS,
+            parseFailure("""{"semanticSegments": []}""").reason,
+        )
+        assertEquals(
+            TimelineParseReason.MALFORMED_JSON,
+            parseFailure("""{"semanticSegments": [""").reason,
+        )
+    }
+
     @Test(expected = TimelineParseException::class)
     fun rejectsUnsupportedJson() {
         parse("""{"locations": []}""")
@@ -108,4 +190,11 @@ class TimelineParserTest {
     }
 
     private fun parse(json: String) = parser.parse(ByteArrayInputStream(json.toByteArray()))
+
+    private fun parseFailure(json: String): TimelineParseException = try {
+        parse(json)
+        throw AssertionError("Expected TimelineParseException")
+    } catch (error: TimelineParseException) {
+        error
+    }
 }

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -24,9 +24,11 @@ the selected route points and export settings are temporarily stored in private
 app storage so creation can continue when the app is no longer on screen and can
 restart if Android recreates the app process. This temporary export data is
 deleted after completion, cancellation, or failure and is excluded from Android
-backup and device transfer. Generated videos are written to the destination the
-On Android 10 and later, completed MP4 files are saved through MediaStore under
-`Movies/Timeline Visualizer`. Android 8 and 9 use the system Save As picker. Cached basemap image tiles may remain in the app's temporary cache
+backup and device transfer. Generated videos are written through Android's
+media storage interfaces. On Android 10 and later, completed MP4 files are saved
+through MediaStore under
+`Movies/Timeline Visualizer`. Android 8 and 9 use the system Save As picker.
+Cached basemap image tiles may remain in the app's temporary cache
 and can be removed by clearing the app cache or uninstalling the app.
 
 After a successful Timeline import, the app stores only the selected document URI

--- a/docs/release-notes-v2.0.1.md
+++ b/docs/release-notes-v2.0.1.md
@@ -1,0 +1,18 @@
+# Timeline Visualizer 2.0.1
+
+This maintenance release improves compatibility with current Google Maps
+Timeline exports before Google Play testing.
+
+- Read route points that use `durationMinutesOffsetFromStartTime` instead of an
+  absolute timestamp.
+- Keep valid absolute timestamps as the preferred representation when both are
+  present.
+- Ignore invalid or out-of-range offsets without interrupting the rest of the
+  Timeline import.
+- Explain whether a file is malformed, uses an older Google Takeout format,
+  contains only raw signals, or has no usable locations.
+- Keep Android and Python parsing behavior consistent.
+- Correct Play submission metadata and privacy-policy wording.
+
+This release implements issue #33. Existing videos, settings, Timeline access,
+and unfinished exports remain compatible.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.0.0` and version code `13`
+- Version name `2.0.1` and version code `14`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `1.9.0` and version code `12`
+- Version name `2.0.0` and version code `13`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases
@@ -30,9 +30,11 @@
 ## Store presence and policy
 
 - Upload the 512×512 app icon and 1024×500 feature graphic
-- Upload at least two current phone screenshots for each maintained locale
-- Paste and proofread the English, Korean, and Japanese listing text
-- Upload four current screenshots and the localized feature graphic for each maintained locale
+- Paste and proofread the listing text for English, Korean, Japanese, Simplified
+  Chinese, Traditional Chinese, Spanish, French, German, and Brazilian Portuguese
+- Upload the four current screenshots and localized feature graphic for English,
+  Korean, and Japanese. Use the English graphics as the fallback for the other
+  six locales
 - Complete Data safety, content rating, target audience, ads, and app-access forms
 - Confirm the public privacy policy and support address work without signing in
 - Confirm the Play build opens Google Play, not GitHub Releases, for updates

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,3 +39,46 @@ def test_coordinate_parser_supports_e7_and_rejects_invalid():
     assert parse_coordinate("375000000,1270000000") == (37.5, 127.0)
     assert parse_coordinate("geo:91,127") is None
     assert parse_coordinate(None) is None
+
+
+def test_offset_path_timestamps_match_absolute_time_behavior():
+    data = [
+        {
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-01T02:00:00Z",
+            "timelinePath": [
+                {"point": "37.0,127.0", "durationMinutesOffsetFromStartTime": "15"},
+                {"point": "37.1,127.1", "durationMinutesOffsetFromStartTime": 60},
+                {
+                    "point": "37.2,127.2",
+                    "time": "2026-01-01T01:30:00Z",
+                    "durationMinutesOffsetFromStartTime": "5",
+                },
+            ],
+        }
+    ]
+
+    points = extract_timeline_points(data, 2026)
+    assert [point["dt"].isoformat() for point in points] == [
+        "2026-01-01T00:15:00+00:00",
+        "2026-01-01T01:00:00+00:00",
+        "2026-01-01T01:30:00+00:00",
+    ]
+
+
+def test_invalid_offset_path_timestamps_are_ignored():
+    data = [
+        {
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-01T01:00:00Z",
+            "timelinePath": [
+                {"point": "37.0,127.0", "durationMinutesOffsetFromStartTime": "-1"},
+                {"point": "37.1,127.1", "durationMinutesOffsetFromStartTime": "unknown"},
+                {"point": "37.2,127.2", "durationMinutesOffsetFromStartTime": "120"},
+            ],
+            "visit": {"topCandidate": {"placeLocation": "37.3,127.3"}},
+        }
+    ]
+
+    points = extract_timeline_points(data, 2026)
+    assert [(point["lat"], point["lon"]) for point in points] == [(37.3, 127.3)]

--- a/tests/test_play_store_materials.py
+++ b/tests/test_play_store_materials.py
@@ -17,7 +17,17 @@ def png_info(path: Path) -> tuple[int, int, int]:
 
 
 def test_listing_text_meets_play_limits():
-    for locale in ("en-US", "ko-KR", "ja-JP"):
+    for locale in (
+        "en-US",
+        "ko-KR",
+        "ja-JP",
+        "zh-CN",
+        "zh-TW",
+        "es-ES",
+        "fr-FR",
+        "de-DE",
+        "pt-BR",
+    ):
         listing = PLAY_STORE / "listing" / locale
         assert len((listing / "title.txt").read_text(encoding="utf-8").strip()) <= 30
         assert len((listing / "short-description.txt").read_text(encoding="utf-8").strip()) <= 80
@@ -48,9 +58,12 @@ def test_phone_screenshots_are_current_play_recommended_size():
 
 def test_play_release_metadata_is_consistent():
     build_file = (ROOT / "app" / "build.gradle.kts").read_text(encoding="utf-8")
-    assert 'versionCode = 13' in build_file
-    assert 'versionName = "2.0.0"' in build_file
-    assert (ROOT / "docs" / "release-notes-v1.9.0.md").is_file()
+    version_code = re.search(r"versionCode = (\d+)", build_file).group(1)
+    version_name = re.search(r'versionName = "([^"]+)"', build_file).group(1)
+    checklist = (PLAY_STORE / "submission-checklist.md").read_text(encoding="utf-8")
+
+    assert f"Version name `{version_name}` and version code `{version_code}`" in checklist
+    assert (ROOT / "docs" / f"release-notes-v{version_name}.md").is_file()
 
 
 def test_android_locales_have_matching_resources_and_placeholders():

--- a/visualizer.py
+++ b/visualizer.py
@@ -20,7 +20,7 @@ import io
 import urllib.request
 import bisect
 import statistics
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 # Third-party imports
@@ -353,13 +353,47 @@ def extract_timeline_points(data, year):
 
     points = []
 
+    def parse_timestamp(time_value):
+        if isinstance(time_value, datetime):
+            return time_value
+        if not time_value:
+            return None
+        try:
+            return dateutil.parser.parse(time_value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+    def path_timestamp(path_point, start_value, end_value):
+        absolute = parse_timestamp(path_point.get('time'))
+        if absolute is not None:
+            return absolute
+        offset_value = path_point.get('durationMinutesOffsetFromStartTime')
+        if isinstance(offset_value, bool):
+            return None
+        try:
+            offset = int(offset_value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if offset < 0:
+            return None
+        start = parse_timestamp(start_value)
+        if start is None:
+            return None
+        try:
+            timestamp = start + timedelta(minutes=offset)
+        except OverflowError:
+            return None
+        end = parse_timestamp(end_value)
+        if end is not None and timestamp > end + timedelta(minutes=1):
+            return None
+        return timestamp
+
     def add_point(time_value, coordinate_value):
         coordinate = parse_coordinate(coordinate_value)
-        if not time_value or coordinate is None:
+        if coordinate is None:
             return
-        try:
-            timestamp = dateutil.parser.parse(time_value)
-        except (TypeError, ValueError, OverflowError):
+        timestamp = parse_timestamp(time_value)
+        if timestamp is None:
             return
         if timestamp.year == year:
             points.append({'dt': timestamp, 'lat': coordinate[0], 'lon': coordinate[1]})
@@ -372,7 +406,7 @@ def extract_timeline_points(data, year):
 
         for path_point in seg.get('timelinePath', []):
             if isinstance(path_point, dict):
-                add_point(path_point.get('time'), path_point.get('point'))
+                add_point(path_timestamp(path_point, start_time, end_time), path_point.get('point'))
 
         activity = seg.get('activity')
         if isinstance(activity, dict):


### PR DESCRIPTION
## What changed

- parse `durationMinutesOffsetFromStartTime` path entries in Android and Python
- prefer valid absolute timestamps and reject invalid or out-of-range offsets
- show format-specific failures for malformed, legacy, raw-only, and empty Timeline exports
- add localized messages across all nine app languages
- update version code to 14 and version name to 2.0.1
- correct the Play submission checklist and English privacy wording

## Why

Current Google Maps Timeline exports can store a point's time as a minute offset from the segment start. The parser only accepted an absolute `time`, so otherwise valid routes were silently discarded.

## User impact

Previously unreadable current Timeline exports can now load without changing existing route geometry. Unsupported files also receive a more useful explanation.

## Validation

- `python -m pytest -q` with 20 passing tests
- focused Android parser regression tests added for string, numeric, mixed, invalid, and out-of-range offsets
- Android build, unit tests, and lint run in the required GitHub validation workflow

Closes #33