### PR TITLE
Fix remaining dense Timeline import crashes in v2.1.2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [28, 35]
+        api-level: [28, 35, 36]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.2
+
+- Keep interpolated route samples virtual instead of retaining millions of route objects.
+- Replace route-sized first-frame projection collections with compact source-point indexes.
+- Use primitive arrays for transfer-threshold statistics to avoid boxed number collections.
+- Add a dense long-gap import fixture below 16 MB and Android API 36 device coverage.
+- Preserve Timeline points, filtering, ordering, distances, and rendered route geometry.
+- Set Android version code 17 and version name 2.1.2.
+
 ## 2.1.1
 
 - Reduce peak memory while normalizing large Timeline JSON exports.

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@ Google マップから書き出した Timeline JSON を使い、Android 端末�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.1.1.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.1.2.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,7 +15,7 @@ JSON 파일과 영상 렌더링은 휴대전화 안에서 처리됩니다.
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.1.1.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.1.2.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ exact dates, preview the Journey, and create an MP4 ready to watch or share.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.1.1.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.1.2.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 16
-        versionName = "2.1.1"
+        versionCode = 17
+        versionName = "2.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
@@ -8,6 +8,8 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dev.mahlernim.timelinevisualizer.data.TimelineSourceStore
+import dev.mahlernim.timelinevisualizer.data.LocationFilterMode
+import dev.mahlernim.timelinevisualizer.ui.LocationFilterPreferences
 import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -16,6 +18,28 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class LargeTimelineImportDeviceTest {
+    @Test
+    fun importsDenseLongGapTimelineBelowSixteenMegabytes() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.getSharedPreferences("display", Context.MODE_PRIVATE).edit()
+            .putBoolean("map_privacy_accepted_v1", true)
+            .commit()
+        LocationFilterPreferences(context).save(LocationFilterMode.OFF)
+        TimelineSourceStore(context).clear()
+        val source = File(context.cacheDir, "dense-long-gap-timeline.json")
+        writeDenseLongGapTimeline(source, 14L * 1024 * 1024)
+
+        try {
+            assertImportCompletes(context, source)
+            assertTrue(source.length() >= 14L * 1024 * 1024)
+            assertTrue(source.length() < 16L * 1024 * 1024)
+        } finally {
+            LocationFilterPreferences(context).reset()
+            TimelineSourceStore(context).clear()
+            source.delete()
+        }
+    }
+
     @Test
     fun importsFortyFiveMegabyteTimelineWithoutTerminatingTheApp() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -26,6 +50,16 @@ class LargeTimelineImportDeviceTest {
         val source = File(context.cacheDir, "large-timeline.json")
         writeLargeTimeline(source, 45L * 1024 * 1024)
 
+        try {
+            assertImportCompletes(context, source)
+            assertTrue(source.length() >= 45L * 1024 * 1024)
+        } finally {
+            TimelineSourceStore(context).clear()
+            source.delete()
+        }
+    }
+
+    private fun assertImportCompletes(context: Context, source: File) {
         val intent = Intent(context, MainActivity::class.java).apply {
             action = Intent.ACTION_VIEW
             data = Uri.fromFile(source)
@@ -34,35 +68,54 @@ class LargeTimelineImportDeviceTest {
         var sawLoading = false
         var imported = false
         val sourceStore = TimelineSourceStore(context)
-        try {
-            ActivityScenario.launch<MainActivity>(intent).use { scenario ->
-                val deadline = System.currentTimeMillis() + 300_000L
-                while (System.currentTimeMillis() < deadline && !imported) {
-                    scenario.onActivity { activity ->
-                        val loading = activity.findViewById<View>(R.id.loadingGroup).visibility == View.VISIBLE
-                        if (loading) {
-                            sawLoading = true
-                            assertEquals(false, activity.findViewById<View>(R.id.importButton).isEnabled)
-                        }
-                        imported = activity.findViewById<View>(R.id.editorGroup).visibility == View.VISIBLE &&
-                            !loading && sourceStore.importInProgress() == null
-                    }
-                    if (!imported) Thread.sleep(100)
-                }
+        ActivityScenario.launch<MainActivity>(intent).use { scenario ->
+            val deadline = System.currentTimeMillis() + 300_000L
+            while (System.currentTimeMillis() < deadline && !imported) {
                 scenario.onActivity { activity ->
-                    assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.editorGroup).visibility)
-                    assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)
-                    assertEquals(true, activity.findViewById<View>(R.id.importButton).isEnabled)
+                    val loading = activity.findViewById<View>(R.id.loadingGroup).visibility == View.VISIBLE
+                    if (loading) {
+                        sawLoading = true
+                        assertEquals(false, activity.findViewById<View>(R.id.importButton).isEnabled)
+                    }
+                    imported = activity.findViewById<View>(R.id.editorGroup).visibility == View.VISIBLE &&
+                        !loading && sourceStore.importInProgress() == null
                 }
+                if (!imported) Thread.sleep(100)
             }
+            scenario.onActivity { activity ->
+                assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.editorGroup).visibility)
+                assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)
+                assertEquals(true, activity.findViewById<View>(R.id.importButton).isEnabled)
+            }
+        }
+        assertTrue(sawLoading)
+        assertTrue(imported)
+        assertEquals(null, sourceStore.importInProgress())
+    }
 
