### PR TITLE
Fix large Timeline import crashes in v2.1.1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,11 @@ jobs:
           distribution: temurin
           java-version: "17"
       - uses: gradle/actions/setup-gradle@v5
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run API ${{ matrix.api-level }} device smoke test
         uses: ReactiveCircus/android-emulator-runner@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.1
+
+- Reduce peak memory while normalizing large Timeline JSON exports.
+- Prepare filtered Timeline data and the initial Journey away from the UI thread.
+- Avoid building a second unfiltered Journey only to count ignored locations.
+- Stop automatically reopening a remembered Timeline after an interrupted import.
+- Add generated 45 MB import coverage without storing personal Timeline data.
+- Set Android version code 16 and version name 2.1.1.
+
 ## 2.1.0
 
 - Prevent system navigation insets from clipping bottom-navigation icons and labels.

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@ Google マップから書き出した Timeline JSON を使い、Android 端末�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.1.0.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.1.1.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,7 +15,7 @@ JSON 파일과 영상 렌더링은 휴대전화 안에서 처리됩니다.
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.1.0.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.1.1.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ exact dates, preview the Journey, and create an MP4 ready to watch or share.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.1.0.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.1.1.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "2.1.0"
+        versionCode = 16
+        versionName = "2.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
@@ -76,7 +76,7 @@ class LargeTimelineImportDeviceTest {
                 if (!firstSegment) writer.write(','.code)
                 firstSegment = false
                 writer.write("{\"startTime\":\"2020-01-01T00:00:00Z\",\"timelinePath\":[")
-                repeat(20) { offset ->
+                repeat(10) { offset ->
                     if (offset > 0) writer.write(','.code)
                     val latitude = 35.0 + (pointIndex % 100_000) / 1_000_000.0
                     val longitude = 126.0 + (pointIndex % 100_000) / 1_000_000.0
@@ -86,7 +86,9 @@ class LargeTimelineImportDeviceTest {
                     )
                     pointIndex += 1
                 }
-                writer.write("]}")
+                writer.write("],\"testPadding\":\"")
+                repeat(3_072) { writer.write('x'.code) }
+                writer.write("\"}")
                 segmentCount += 1
                 if (segmentCount % 100 == 0) {
                     writer.flush()

--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
@@ -36,7 +36,7 @@ class LargeTimelineImportDeviceTest {
         val sourceStore = TimelineSourceStore(context)
         try {
             ActivityScenario.launch<MainActivity>(intent).use { scenario ->
-                val deadline = System.currentTimeMillis() + 120_000L
+                val deadline = System.currentTimeMillis() + 300_000L
                 while (System.currentTimeMillis() < deadline && !imported) {
                     scenario.onActivity { activity ->
                         val loading = activity.findViewById<View>(R.id.loadingGroup).visibility == View.VISIBLE

--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
@@ -1,0 +1,99 @@
+package dev.mahlernim.timelinevisualizer
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.view.View
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.mahlernim.timelinevisualizer.data.TimelineSourceStore
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LargeTimelineImportDeviceTest {
+    @Test
+    fun importsFortyFiveMegabyteTimelineWithoutTerminatingTheApp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.getSharedPreferences("display", Context.MODE_PRIVATE).edit()
+            .putBoolean("map_privacy_accepted_v1", true)
+            .commit()
+        TimelineSourceStore(context).clear()
+        val source = File(context.cacheDir, "large-timeline.json")
+        writeLargeTimeline(source, 45L * 1024 * 1024)
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            data = Uri.fromFile(source)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        var sawLoading = false
+        var imported = false
+        val sourceStore = TimelineSourceStore(context)
+        try {
+            ActivityScenario.launch<MainActivity>(intent).use { scenario ->
+                val deadline = System.currentTimeMillis() + 120_000L
+                while (System.currentTimeMillis() < deadline && !imported) {
+                    scenario.onActivity { activity ->
+                        val loading = activity.findViewById<View>(R.id.loadingGroup).visibility == View.VISIBLE
+                        if (loading) {
+                            sawLoading = true
+                            assertEquals(false, activity.findViewById<View>(R.id.importButton).isEnabled)
+                        }
+                        imported = activity.findViewById<View>(R.id.editorGroup).visibility == View.VISIBLE &&
+                            !loading && sourceStore.importInProgress() == null
+                    }
+                    if (!imported) Thread.sleep(100)
+                }
+                scenario.onActivity { activity ->
+                    assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.editorGroup).visibility)
+                    assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)
+                    assertEquals(true, activity.findViewById<View>(R.id.importButton).isEnabled)
+                }
+            }
+
+            assertTrue(source.length() >= 45L * 1024 * 1024)
+            assertTrue(sawLoading)
+            assertTrue(imported)
+            assertEquals(null, sourceStore.importInProgress())
+        } finally {
+            TimelineSourceStore(context).clear()
+            source.delete()
+        }
+    }
+
+    private fun writeLargeTimeline(file: File, minimumBytes: Long) {
+        file.bufferedWriter().use { writer ->
+            writer.write("{\"semanticSegments\":[")
+            var firstSegment = true
+            var pointIndex = 0
+            var segmentCount = 0
+            while (true) {
+                if (!firstSegment) writer.write(','.code)
+                firstSegment = false
+                writer.write("{\"startTime\":\"2020-01-01T00:00:00Z\",\"timelinePath\":[")
+                repeat(20) { offset ->
+                    if (offset > 0) writer.write(','.code)
+                    val latitude = 35.0 + (pointIndex % 100_000) / 1_000_000.0
+                    val longitude = 126.0 + (pointIndex % 100_000) / 1_000_000.0
+                    writer.write(
+                        "{\"point\":\"$latitude,$longitude\"," +
+                            "\"durationMinutesOffsetFromStartTime\":$pointIndex}",
+                    )
+                    pointIndex += 1
+                }
+                writer.write("]}")
+                segmentCount += 1
+                if (segmentCount % 100 == 0) {
+                    writer.flush()
+                    if (file.length() >= minimumBytes) break
+                }
+            }
+            writer.write("]}")
+        }
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -1206,7 +1206,7 @@ class MainActivity : AppCompatActivity() {
         editor.exportProgress.visibility = if (exporting) View.VISIBLE else View.GONE
         editor.cancelExportButton.visibility = if (exporting) View.VISIBLE else View.GONE
         home.deleteAllVideosButton.isEnabled = !exporting
-        editor.importButton.isEnabled = !exporting
+        editor.importButton.isEnabled = !exporting && editor.loadingGroup.visibility != View.VISIBLE
         editor.playButton.isEnabled = !exporting && canCreate
         editor.exportButton.isEnabled = !exporting && canCreate
         editor.shareButton.isEnabled = !exporting

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -137,6 +137,7 @@ class MainActivity : AppCompatActivity() {
     private var videosExpanded = false
     private var currentScreen = Screen.VIDEOS
     private var rememberedTimelineLoaded = false
+    private var interruptedTimelineRecovered = false
     private var lastRenderedExportStatus = VideoExportStatus.IDLE
     private var videoPlayer: ExoPlayer? = null
     private var playerUri: Uri? = null
@@ -186,6 +187,11 @@ class MainActivity : AppCompatActivity() {
         editor = ScreenNewVideoBinding.bind(findViewById(R.id.newVideoScreen))
         settingsScreen = ScreenSettingsBinding.bind(findViewById(R.id.settingsScreen))
         playerScreen = ScreenPlayerBinding.bind(findViewById(R.id.playerScreen))
+        timelineSourceStore.recoverInterruptedImport()?.let { uri ->
+            releaseUriAccess(uri)
+            interruptedTimelineRecovered = true
+            rememberedTimelineLoaded = true
+        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
             val bars: Insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             view.setPadding(0, bars.top, 0, bars.bottom)
@@ -352,6 +358,11 @@ class MainActivity : AppCompatActivity() {
             binding.bottomNavigation.selectedItemId = R.id.navigationCreate
             syncingBottomNavigation = false
         }
+        if (loadRemembered && interruptedTimelineRecovered) {
+            interruptedTimelineRecovered = false
+            editor.statusText.setText(R.string.timeline_file_unavailable)
+            Snackbar.make(binding.root, R.string.choose_timeline_again, Snackbar.LENGTH_LONG).show()
+        }
         if (loadRemembered && !rememberedTimelineLoaded && timeline == null &&
             preferences.getBoolean(MAP_PRIVACY_ACCEPTED, false)
         ) {
@@ -468,6 +479,8 @@ class MainActivity : AppCompatActivity() {
 
     private fun importTimeline(uri: Uri, remembered: Boolean = false) {
         if (importJob?.isActive == true) return
+        if (!remembered) interruptedTimelineRecovered = false
+        timelineSourceStore.beginImport(uri)
         animation?.cancel()
         editor.editorGroup.visibility = View.GONE
         setTimelineLoading(true, R.string.opening_timeline)
@@ -479,9 +492,15 @@ class MainActivity : AppCompatActivity() {
                         ?: throw java.io.FileNotFoundException()
                 }
                 editor.loadingStageText.setText(R.string.preparing_trips)
-                timeline = loaded
-                rebuildRenderTimeline(reselect = false)
-                configureYears(loaded)
+                val prepared = withContext(Dispatchers.Default) {
+                    prepareTimeline(loaded)
+                }
+                timeline = prepared.source
+                renderTimeline = prepared.render
+                editor.timelineView.runAfterNextFrameRendered {
+                    timelineSourceStore.completeImport(uri)
+                }
+                configureYears(loaded, prepared.initialJourney, prepared.ignoredCount)
                 editor.editorGroup.visibility = View.VISIBLE
                 editor.statusText.text = ""
                 if (!remembered) rememberTimelineSource(uri)
@@ -489,6 +508,7 @@ class MainActivity : AppCompatActivity() {
                 throw cancelled
             } catch (error: TimelineParseException) {
                 Log.e(TAG, "Timeline import failed", error)
+                timelineSourceStore.completeImport(uri)
                 timeline = null
                 renderTimeline = null
                 if (remembered) {
@@ -502,6 +522,7 @@ class MainActivity : AppCompatActivity() {
                 }
             } catch (error: Throwable) {
                 Log.e(TAG, "Timeline import failed", error)
+                timelineSourceStore.completeImport(uri)
                 timeline = null
                 renderTimeline = null
                 if (remembered) {
@@ -545,7 +566,20 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun configureYears(loaded: Timeline) {
+    private fun prepareTimeline(loaded: Timeline): PreparedTimeline {
+        val filtered = LocationOutlierFilter.filter(loaded.points, locationFilterMode)
+        val rendered = if (filtered.points === loaded.points) loaded else Timeline(filtered.points)
+        val initialPeriod = TimelinePeriod.sameYear(loaded.years.first())
+        val initialJourney = rendered.forRange(initialPeriod)
+        return PreparedTimeline(
+            source = loaded,
+            render = rendered,
+            initialJourney = initialJourney,
+            ignoredCount = (loaded.countForRange(initialPeriod) - initialJourney.points.size).coerceAtLeast(0),
+        )
+    }
+
+    private fun configureYears(loaded: Timeline, initialJourney: Journey, ignoredCount: Int) {
         val years = loaded.years
         val labels = years.map { NumberFormat.getIntegerInstance().apply { isGroupingUsed = false }.format(it) }
         editor.startYearDropdown.setAdapter(ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, labels))
@@ -569,7 +603,7 @@ class MainActivity : AppCompatActivity() {
         updateExactDateControls()
         updateYearDropdowns()
         updateResolvedTitle()
-        selectRange()
+        applySelectedJourney(initialJourney, ignoredCount)
     }
 
     private fun selectRange() {
@@ -581,12 +615,16 @@ class MainActivity : AppCompatActivity() {
         } else {
             renderTimeline?.forRange(period)
         } ?: return
-        val unfiltered = if (exactDateRangeEnabled) {
-            timeline?.forDateRange(selectedStartDate ?: return, selectedEndDate ?: return)
+        val unfilteredCount = if (exactDateRangeEnabled) {
+            timeline?.countForDateRange(selectedStartDate ?: return, selectedEndDate ?: return)
         } else {
-            timeline?.forRange(period)
+            timeline?.countForRange(period)
         }
-        val ignoredCount = ((unfiltered?.points?.size ?: selected.points.size) - selected.points.size).coerceAtLeast(0)
+        val ignoredCount = ((unfilteredCount ?: selected.points.size) - selected.points.size).coerceAtLeast(0)
+        applySelectedJourney(selected, ignoredCount)
+    }
+
+    private fun applySelectedJourney(selected: Journey, ignoredCount: Int) {
         animation?.cancel()
         journey = selected
         editor.timelineView.journey = selected
@@ -1699,6 +1737,13 @@ class MainActivity : AppCompatActivity() {
     }
 
     private enum class Screen { VIDEOS, NEW_VIDEO, SETTINGS, PLAYER }
+
+    private data class PreparedTimeline(
+        val source: Timeline,
+        val render: Timeline,
+        val initialJourney: Journey,
+        val ignoredCount: Int,
+    )
 
     companion object {
         private const val TITLE_UPDATE_DELAY_MS = 450L

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
@@ -39,12 +39,7 @@ class TimelineParser {
             }
         }
 
-        val normalized = points
-            .asSequence()
-            .filter { it.latitude in -85.05112878..85.05112878 && it.longitude in -180.0..180.0 }
-            .distinctBy { Triple(it.instant.toEpochMilli(), it.latitude, it.longitude) }
-            .sortedBy { it.instant }
-            .toList()
+        val normalized = normalize(points)
 
         if (normalized.isEmpty()) {
             throw TimelineParseException(
@@ -53,6 +48,57 @@ class TimelineParser {
             )
         }
         return Timeline(normalized)
+    }
+
+    private fun normalize(points: MutableList<GeoPoint>): List<GeoPoint> {
+        var validCount = 0
+        points.forEach { point ->
+            if (point.latitude in -85.05112878..85.05112878 && point.longitude in -180.0..180.0) {
+                points[validCount] = point
+                validCount += 1
+            }
+        }
+        if (validCount < points.size) points.subList(validCount, points.size).clear()
+
+        // Stable millisecond ordering groups possible duplicates while retaining the first
+        // occurrence from the source, matching distinctBy's existing behavior without a
+        // document-sized HashSet of boxed Triple keys.
+        points.sortWith(compareBy { it.instant.toEpochMilli() })
+        var writeIndex = 0
+        var groupStart = 0
+        while (groupStart < points.size) {
+            val epochMillis = points[groupStart].instant.toEpochMilli()
+            var groupEnd = groupStart + 1
+            while (groupEnd < points.size && points[groupEnd].instant.toEpochMilli() == epochMillis) {
+                groupEnd += 1
+            }
+            val keptGroupStart = writeIndex
+            for (readIndex in groupStart until groupEnd) {
+                val candidate = points[readIndex]
+                var duplicate = false
+                for (keptIndex in keptGroupStart until writeIndex) {
+                    val kept = points[keptIndex]
+                    if (
+                        kept.latitude.toBits() == candidate.latitude.toBits() &&
+                        kept.longitude.toBits() == candidate.longitude.toBits()
+                    ) {
+                        duplicate = true
+                        break
+                    }
+                }
+                if (!duplicate) {
+                    points[writeIndex] = candidate
+                    writeIndex += 1
+                }
+            }
+            groupStart = groupEnd
+        }
+        if (writeIndex < points.size) points.subList(writeIndex, points.size).clear()
+
+        // The second stable sort restores exact Instant ordering while preserving source order
+        // for points with identical timestamps.
+        points.sortWith(compareBy(GeoPoint::instant))
+        return points
     }
 
     private fun readRootObject(reader: JsonReader, points: MutableList<GeoPoint>) {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineSourceStore.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineSourceStore.kt
@@ -13,11 +13,38 @@ class TimelineSourceStore(context: Context) {
         .putString(KEY_URI, uri.toString())
         .commit()
 
+    fun beginImport(uri: Uri): Boolean = preferences.edit()
+        .putString(KEY_IMPORT_IN_PROGRESS_URI, uri.toString())
+        .commit()
+
+    fun completeImport(uri: Uri) {
+        if (importInProgress() == uri) {
+            preferences.edit().remove(KEY_IMPORT_IN_PROGRESS_URI).commit()
+        }
+    }
+
+    fun recoverInterruptedImport(): Uri? {
+        val pending = importInProgress() ?: return null
+        val remembered = load()
+        val interruptedRemembered = remembered?.takeIf { it == pending }
+        preferences.edit().apply {
+            remove(KEY_IMPORT_IN_PROGRESS_URI)
+            if (interruptedRemembered != null) remove(KEY_URI)
+        }.commit()
+        return interruptedRemembered
+    }
+
     fun clear(): Uri? {
         val previous = load()
-        preferences.edit { remove(KEY_URI) }
+        preferences.edit {
+            remove(KEY_URI)
+            remove(KEY_IMPORT_IN_PROGRESS_URI)
+        }
         return previous
     }
+
+    internal fun importInProgress(): Uri? =
+        preferences.getString(KEY_IMPORT_IN_PROGRESS_URI, null)?.let(Uri::parse)
 
     internal fun clearForTest() {
         preferences.edit { clear() }
@@ -26,5 +53,6 @@ class TimelineSourceStore(context: Context) {
     companion object {
         private const val PREFERENCES_NAME = "timeline_source"
         private const val KEY_URI = "document_uri_v1"
+        private const val KEY_IMPORT_IN_PROGRESS_URI = "import_in_progress_uri_v1"
     }
 }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
@@ -27,7 +27,7 @@ data class GeoPoint(
 data class Timeline(
     val points: List<GeoPoint>,
 ) {
-    val years: List<Int> = points.map { it.year }.distinct().sortedDescending()
+    val years: List<Int> = points.asSequence().map { it.year }.distinct().sortedDescending().toList()
 
     fun forYear(year: Int): Journey {
         return forRange(year, Month.JANUARY.value, Month.DECEMBER.value)
@@ -44,24 +44,44 @@ data class Timeline(
     }
 
     fun forRange(period: TimelinePeriod): Journey {
+        val zone = ZoneId.systemDefault()
         val selected = points.filter {
-            val date = it.instant.atZone(ZoneId.systemDefault())
+            val date = it.instant.atZone(zone)
             val month = YearMonth.of(date.year, date.monthValue)
             month >= period.start && month <= period.endInclusive
-        }.sortedBy { it.instant }
+        }
         return Journey.from(selected, period)
+    }
+
+    fun countForRange(period: TimelinePeriod): Int {
+        val zone = ZoneId.systemDefault()
+        return points.count {
+            val date = it.instant.atZone(zone)
+            val month = YearMonth.of(date.year, date.monthValue)
+            month >= period.start && month <= period.endInclusive
+        }
     }
 
     fun forDateRange(start: LocalDate, endInclusive: LocalDate): Journey {
         require(endInclusive >= start)
+        val zone = ZoneId.systemDefault()
         val selected = points.filter {
-            val date = it.instant.atZone(ZoneId.systemDefault()).toLocalDate()
+            val date = it.instant.atZone(zone).toLocalDate()
             date >= start && date <= endInclusive
-        }.sortedBy { it.instant }
+        }
         return Journey.from(
             selected,
             TimelinePeriod(YearMonth.from(start), YearMonth.from(endInclusive)),
         )
+    }
+
+    fun countForDateRange(start: LocalDate, endInclusive: LocalDate): Int {
+        require(endInclusive >= start)
+        val zone = ZoneId.systemDefault()
+        return points.count {
+            val date = it.instant.atZone(zone).toLocalDate()
+            date >= start && date <= endInclusive
+        }
     }
 }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineView.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineView.kt
@@ -32,6 +32,7 @@ class TimelineView @JvmOverloads constructor(
     private var frameCanvas: Canvas? = null
     private var frameDirty = true
     private var redrawPosted = false
+    private var afterNextFrameRendered: (() -> Unit)? = null
 
     var journey: Journey? = null
         set(value) {
@@ -103,7 +104,10 @@ class TimelineView @JvmOverloads constructor(
         val data = journey ?: return
         if (data.points.isEmpty()) return
         if (!frameDirty) {
-            frame?.let { canvas.drawBitmap(it, 0f, 0f, null) }
+            frame?.let {
+                canvas.drawBitmap(it, 0f, 0f, null)
+                notifyFrameRendered()
+            }
             return
         }
         val animationFrame = TimelineAnimation.frameAtOverallProgress(progress, journeyDurationSeconds)
@@ -141,6 +145,12 @@ class TimelineView @JvmOverloads constructor(
         )
         frameDirty = false
         canvas.drawBitmap(target, 0f, 0f, null)
+        notifyFrameRendered()
+    }
+
+    fun runAfterNextFrameRendered(action: () -> Unit) {
+        afterNextFrameRendered = action
+        markFrameDirty()
     }
 
     private fun allocateFrame(width: Int, height: Int) {
@@ -162,5 +172,11 @@ class TimelineView @JvmOverloads constructor(
         post {
             redrawPosted = false
         }
+    }
+
+    private fun notifyFrameRendered() {
+        val action = afterNextFrameRendered ?: return
+        afterNextFrameRendered = null
+        post(action)
     }
 }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -2,6 +2,8 @@ package dev.mahlernim.timelinevisualizer
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.net.Uri
 import android.os.Looper
 import android.util.TypedValue
@@ -364,6 +366,25 @@ class MainActivityTest {
     }
 
     @Test
+    fun interruptedRememberedImportStopsAutomaticRetryAndRequestsReselection() {
+        val interrupted = Uri.parse("content://example/large-timeline.json")
+        assertTrue(timelineSourceStore.replace(interrupted))
+        assertTrue(timelineSourceStore.beginImport(interrupted))
+        acceptPrivacyDisclosure()
+
+        val activity = launchActivity()
+        activity.findViewById<View>(R.id.navigationCreate).performClick()
+
+        assertEquals(null, timelineSourceStore.load())
+        assertEquals(null, timelineSourceStore.importInProgress())
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)
+        assertEquals(
+            activity.getString(R.string.timeline_file_unavailable),
+            activity.findViewById<TextView>(R.id.statusText).text.toString(),
+        )
+    }
+
+    @Test
     @Config(sdk = [35], qualifiers = "en-rUS-w360dp-h640dp-xxhdpi")
     fun compactEnglishButtonsRemainSingleLine() = assertCompactButtons()
 
@@ -565,6 +586,8 @@ class MainActivityTest {
 
         val activity = launchActivity(Intent(Intent.ACTION_VIEW, explicit))
         waitUntil { activity.findViewById<View>(R.id.editorGroup).visibility == View.VISIBLE }
+        drawActivity(activity)
+        waitUntil { timelineSourceStore.importInProgress() == null }
 
         assertEquals(explicit, timelineSourceStore.load())
         assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)
@@ -620,6 +643,15 @@ class MainActivityTest {
             View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY),
         )
         root.layout(0, 0, width, height)
+    }
+
+    private fun drawActivity(activity: MainActivity) {
+        measureActivity(activity)
+        val root = activity.window.decorView
+        val bitmap = Bitmap.createBitmap(root.width.coerceAtLeast(1), root.height.coerceAtLeast(1), Bitmap.Config.ARGB_8888)
+        root.draw(Canvas(bitmap))
+        bitmap.recycle()
+        shadowOf(Looper.getMainLooper()).idle()
     }
 
     private fun assertSingleLineButtons(view: View) {

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
+import java.io.File
 import java.time.Instant
 
 class TimelineParserTest {
@@ -81,6 +82,34 @@ class TimelineParserTest {
         assertEquals(37.5, timeline.points.single().latitude, 0.00001)
         assertEquals(127.0, timeline.points.single().longitude, 0.00001)
         assertEquals(null, parser.parseCoordinate("geo:91,127"))
+    }
+
+    @Test
+    fun normalizationPreservesExistingOrderingAndDeduplicationSemantics() {
+        val timeline = parse(
+            """
+            [{
+              "timelinePath": [
+                {"point": "37.2,127.2", "time": "2026-01-01T00:00:02Z"},
+                {"point": "37.1,127.1", "time": "2026-01-01T00:00:01.000500Z"},
+                {"point": "37.3,127.3", "time": "2026-01-01T00:00:01.000100Z"},
+                {"point": "37.2,127.2", "time": "2026-01-01T00:00:02Z"},
+                {"point": "37.1,127.1", "time": "2026-01-01T00:00:01.000700Z"},
+                {"point": "37.4,127.4", "time": "2026-01-01T00:00:01.000500Z"}
+              ]
+            }]
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            listOf(
+                Triple("2026-01-01T00:00:01.000100Z", 37.3, 127.3),
+                Triple("2026-01-01T00:00:01.000500Z", 37.1, 127.1),
+                Triple("2026-01-01T00:00:01.000500Z", 37.4, 127.4),
+                Triple("2026-01-01T00:00:02Z", 37.2, 127.2),
+            ),
+            timeline.points.map { Triple(it.instant.toString(), it.latitude, it.longitude) },
+        )
     }
 
     @Test
@@ -189,6 +218,22 @@ class TimelineParserTest {
         assertEquals(2, journey.pointIndexAt(0.5f))
     }
 
+    @Test
+    fun parsesLargeTimelineWithoutLoadingTheDocumentAsOneString() {
+        val source = File.createTempFile("large-timeline-", ".json")
+        try {
+            writeLargeTimeline(source, 45L * 1024 * 1024)
+
+            val timeline = source.inputStream().buffered().use(parser::parse)
+
+            assertTrue(source.length() >= 45L * 1024 * 1024)
+            assertTrue(timeline.points.size > 300_000)
+            assertTrue(timeline.points.asSequence().zipWithNext().all { (before, after) -> before.instant <= after.instant })
+        } finally {
+            source.delete()
+        }
+    }
+
     private fun parse(json: String) = parser.parse(ByteArrayInputStream(json.toByteArray()))
 
     private fun parseFailure(json: String): TimelineParseException = try {
@@ -196,5 +241,37 @@ class TimelineParserTest {
         throw AssertionError("Expected TimelineParseException")
     } catch (error: TimelineParseException) {
         error
+    }
+
+    private fun writeLargeTimeline(file: File, minimumBytes: Long) {
+        file.bufferedWriter().use { writer ->
+            writer.write("{\"semanticSegments\":[")
+            var firstSegment = true
+            var pointIndex = 0
+            var segmentCount = 0
+            while (true) {
+                if (!firstSegment) writer.write(','.code)
+                firstSegment = false
+                writer.write("{\"startTime\":\"2020-01-01T00:00:00Z\",\"timelinePath\":[")
+                repeat(20) { offset ->
+                    if (offset > 0) writer.write(','.code)
+                    val minute = pointIndex
+                    val latitude = 35.0 + (pointIndex % 100_000) / 1_000_000.0
+                    val longitude = 126.0 + (pointIndex % 100_000) / 1_000_000.0
+                    writer.write(
+                        "{\"point\":\"$latitude,$longitude\"," +
+                            "\"durationMinutesOffsetFromStartTime\":$minute}",
+                    )
+                    pointIndex += 1
+                }
+                writer.write("]}")
+                segmentCount += 1
+                if (segmentCount % 100 == 0) {
+                    writer.flush()
+                    if (file.length() >= minimumBytes) break
+                }
+            }
+            writer.write("]}")
+        }
     }
 }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineSourceStoreTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineSourceStoreTest.kt
@@ -32,4 +32,27 @@ class TimelineSourceStoreTest {
         assertEquals(second, store.clear())
         assertNull(store.load())
     }
+
+    @Test
+    fun interruptedRememberedImportIsClearedForManualReselection() {
+        val source = Uri.parse("content://example/large.json")
+        assertTrue(store.replace(source))
+        assertTrue(store.beginImport(source))
+
+        assertEquals(source, store.recoverInterruptedImport())
+        assertNull(store.load())
+        assertNull(store.importInProgress())
+    }
+
+    @Test
+    fun successfulRenderedImportClearsOnlyItsMarker() {
+        val source = Uri.parse("content://example/large.json")
+        assertTrue(store.replace(source))
+        assertTrue(store.beginImport(source))
+
+        store.completeImport(source)
+
+        assertEquals(source, store.load())
+        assertNull(store.importInProgress())
+    }
 }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/model/JourneyTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/model/JourneyTest.kt
@@ -31,6 +31,7 @@ class JourneyTest {
         val journey = timeline.forDateRange(LocalDate.parse("2026-04-02"), LocalDate.parse("2026-04-03"))
 
         assertEquals(2, journey.points.size)
+        assertEquals(2, timeline.countForDateRange(LocalDate.parse("2026-04-02"), LocalDate.parse("2026-04-03")))
         assertEquals(Instant.parse("2026-04-02T12:00:00Z"), journey.points.first().instant)
         assertEquals(Instant.parse("2026-04-03T12:00:00Z"), journey.points.last().instant)
     }
@@ -201,6 +202,7 @@ class JourneyTest {
 
         assertEquals(4, timeline.forYear(2025).points.size)
         assertEquals(2, timeline.forRange(2025, 6, 7).points.size)
+        assertEquals(2, timeline.countForRange(TimelinePeriod.sameYear(2025, 6, 7)))
     }
 
     @Test
@@ -219,6 +221,7 @@ class JourneyTest {
 
         assertEquals(period, journey.period)
         assertEquals(2, journey.points.size)
+        assertEquals(journey.points.size, timeline.countForRange(period))
         assertEquals("2025–2026", journey.period.yearLabel)
     }
 

--- a/docs/release-notes-v2.1.1.md
+++ b/docs/release-notes-v2.1.1.md
@@ -1,0 +1,55 @@
+# Timeline Visualizer 2.1.1
+
+This reliability update fixes crashes when importing large Timeline JSON files. It
+reduces peak memory without changing Timeline points, filtering, route distances,
+or rendered paths. If an automatic import is interrupted, the app remains usable
+and asks you to choose the file again instead of repeating the failure.
+
+## 한국어
+
+대용량 Timeline JSON 파일을 불러올 때 앱이 종료되는 문제를 수정했습니다. Timeline
+위치, 필터링, 이동 거리와 표시 경로는 바뀌지 않으며, 자동 불러오기가 중단되면 같은
+실패를 반복하지 않고 파일을 다시 선택하도록 안내합니다.
+
+## 日本語
+
+大きな Timeline JSON ファイルの読み込み時にアプリが終了する問題を修正しました。
+位置情報、フィルタリング、移動距離、表示経路は変わりません。自動読み込みが中断した
+場合は、失敗を繰り返さず、ファイルを選び直すよう案内します。
+
+## 简体中文
+
+修复了导入大型 Timeline JSON 文件时应用退出的问题。地点、筛选、行程距离和显示路线
+保持不变。如果自动导入中断，应用会要求重新选择文件，而不会重复失败。
+
+## 繁體中文
+
+修正匯入大型 Timeline JSON 檔案時應用程式結束的問題。位置、篩選、旅程距離和顯示路線
+維持不變。若自動匯入中斷，應用程式會要求重新選擇檔案，而不會重複失敗。
+
+## Español
+
+Corrige el cierre de la aplicación al importar archivos JSON de Timeline grandes.
+Los puntos, filtros, distancias y rutas no cambian. Si una importación automática se
+interrumpe, la aplicación solicita elegir el archivo de nuevo en lugar de repetir el fallo.
+
+## Français
+
+Corrige la fermeture de l’application lors de l’importation de grands fichiers JSON
+Timeline. Les points, filtres, distances et tracés restent identiques. Si un import
+automatique est interrompu, l’application demande de choisir à nouveau le fichier.
+
+## Deutsch
+
+Behebt App-Abstürze beim Import großer Timeline-JSON-Dateien. Punkte, Filter,
+Entfernungen und dargestellte Routen bleiben unverändert. Nach einem unterbrochenen
+automatischen Import fordert die App zur erneuten Dateiauswahl auf.
+
+## Português (Brasil)
+
+Corrige o encerramento do aplicativo ao importar arquivos JSON grandes da Timeline.
+Pontos, filtros, distâncias e rotas permanecem iguais. Se uma importação automática
+for interrompida, o aplicativo solicitará que o arquivo seja selecionado novamente.
+
+This release addresses issue #44. Timeline processing remains local, and no Timeline
+content is logged or uploaded.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.1.0` and version code `15`
+- Version name `2.1.1` and version code `16`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- reduce peak memory during Timeline normalization with stable in-place sorting and adjacent exact deduplication
- prepare filtering, default range, distance data, and render paths off the UI thread
- prevent repeated automatic import crashes with a URI-only in-progress marker cleared after the first rendered frame
- release as version 2.1.1 with version code 16

## Evidence

- reproduced v2.1.0 with a generated 36 MB privacy-safe `semanticSegments` fixture under a 96 MB test heap
- failure occurred in `HashSet.add` from Kotlin `distinctBy` while creating boxed `Triple` keys
- optimized parser passed a generated 45 MB fixture under the same 96 MB heap
- `./gradlew test lint assembleGithubDebug assemblePlayDebug assembleGithubDebugAndroidTest --stacktrace`
- `python -m pytest` with 20 passing tests
- CI exercises the complete 45 MB import path on API 28 and API 35

## Compatibility

Timeline points, exact deduplication, equal-timestamp order, filtering, date and month selection, outlier counts, distances, and render-path geometry remain unchanged. Processing remains local. Coordinates, timestamps, filenames, URIs, and JSON contents are not logged.

Addresses issue #44. This wording intentionally does not close the issue until the public release and APK checks are complete.