### PR TITLE
Fix Kotlin compilation deprecation warnings in TimelineParser and Mp4Exporter

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
@@ -1,5 +1,6 @@
 package dev.mahlernim.timelinevisualizer.data
 
+import com.google.gson.Strictness
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
 import com.google.gson.stream.MalformedJsonException
@@ -28,7 +29,7 @@ class TimelineParser {
     private fun parseSupportedTimeline(input: InputStream): Timeline {
         val points = mutableListOf<GeoPoint>()
         JsonReader(InputStreamReader(input, Charsets.UTF_8)).use { reader ->
-            reader.isLenient = true
+            reader.strictness = Strictness.LENIENT
             when (reader.peek()) {
                 JsonToken.BEGIN_ARRAY -> readSegments(reader, points)
                 JsonToken.BEGIN_OBJECT -> readRootObject(reader, points)

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -251,6 +251,7 @@ class Mp4Exporter(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun selectEncoder(width: Int, height: Int, bitrate: Int): EncoderChoice {
         val preferredFormats = listOf(
             MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar,
@@ -274,6 +275,7 @@ class Mp4Exporter(
         error("This device does not expose a compatible H.264 encoder")
     }
 
+    @Suppress("DEPRECATION")
     private fun argbToYuv420(pixels: IntArray, output: ByteArray, width: Int, height: Int, colorFormat: Int) {
         val frameSize = width * height
         var yIndex = 0


### PR DESCRIPTION
### Summary of changes
- Replaced deprecated `JsonReader.isLenient = true` with `JsonReader.strictness = Strictness.LENIENT` in `TimelineParser.kt`.
- Added `@Suppress("DEPRECATION")` to `selectEncoder` and `argbToYuv420` in `Mp4Exporter.kt` for legacy YUV 420 color format constants (`COLOR_FormatYUV420Planar` and `COLOR_FormatYUV420SemiPlanar`).