-            assertTrue(source.length() >= 45L * 1024 * 1024)
-            assertTrue(sawLoading)
-            assertTrue(imported)
-            assertEquals(null, sourceStore.importInProgress())
-        } finally {
-            TimelineSourceStore(context).clear()
-            source.delete()
+    private fun writeDenseLongGapTimeline(file: File, minimumBytes: Long) {
+        file.bufferedWriter().use { writer ->
+            writer.write("{\"semanticSegments\":[")
+            var firstSegment = true
+            var pointIndex = 0
+            while (true) {
+                if (!firstSegment) writer.write(','.code)
+                firstSegment = false
+                writer.write("{\"startTime\":\"2020-01-01T00:00:00Z\",\"timelinePath\":[")
+                repeat(1_000) { offset ->
+                    if (offset > 0) writer.write(','.code)
+                    val longitude = if (pointIndex % 2 == 0) 0.0 else 179.0
+                    writer.write(
+                        "{\"point\":\"0.0,$longitude\"," +
+                            "\"durationMinutesOffsetFromStartTime\":$pointIndex}",
+                    )
+                    pointIndex += 1
+                }
+                writer.write("]}")
+                writer.flush()
+                if (file.length() >= minimumBytes) break
+            }
+            writer.write("]}")
         }
     }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
@@ -5,6 +5,7 @@ import java.time.Month
 import java.time.YearMonth
 import java.time.LocalDate
 import java.time.ZoneId
+import java.util.AbstractList
 import kotlin.math.asin
 import kotlin.math.atan2
 import kotlin.math.ceil
@@ -120,6 +121,62 @@ data class RouteSample(
     val distanceKm: Double,
 )
 
+internal data class RenderSampleLocation(
+    val toPointIndex: Int,
+    val step: Int,
+    val steps: Int,
+) {
+    val fraction: Double get() = step.toDouble() / steps
+}
+
+private class JourneyRenderPath(
+    private val points: List<GeoPoint>,
+    private val cumulativeDistanceKm: DoubleArray,
+) : AbstractList<RouteSample>() {
+    private val segmentEnds = IntArray((points.size - 1).coerceAtLeast(0))
+
+    override val size: Int
+
+    init {
+        var sampleCount = if (points.isEmpty()) 0L else 1L
+        for (toIndex in 1..points.lastIndex) {
+            val segmentDistance = cumulativeDistanceKm[toIndex] - cumulativeDistanceKm[toIndex - 1]
+            val steps = renderSteps(segmentDistance)
+            sampleCount += steps
+            require(sampleCount <= Int.MAX_VALUE) { "Timeline contains too many render samples" }
+            segmentEnds[toIndex - 1] = sampleCount.toInt()
+        }
+        size = sampleCount.toInt()
+    }
+
+    override fun get(index: Int): RouteSample {
+        if (index !in indices) throw IndexOutOfBoundsException("Index $index, size $size")
+        if (index == 0) return RouteSample(points.first(), 0.0)
+        val location = locationAt(index)
+        val fromIndex = location.toPointIndex - 1
+        val fraction = location.fraction
+        val startDistance = cumulativeDistanceKm[fromIndex]
+        val segmentDistance = cumulativeDistanceKm[location.toPointIndex] - startDistance
+        return RouteSample(
+            interpolate(points[fromIndex], points[location.toPointIndex], fraction),
+            startDistance + segmentDistance * fraction,
+        )
+    }
+
+    fun locationAt(index: Int): RenderSampleLocation {
+        require(index in 1 until size)
+        var low = 0
+        var high = segmentEnds.size
+        while (low < high) {
+            val middle = (low + high) ushr 1
+            if (segmentEnds[middle] <= index) low = middle + 1 else high = middle
+        }
+        val previousEnd = if (low == 0) 1 else segmentEnds[low - 1]
+        val steps = segmentEnds[low] - previousEnd
+        return RenderSampleLocation(low + 1, index - previousEnd + 1, steps)
+    }
+}
+
 data class JourneyLeg(
     val startKm: Double,
     val endKm: Double,
@@ -133,9 +190,10 @@ data class Journey(
     val points: List<GeoPoint>,
     val cumulativeDistanceKm: DoubleArray,
 ) {
+    private val renderPathData = JourneyRenderPath(points, cumulativeDistanceKm)
     val year: Int get() = period.startYear
     val totalDistanceKm: Double get() = cumulativeDistanceKm.lastOrNull() ?: 0.0
-    val renderPath: List<RouteSample> = buildRenderPath()
+    val renderPath: List<RouteSample> = renderPathData
     /**
      * A bounded, journey-specific cutoff for unusually large untracked hops. Dense local routes
      * can recognize shorter transfers, while consistently sparse routes keep the conservative cap.
@@ -192,39 +250,23 @@ data class Journey(
         )
     }
 
-    private fun buildRenderPath(): List<RouteSample> {
-        if (points.isEmpty()) return emptyList()
-        if (points.size == 1) return listOf(RouteSample(points.first(), 0.0))
-        return buildList {
-            add(RouteSample(points.first(), 0.0))
-            for (index in 1..points.lastIndex) {
-                val startDistance = cumulativeDistanceKm[index - 1]
-                val segmentDistance = cumulativeDistanceKm[index] - startDistance
-                val steps = ceil(segmentDistance / MAX_RENDER_STEP_KM).toInt().coerceIn(1, MAX_STEPS_PER_SEGMENT)
-                for (step in 1..steps) {
-                    val fraction = step.toDouble() / steps
-                    add(
-                        RouteSample(
-                            interpolate(points[index - 1], points[index], fraction),
-                            startDistance + segmentDistance * fraction,
-                        ),
-                    )
-                }
-            }
-        }
-    }
+    internal fun renderSampleLocation(index: Int): RenderSampleLocation? =
+        if (index == 0 || renderPath.isEmpty()) null else renderPathData.locationAt(index)
 
     private fun calculateTransferThresholdKm(): Double {
-        val ordinaryCandidates = cumulativeDistanceKm
-            .asSequence()
-            .zipWithNext { before, after -> after - before }
-            .filter { it > 0.0 && it < MAX_TRANSFER_THRESHOLD_KM }
-            .sorted()
-            .toList()
-        if (ordinaryCandidates.isEmpty()) return MAX_TRANSFER_THRESHOLD_KM
+        val candidates = DoubleArray((cumulativeDistanceKm.size - 1).coerceAtLeast(0))
+        var count = 0
+        for (index in 1 until cumulativeDistanceKm.size) {
+            val distance = cumulativeDistanceKm[index] - cumulativeDistanceKm[index - 1]
+            if (distance > 0.0 && distance < MAX_TRANSFER_THRESHOLD_KM) candidates[count++] = distance
+        }
+        if (count == 0) return MAX_TRANSFER_THRESHOLD_KM
 
-        val typicalHopKm = median(ordinaryCandidates)
-        val medianDeviationKm = median(ordinaryCandidates.map { kotlin.math.abs(it - typicalHopKm) }.sorted())
+        candidates.sort(0, count)
+        val typicalHopKm = median(candidates, count)
+        for (index in 0 until count) candidates[index] = kotlin.math.abs(candidates[index] - typicalHopKm)
+        candidates.sort(0, count)
+        val medianDeviationKm = median(candidates, count)
         return max(
             MIN_TRANSFER_THRESHOLD_KM,
             max(typicalHopKm * TRANSFER_TO_TYPICAL_RATIO, typicalHopKm + medianDeviationKm * DEVIATION_MULTIPLIER),
@@ -258,7 +300,7 @@ data class Journey(
             return Journey(period, points, distances)
         }
 
-        private fun interpolate(a: GeoPoint, b: GeoPoint, fraction: Double): GeoPoint {
+        internal fun interpolate(a: GeoPoint, b: GeoPoint, fraction: Double): GeoPoint {
             if (fraction <= 0.0) return a
             if (fraction >= 1.0) return b
             val lat1 = Math.toRadians(a.latitude)
@@ -288,18 +330,16 @@ data class Journey(
             return GeoPoint(instant, latitude, longitude)
         }
 
-        private const val MAX_RENDER_STEP_KM = 75.0
-        private const val MAX_STEPS_PER_SEGMENT = 320
         private const val MIN_TRANSFER_THRESHOLD_KM = 60.0
         private const val MAX_TRANSFER_THRESHOLD_KM = 120.0
         // A hop must also stand well clear of the journey's ordinary sampling pattern.
         private const val TRANSFER_TO_TYPICAL_RATIO = 3.0
         private const val DEVIATION_MULTIPLIER = 6.0
 
-        private fun median(sorted: List<Double>): Double {
-            if (sorted.isEmpty()) return 0.0
-            val middle = sorted.size / 2
-            return if (sorted.size % 2 == 0) {
+        private fun median(sorted: DoubleArray, size: Int): Double {
+            if (size == 0) return 0.0
+            val middle = size / 2
+            return if (size % 2 == 0) {
                 (sorted[middle - 1] + sorted[middle]) / 2.0
             } else {
                 sorted[middle]
@@ -307,6 +347,15 @@ data class Journey(
         }
     }
 }
+
+private const val MAX_RENDER_STEP_KM = 75.0
+private const val MAX_STEPS_PER_SEGMENT = 320
+
+private fun renderSteps(segmentDistance: Double): Int =
+    ceil(segmentDistance / MAX_RENDER_STEP_KM).toInt().coerceIn(1, MAX_STEPS_PER_SEGMENT)
+
+private fun interpolate(a: GeoPoint, b: GeoPoint, fraction: Double): GeoPoint =
+    Journey.interpolate(a, b, fraction)
 
 internal fun haversineKm(a: GeoPoint, b: GeoPoint): Double {
     val lat1 = Math.toRadians(a.latitude)

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -93,6 +93,9 @@ class TimelinePainter {
         color = Color.argb(220, 255, 248, 250)
     }
 
+    internal fun routeWorldPoint(journey: Journey, index: Int): WorldPoint =
+        prepare(journey).worldPointAt(index)
+
     fun viewport(
         journey: Journey,
         progress: Float,
@@ -145,25 +148,30 @@ class TimelinePainter {
         val lookaheadLimitKm = if (leg?.isTransfer == true) leg.endKm else journey.totalDistanceKm
         val tailDistance = max(rangeStartKm, current.distanceKm - contextKm)
         val lookaheadDistance = min(lookaheadLimitKm, current.distanceKm + contextKm)
-        val focus = buildList {
-            add(journey.positionAtDistance(tailDistance).point)
-            val start = prepared.lowerBound(tailDistance)
-            val end = prepared.upperBound(lookaheadDistance)
-            for (index in start..end) {
-                if (index in prepared.projected.indices) add(journey.renderPath[index].point)
-            }
-            add(current.point)
-            add(journey.positionAtDistance(lookaheadDistance).point)
-        }.map(WebMercator::project)
-
         val routeReferenceX = prepared.referenceX(current.distanceKm)
         val centerPoint = WebMercator.project(current.point)
         val centerX = unwrapNear(centerPoint.x, routeReferenceX)
-        val wrappedX = focus.map { unwrapNear(it.x, centerX) }
-        val ys = focus.map { it.y }
         val centerY = centerPoint.y
-        val contentSpanX = max(0.00015, (wrappedX.maxOrNull() ?: centerX) - (wrappedX.minOrNull() ?: centerX))
-        val contentSpanY = max(0.00015, (ys.maxOrNull() ?: centerY) - (ys.minOrNull() ?: centerY))
+        var minFocusX = centerX
+        var maxFocusX = centerX
+        var minFocusY = centerY
+        var maxFocusY = centerY
+        fun include(point: WorldPoint) {
+            val x = unwrapNear(point.x, centerX)
+            minFocusX = min(minFocusX, x)
+            maxFocusX = max(maxFocusX, x)
+            minFocusY = min(minFocusY, point.y)
+            maxFocusY = max(maxFocusY, point.y)
+        }
+        include(WebMercator.project(journey.positionAtDistance(tailDistance).point))
+        val start = prepared.lowerBound(tailDistance)
+        val end = prepared.upperBound(lookaheadDistance)
+        for (index in start..end) {
+            if (index in 0 until prepared.size) include(prepared.worldPointAt(index))
+        }
+        include(WebMercator.project(journey.positionAtDistance(lookaheadDistance).point))
+        val contentSpanX = max(0.00015, maxFocusX - minFocusX)
+        val contentSpanY = max(0.00015, maxFocusY - minFocusY)
         val aspect = width.toDouble() / height.coerceAtLeast(1)
         var spanY = max(contentSpanY * padding, contentSpanX * padding / aspect)
         spanY = spanY.coerceIn(movement.minimumViewportSpan, 0.72)
@@ -310,10 +318,24 @@ class TimelinePainter {
 
     private fun overviewViewport(journey: Journey, width: Int, height: Int): Viewport {
         val prepared = prepare(journey)
-        val minX = prepared.unwrappedX.minOrNull() ?: 0.5
-        val maxX = prepared.unwrappedX.maxOrNull() ?: minX
-        val minY = prepared.projected.minOfOrNull { it.y } ?: 0.5
-        val maxY = prepared.projected.maxOfOrNull { it.y } ?: minY
+        var minX = 0.5
+        var maxX = 0.5
+        var minY = 0.5
+        var maxY = 0.5
+        if (prepared.size > 0) {
+            val first = prepared.worldPointAt(0)
+            minX = first.x
+            maxX = first.x
+            minY = first.y
+            maxY = first.y
+            for (index in 1 until prepared.size) {
+                val point = prepared.worldPointAt(index)
+                minX = min(minX, point.x)
+                maxX = max(maxX, point.x)
+                minY = min(minY, point.y)
+                maxY = max(maxY, point.y)
+            }
+        }
         val contentCenterX = (minX + maxX) / 2.0
         val contentCenterY = (minY + maxY) / 2.0
         val contentSpanX = (maxX - minX).coerceAtLeast(MIN_VIEWPORT_SPAN)
@@ -602,7 +624,7 @@ class TimelinePainter {
         paint: Paint,
         alphaScale: Int,
     ) {
-        if (endDistance <= startDistance || prepared.distances.isEmpty() || alphaScale <= 0) return
+        if (endDistance <= startDistance || prepared.size == 0 || alphaScale <= 0) return
         val start = journey.positionAtDistance(startDistance)
         val end = journey.positionAtDistance(endDistance)
         val startScreen = screenPoint(start, prepared, viewport, width, height)
@@ -614,10 +636,10 @@ class TimelinePainter {
         var lastX = startScreen.first
         var lastY = startScreen.second
         var index = firstIndex
-        while (index <= lastIndex && index in prepared.projected.indices) {
-            val projected = prepared.projected[index]
+        while (index <= lastIndex && index in 0 until prepared.size) {
+            val projected = prepared.worldPointAt(index)
             val screen = worldToScreen(
-                WorldPoint(prepared.unwrappedX[index], projected.y),
+                projected,
                 viewport,
                 width,
                 height,
@@ -652,23 +674,10 @@ class TimelinePainter {
 
     private fun prepare(journey: Journey): PreparedJourney {
         if (cachedJourney === journey) return cachedPrepared!!
-        val projected = journey.renderPath.map { WebMercator.project(it.point) }
-        val prepared = PreparedJourney(
-            projected = projected,
-            unwrappedX = unwrapRoute(projected.map { it.x }),
-            distances = DoubleArray(journey.renderPath.size) { journey.renderPath[it].distanceKm },
-        )
+        val prepared = PreparedJourney(journey)
         cachedJourney = journey
         cachedPrepared = prepared
         return prepared
-    }
-
-    private fun unwrapRoute(values: List<Double>): List<Double> {
-        if (values.isEmpty()) return emptyList()
-        return buildList {
-            add(values.first())
-            for (index in 1..values.lastIndex) add(unwrapNear(values[index], last()))
-        }
     }
 
     private fun unwrapNear(value: Double, reference: Double): Double {
@@ -678,40 +687,73 @@ class TimelinePainter {
         return result
     }
 
-    private data class PreparedJourney(
-        val projected: List<WorldPoint>,
-        val unwrappedX: List<Double>,
-        val distances: DoubleArray,
-    ) {
+    private class PreparedJourney(private val journey: Journey) {
+        private val unwrappedPointX = DoubleArray(journey.points.size)
+        val size: Int get() = journey.renderPath.size
+
+        init {
+            for (index in journey.points.indices) {
+                val projected = WebMercator.project(journey.points[index])
+                unwrappedPointX[index] = if (index == 0) projected.x else {
+                    unwrap(projected.x, unwrappedPointX[index - 1])
+                }
+            }
+        }
+
+        fun worldPointAt(index: Int): WorldPoint {
+            val sample = journey.renderPath[index]
+            val projected = WebMercator.project(sample.point)
+            val location = journey.renderSampleLocation(index)
+            val reference = if (location == null) {
+                unwrappedPointX.firstOrNull() ?: 0.5
+            } else {
+                val from = location.toPointIndex - 1
+                unwrappedPointX[from] +
+                    (unwrappedPointX[location.toPointIndex] - unwrappedPointX[from]) * location.fraction
+            }
+            return WorldPoint(unwrap(projected.x, reference), projected.y)
+        }
+
+        private fun distanceAt(index: Int): Double = journey.renderPath[index].distanceKm
+
         fun lowerBound(value: Double): Int {
             var low = 0
-            var high = distances.size
+            var high = size
             while (low < high) {
                 val middle = (low + high) ushr 1
-                if (distances[middle] < value) low = middle + 1 else high = middle
+                if (distanceAt(middle) < value) low = middle + 1 else high = middle
             }
-            return low.coerceAtMost(distances.lastIndex.coerceAtLeast(0))
+            return low.coerceAtMost((size - 1).coerceAtLeast(0))
         }
 
         fun upperBound(value: Double): Int {
             var low = 0
-            var high = distances.size
+            var high = size
             while (low < high) {
                 val middle = (low + high) ushr 1
-                if (distances[middle] <= value) low = middle + 1 else high = middle
+                if (distanceAt(middle) <= value) low = middle + 1 else high = middle
             }
             return low - 1
         }
 
         fun referenceX(distanceKm: Double): Double {
-            if (distances.isEmpty()) return 0.5
-            val after = lowerBound(distanceKm)
-            val before = (after - 1).coerceAtLeast(0)
-            val nearest = if (
-                after in distances.indices &&
-                kotlin.math.abs(distances[after] - distanceKm) < kotlin.math.abs(distances[before] - distanceKm)
-            ) after else before
-            return unwrappedX[nearest]
+            if (journey.points.isEmpty()) return 0.5
+            val position = journey.positionAtDistance(distanceKm)
+            val projected = WebMercator.project(position.point)
+            val reference = if (position.fromIndex == position.toIndex) {
+                unwrappedPointX[position.fromIndex]
+            } else {
+                unwrappedPointX[position.fromIndex] +
+                    (unwrappedPointX[position.toIndex] - unwrappedPointX[position.fromIndex]) * position.segmentFraction
+            }
+            return unwrap(projected.x, reference)
+        }
+
+        private fun unwrap(value: Double, reference: Double): Double {
+            var result = value
+            while (result - reference > 0.5) result -= 1.0
+            while (result - reference < -0.5) result += 1.0
+            return result
         }
     }
 

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/model/JourneyTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/model/JourneyTest.kt
@@ -5,6 +5,7 @@ import dev.mahlernim.timelinevisualizer.render.CameraMovement
 import dev.mahlernim.timelinevisualizer.render.CameraSettings
 import dev.mahlernim.timelinevisualizer.render.LongTripCompression
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -61,6 +62,68 @@ class JourneyTest {
         assertTrue(journey.renderPath.size > 20)
         val largestStep = journey.renderPath.zipWithNext { a, b -> b.distanceKm - a.distanceKm }.max()
         assertTrue("Largest rendered step was $largestStep km", largestStep <= 75.1)
+    }
+
+    @Test
+    fun virtualRenderPathMatchesThePreviousGeometryExactly() {
+        val points = listOf(
+            seoul,
+            bohol,
+            bohol.copy(
+                instant = Instant.parse("2025-06-01T08:00:00Z"),
+                latitude = 35.6762,
+                longitude = 139.6503,
+            ),
+        )
+        val journey = Journey.from(points, 2025)
+        val expected = legacyRenderPath(journey)
+
+        assertEquals(expected.size, journey.renderPath.size)
+        expected.indices.forEach { index ->
+            assertEquals(expected[index].distanceKm, journey.renderPath[index].distanceKm, 0.0)
+            assertEquals(expected[index].point, journey.renderPath[index].point)
+        }
+        assertSame(points.last(), journey.renderPath.last().point)
+    }
+
+    @Test
+    fun virtualProjectionMatchesThePreviousPreparedRoute() {
+        val points = listOf(
+            seoul.copy(latitude = 10.0, longitude = 179.0),
+            bohol.copy(latitude = 20.0, longitude = -179.0),
+            bohol.copy(
+                instant = Instant.parse("2025-06-01T08:00:00Z"),
+                latitude = 35.6762,
+                longitude = 139.6503,
+            ),
+        )
+        val journey = Journey.from(points, 2025)
+        val expected = unwrapLegacyRoute(legacyRenderPath(journey))
+        val painter = TimelinePainter()
+
+        expected.indices.forEach { index ->
+            val actual = painter.routeWorldPoint(journey, index)
+            assertEquals(expected[index].x, actual.x, 1e-12)
+            assertEquals(expected[index].y, actual.y, 1e-12)
+        }
+    }
+
+    @Test(timeout = 15_000)
+    fun millionsOfRenderSamplesStayVirtual() {
+        val start = Instant.parse("2025-01-01T00:00:00Z")
+        val points = List(30_000) { index ->
+            GeoPoint(
+                instant = start.plusSeconds(index.toLong()),
+                latitude = 0.0,
+                longitude = if (index % 2 == 0) 0.0 else 179.0,
+            )
+        }
+
+        val journey = Journey.from(points, 2025)
+
+        assertTrue("Expected millions of samples, got ${journey.renderPath.size}", journey.renderPath.size > 7_000_000)
+        assertEquals(points.first(), journey.renderPath.first().point)
+        assertSame(points.last(), journey.renderPath.last().point)
     }
 
     @Test
@@ -250,6 +313,33 @@ class JourneyTest {
             longitude = centerLongitude + if (index % 2 == 0) -0.01 else 0.01,
             hour = startHour + index,
         )
+    }
+
+    private fun legacyRenderPath(journey: Journey): List<RouteSample> = buildList {
+        if (journey.points.isEmpty()) return@buildList
+        add(RouteSample(journey.points.first(), 0.0))
+        for (index in 1..journey.points.lastIndex) {
+            val startDistance = journey.cumulativeDistanceKm[index - 1]
+            val segmentDistance = journey.cumulativeDistanceKm[index] - startDistance
+            val steps = kotlin.math.ceil(segmentDistance / 75.0).toInt().coerceIn(1, 320)
+            for (step in 1..steps) {
+                val fraction = step.toDouble() / steps
+                add(
+                    RouteSample(
+                        Journey.interpolate(journey.points[index - 1], journey.points[index], fraction),
+                        startDistance + segmentDistance * fraction,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun unwrapLegacyRoute(path: List<RouteSample>): List<WorldPoint> = buildList {
+        path.forEach { sample ->
+            val projected = WebMercator.project(sample.point)
+            val x = if (isEmpty()) projected.x else unwrapNear(projected.x, last().x)
+            add(WorldPoint(x, projected.y))
+        }
     }
 
     private companion object {

--- a/docs/release-notes-v2.1.2.md
+++ b/docs/release-notes-v2.1.2.md
@@ -1,0 +1,49 @@
+# Timeline Visualizer 2.1.2
+
+This reliability update fixes an additional memory spike while preparing and drawing
+dense Timeline routes. Timeline points, filtering, ordering, distances, and displayed
+route geometry remain unchanged.
+
+## 한국어
+
+밀집된 Timeline 경로를 준비하고 표시할 때 발생하던 추가 메모리 급증 문제를
+수정했습니다. Timeline 위치, 필터링, 순서, 이동 거리와 표시 경로는 바뀌지 않습니다.
+
+## 日本語
+
+密度の高い Timeline 経路の準備と描画で発生していた追加のメモリ急増を修正しました。
+位置情報、フィルタリング、順序、移動距離、表示経路は変わりません。
+
+## 简体中文
+
+修复了准备和绘制密集 Timeline 路线时的额外内存峰值。地点、筛选、顺序、行程距离和
+显示路线保持不变。
+
+## 繁體中文
+
+修正準備及繪製密集 Timeline 路線時的額外記憶體尖峰。位置、篩選、順序、旅程距離和
+顯示路線維持不變。
+
+## Español
+
+Corrige un pico adicional de memoria al preparar y dibujar rutas densas de Timeline.
+Los puntos, filtros, el orden, las distancias y la geometría mostrada no cambian.
+
+## Français
+
+Corrige un pic de mémoire supplémentaire pendant la préparation et le tracé des
+itinéraires Timeline denses. Les points, filtres, l’ordre, les distances et le tracé
+affiché restent inchangés.
+
+## Deutsch
+
+Behebt eine weitere Speicherspitze beim Vorbereiten und Zeichnen dichter
+Timeline-Routen. Punkte, Filter, Reihenfolge, Entfernungen und Routengeometrie bleiben
+unverändert.
+
+## Português (Brasil)
+
+Corrige um pico adicional de memória ao preparar e desenhar rotas densas da Timeline.
+Pontos, filtros, ordem, distâncias e geometria exibida permanecem iguais.
+
+Timeline processing remains local. No Timeline content is logged or uploaded.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.1.1` and version code `16`
+- Version name `2.1.2` and version code `17`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## What changed

- keeps exact interpolated route samples virtual instead of retaining millions of `GeoPoint` and `RouteSample` objects
- replaces route-sized first-frame projection collections with compact source-point indexes and on-demand projection
- calculates transfer thresholds with primitive arrays
- adds a dense long-gap fixture below 16 MB and an API 36 device lane
- sets version 2.1.2 with version code 17 and localized crash-fix release notes

## Root cause

v2.1.1 bounded parser normalization memory but still expanded every long route segment during `Journey` construction. It then created several more route-sized collections during first-frame preparation. File byte size was a weak proxy, so a dense 16 MB file with long gaps could use more memory than the padded 45 MB regression fixture.

## Validation

- v2.1.1 fails the 30,000-point, seven-million-sample stress case with `OutOfMemoryError` under a 384 MB JVM heap
- this branch passes the identical bounded-heap stress case
- exact route samples, distances, and projected positions match the prior algorithm, including a date-line crossing
- full Android unit, Robolectric, lint, GitHub debug, and Play debug builds pass
- Python suite passes, 20 tests
- generated 14 to 16 MB dense long-gap and 45 MB padded imports pass on API 35 and API 36 emulators
- loading ends, duplicate import remains disabled during processing, the process survives, and the import marker clears
- no personal Timeline data is committed, logged, or uploaded

References #44. This does not close the issue until the public v2.1.2 APK is independently verified.