### PR TITLE
Fix first-frame crash caused by translated date-pattern letters (es/fr/pt-BR/de)

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/RenderText.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/RenderText.kt
@@ -1,5 +1,6 @@
 package dev.mahlernim.timelinevisualizer.render
 
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 data class RenderText(
@@ -11,7 +12,16 @@ data class RenderText(
 ) {
     val locale: Locale get() = Locale.forLanguageTag(localeTag).takeUnless { it.language.isBlank() } ?: Locale.ENGLISH
 
+    // A translated pattern may hold reserved or unknown letters (a translator turning "yyyy"
+    // into "aaaa" or "jjjj"), and ofPattern throws for those while the first frame renders on
+    // the main thread. Fall back to the default pattern instead of crashing playback.
+    val dateFormatter: DateTimeFormatter by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        runCatching { DateTimeFormatter.ofPattern(datePattern, locale) }
+            .getOrElse { DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN, locale) }
+    }
+
     companion object {
+        const val DEFAULT_DATE_PATTERN = "MMMM yyyy"
         val ENGLISH = RenderText(
             localeTag = "en",
             fallbackTitle = "My Timeline",

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -13,7 +13,6 @@ import dev.mahlernim.timelinevisualizer.model.JourneyPosition
 import dev.mahlernim.timelinevisualizer.model.WebMercator
 import dev.mahlernim.timelinevisualizer.model.WorldPoint
 import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import java.text.NumberFormat
 import java.util.Locale
 import kotlin.math.floor
@@ -592,8 +591,7 @@ class TimelinePainter {
             displayTitle.take(count.coerceAtLeast(1)).trimEnd() + "…"
         }
         canvas.drawText(fittedTitle, width / 2f, 72f * scale, titlePaint)
-        val date = DateTimeFormatter.ofPattern(renderText.datePattern, renderText.locale)
-            .format(position.point.instant.atZone(ZoneId.systemDefault()))
+        val date = renderText.dateFormatter.format(position.point.instant.atZone(ZoneId.systemDefault()))
         val distance = position.distanceKm
         val number = NumberFormat.getNumberInstance(renderText.locale).apply { maximumFractionDigits = 0 }
         canvas.drawText(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -125,7 +125,6 @@
     <string name="project_on_github">Projekt auf GitHub</string>
     <string name="update_page_unavailable">Die Update-Seite konnte nicht geöffnet werden</string>
     <string name="web_page_unavailable">Die Webseite konnte nicht geöffnet werden</string>
-    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline-Video</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -125,7 +125,7 @@
     <string name="project_on_github">Projekt auf GitHub</string>
     <string name="update_page_unavailable">Die Update-Seite konnte nicht geöffnet werden</string>
     <string name="web_page_unavailable">Die Webseite konnte nicht geöffnet werden</string>
-    <string name="render_date_pattern">MMMM jjjj</string>
+    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline-Video</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -129,7 +129,6 @@
     <string name="project_on_github">Proyecto en GitHub</string>
     <string name="update_page_unavailable">No se pudo abrir la página de actualización</string>
     <string name="web_page_unavailable">No se pudo abrir la página web</string>
-    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Vídeo Timeline</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -129,7 +129,7 @@
     <string name="project_on_github">Proyecto en GitHub</string>
     <string name="update_page_unavailable">No se pudo abrir la página de actualización</string>
     <string name="web_page_unavailable">No se pudo abrir la página web</string>
-    <string name="render_date_pattern">MMMM aaaa</string>
+    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Vídeo Timeline</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -129,7 +129,6 @@
     <string name="project_on_github">Projet sur GitHub</string>
     <string name="update_page_unavailable">Impossible d\'ouvrir la page de mise à jour</string>
     <string name="web_page_unavailable">Impossible d\'ouvrir la page Web</string>
-    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Vidéo Timeline</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -129,7 +129,7 @@
     <string name="project_on_github">Projet sur GitHub</string>
     <string name="update_page_unavailable">Impossible d\'ouvrir la page de mise à jour</string>
     <string name="web_page_unavailable">Impossible d\'ouvrir la page Web</string>
-    <string name="render_date_pattern">MMMM aaaa</string>
+    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Vidéo Timeline</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">タイムライン可視化</string>
     <string name="import_timeline">ファイルを選択</string>
     <string name="how_to_export">タイムライン ファイルを取得</string>
@@ -120,7 +120,7 @@
     <string name="project_on_github">GitHubのプロジェクト</string>
     <string name="update_page_unavailable">更新ページを開けませんでした</string>
     <string name="web_page_unavailable">ウェブページを開けませんでした</string>
-    <string name="render_date_pattern">yyyy年M月</string>
+    <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy年M月</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap  © CARTO</string>
     <string name="timeline_video">タイムライン動画</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">타임라인 비주얼라이저</string>
     <string name="import_timeline">파일 선택</string>
     <string name="how_to_export">타임라인 파일 받기</string>
@@ -120,7 +120,7 @@
     <string name="project_on_github">GitHub 프로젝트</string>
     <string name="update_page_unavailable">업데이트 페이지를 열 수 없습니다</string>
     <string name="web_page_unavailable">웹페이지를 열 수 없습니다</string>
-    <string name="render_date_pattern">yyyy년 M월</string>
+    <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy년 M월</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap  © CARTO</string>
     <string name="timeline_video">타임라인 영상</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -129,7 +129,6 @@
     <string name="project_on_github">Projeto em GitHub</string>
     <string name="update_page_unavailable">Não foi possível abrir a página de atualização</string>
     <string name="web_page_unavailable">Não foi possível abrir a página da web</string>
-    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap</string>
     <string name="timeline_video">Vídeo Timeline</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -129,7 +129,7 @@
     <string name="project_on_github">Projeto em GitHub</string>
     <string name="update_page_unavailable">Não foi possível abrir a página de atualização</string>
     <string name="web_page_unavailable">Não foi possível abrir a página da web</string>
-    <string name="render_date_pattern">MMMM aaaa</string>
+    <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap</string>
     <string name="timeline_video">Vídeo Timeline</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -121,7 +121,7 @@
     <string name="project_on_github">GitHub 上的项目</string>
     <string name="update_page_unavailable">无法打开更新页面</string>
     <string name="web_page_unavailable">无法打开网页</string>
-    <string name="render_date_pattern">MMMM 年</string>
+    <string name="render_date_pattern">yyyy年M月</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline视频</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">Timeline Visualizer</string>
     <string name="import_timeline">选择文件</string>
     <string name="how_to_export">获取Timeline文件</string>
@@ -121,7 +121,7 @@
     <string name="project_on_github">GitHub 上的项目</string>
     <string name="update_page_unavailable">无法打开更新页面</string>
     <string name="web_page_unavailable">无法打开网页</string>
-    <string name="render_date_pattern">yyyy年M月</string>
+    <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy年M月</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline视频</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -121,7 +121,7 @@
     <string name="project_on_github">GitHub 上的項目</string>
     <string name="update_page_unavailable">無法開啟更新頁面</string>
     <string name="web_page_unavailable">無法開啟網頁</string>
-    <string name="render_date_pattern">MMMM 年</string>
+    <string name="render_date_pattern">yyyy年M月</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline視頻</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">Timeline Visualizer</string>
     <string name="import_timeline">選擇文件</string>
     <string name="how_to_export">取得Timeline文件</string>
@@ -121,7 +121,7 @@
     <string name="project_on_github">GitHub 上的項目</string>
     <string name="update_page_unavailable">無法開啟更新頁面</string>
     <string name="web_page_unavailable">無法開啟網頁</string>
-    <string name="render_date_pattern">yyyy年M月</string>
+    <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy年M月</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline視頻</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,10 +124,13 @@
     <string name="project_on_github">Project on GitHub</string>
     <string name="update_page_unavailable">Could not open the update page</string>
     <string name="web_page_unavailable">Could not open the web page</string>
-    <!-- java.time.DateTimeFormatter pattern. Reorder or add literal text for a locale, but keep
-         the pattern letters (M, y) exactly as they are: letters a-z are reserved format symbols,
-         and translating them (e.g. "aaaa" or "jjjj" for "yyyy") makes the pattern invalid. -->
-    <string name="render_date_pattern">MMMM yyyy</string>
+    <!-- java.time.DateTimeFormatter pattern, deliberately developer-owned: letters a-z are
+         reserved format symbols, and translating them (e.g. "aaaa" or "jjjj" for "yyyy")
+         makes the pattern invalid and used to crash the first rendered frame. It is marked
+         translatable="false" so translation tooling skips it; locales that need a different
+         date shape (ja, ko, zh) carry a hand-maintained override in their strings.xml,
+         changed only through code review, with tools:ignore="ExtraTranslation". -->
+    <string name="render_date_pattern" translatable="false">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap  © CARTO</string>
     <string name="timeline_video">Timeline video</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,9 @@
     <string name="project_on_github">Project on GitHub</string>
     <string name="update_page_unavailable">Could not open the update page</string>
     <string name="web_page_unavailable">Could not open the web page</string>
+    <!-- java.time.DateTimeFormatter pattern. Reorder or add literal text for a locale, but keep
+         the pattern letters (M, y) exactly as they are: letters a-z are reserved format symbols,
+         and translating them (e.g. "aaaa" or "jjjj" for "yyyy") makes the pattern invalid. -->
     <string name="render_date_pattern">MMMM yyyy</string>
     <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap  © CARTO</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/LocalizedDatePatternsTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/LocalizedDatePatternsTest.kt
@@ -30,8 +30,13 @@ class LocalizedDatePatternsTest {
         val problems = mutableListOf<String>()
         var patternsChecked = 0
         patternFiles.forEach { stringsFile ->
-            val pattern = renderDatePattern(stringsFile) ?: return@forEach
+            val resource = renderDatePattern(stringsFile) ?: return@forEach
             patternsChecked += 1
+            val folder = stringsFile.parentFile.name
+            if (folder == "values" && resource.translatable != "false") {
+                problems += "$folder: render_date_pattern must stay translatable=\"false\" so translation tooling skips it"
+            }
+            val pattern = resource.pattern
             val formatter = try {
                 DateTimeFormatter.ofPattern(pattern)
             } catch (error: IllegalArgumentException) {
@@ -50,13 +55,20 @@ class LocalizedDatePatternsTest {
         if (problems.isNotEmpty()) fail(problems.joinToString("\n"))
     }
 
-    private fun renderDatePattern(stringsFile: File): String? {
+    private data class PatternResource(val pattern: String, val translatable: String?)
+
+    private fun renderDatePattern(stringsFile: File): PatternResource? {
         val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stringsFile)
         val strings = document.getElementsByTagName("string")
         for (index in 0 until strings.length) {
             val node = strings.item(index)
             val name = node.attributes?.getNamedItem("name")?.nodeValue
-            if (name == "render_date_pattern") return node.textContent
+            if (name == "render_date_pattern") {
+                return PatternResource(
+                    pattern = node.textContent,
+                    translatable = node.attributes?.getNamedItem("translatable")?.nodeValue,
+                )
+            }
         }
         return null
     }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/LocalizedDatePatternsTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/LocalizedDatePatternsTest.kt
@@ -1,0 +1,63 @@
+package dev.mahlernim.timelinevisualizer.render
+
+import java.io.File
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Guards every translation of render_date_pattern: a translated pattern letter (such as "aaaa"
+ * or "jjjj" for "yyyy") makes DateTimeFormatter.ofPattern throw during the first rendered
+ * frame, which closed the app for Spanish, French, Portuguese, and German users right after a
+ * Timeline import succeeded.
+ */
+class LocalizedDatePatternsTest {
+    @Test
+    fun everyLocalizedRenderDatePatternCompilesAndShowsMonthAndYear() {
+        val resources = sequenceOf(File("src/main/res"), File("app/src/main/res"))
+            .firstOrNull(File::isDirectory)
+            ?: error("Resource directory not found from ${File(".").absolutePath}")
+        val patternFiles = resources.listFiles { file -> file.name.startsWith("values") }
+            .orEmpty()
+            .mapNotNull { valuesDir -> File(valuesDir, "strings.xml").takeIf(File::isFile) }
+        assertTrue("No strings.xml files found", patternFiles.isNotEmpty())
+
+        val sample = ZonedDateTime.of(2025, 8, 19, 12, 0, 0, 0, ZoneOffset.UTC)
+        val problems = mutableListOf<String>()
+        var patternsChecked = 0
+        patternFiles.forEach { stringsFile ->
+            val pattern = renderDatePattern(stringsFile) ?: return@forEach
+            patternsChecked += 1
+            val formatter = try {
+                DateTimeFormatter.ofPattern(pattern)
+            } catch (error: IllegalArgumentException) {
+                problems += "${stringsFile.parentFile.name}: pattern \"$pattern\" is invalid (${error.message})"
+                return@forEach
+            }
+            val formatted = formatter.format(sample)
+            if (!formatted.contains("2025")) {
+                problems += "${stringsFile.parentFile.name}: pattern \"$pattern\" renders \"$formatted\" without the year"
+            }
+            if (formatted == formatter.format(sample.withMonth(9))) {
+                problems += "${stringsFile.parentFile.name}: pattern \"$pattern\" renders \"$formatted\" without the month"
+            }
+        }
+        assertTrue("render_date_pattern missing from default resources", patternsChecked > 0)
+        if (problems.isNotEmpty()) fail(problems.joinToString("\n"))
+    }
+
+    private fun renderDatePattern(stringsFile: File): String? {
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stringsFile)
+        val strings = document.getElementsByTagName("string")
+        for (index in 0 until strings.length) {
+            val node = strings.item(index)
+            val name = node.attributes?.getNamedItem("name")?.nodeValue
+            if (name == "render_date_pattern") return node.textContent
+        }
+        return null
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/RenderTextTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/RenderTextTest.kt
@@ -1,0 +1,37 @@
+package dev.mahlernim.timelinevisualizer.render
+
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RenderTextTest {
+    private val august2025: ZonedDateTime = ZonedDateTime.of(2025, 8, 19, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    @Test
+    fun validPatternFormatsWithTheRequestedLocale() {
+        val text = RenderText.ENGLISH.copy(localeTag = "es", datePattern = "MMMM yyyy")
+        assertEquals("agosto 2025", text.dateFormatter.format(august2025))
+    }
+
+    @Test
+    fun translatedYearLettersFallBackInsteadOfThrowing() {
+        // "aaaa" is what translating "yyyy" produced in the Spanish, French, and Portuguese
+        // resources; "a" is the reserved am/pm symbol, so ofPattern rejects the pattern.
+        val text = RenderText.ENGLISH.copy(localeTag = "pt-BR", datePattern = "MMMM aaaa")
+        assertEquals("agosto 2025", text.dateFormatter.format(august2025))
+    }
+
+    @Test
+    fun unknownPatternLettersFallBackInsteadOfThrowing() {
+        // "jjjj" came from translating "yyyy" in the German resources; "j" is not a valid symbol.
+        val text = RenderText.ENGLISH.copy(localeTag = "de", datePattern = "MMMM jjjj")
+        assertEquals("August 2025", text.dateFormatter.format(august2025))
+    }
+
+    @Test
+    fun localizedLiteralTextIsPreserved() {
+        val text = RenderText.ENGLISH.copy(localeTag = "ja", datePattern = "yyyy年M月")
+        assertEquals("2025年8月", text.dateFormatter.format(august2025))
+    }
+}

--- a/tests/test_play_store_materials.py
+++ b/tests/test_play_store_materials.py
@@ -81,16 +81,23 @@ def test_android_locales_have_matching_resources_and_placeholders():
 
     def resources(path: Path):
         result = {}
+        developer_owned = set()
         for element in ET.parse(path).getroot():
             name = element.attrib["name"]
             text = " ".join(element.itertext())
             placeholders = sorted(set(re.findall(r"%\d+\$[a-zA-Z]|\{(?:year|name)\}", text)))
-            result[(element.tag, name)] = placeholders
-        return result
+            key = (element.tag, name)
+            result[key] = placeholders
+            if element.attrib.get("translatable") == "false":
+                developer_owned.add(key)
+        return result, developer_owned
 
-    localized = {locale: resources(path) for locale, path in files.items()}
+    localized = {locale: resources(path)[0] for locale, path in files.items()}
+    developer_owned = resources(files["en"])[1]
+    expected = {key: value for key, value in localized["en"].items() if key not in developer_owned}
     for locale, values in localized.items():
-        assert values == localized["en"], locale
+        translated = {key: value for key, value in values.items() if key not in developer_owned}
+        assert translated == expected, locale
 
 
 def test_localized_restoration_guides_are_complete_and_accessible():


### PR DESCRIPTION
## Root cause of the remaining #44 crashes

The remaining "app closes right after choosing the file" reports in #44 are not memory-related — they are locale-related, which is why file sizes from 16 MB to 105 MB all reproduce it and why English-locale device tests pass.

The translations shipped the **date pattern itself translated**:

| Locale | Shipped pattern | Result |
|---|---|---|
| es, fr, pt-BR | `MMMM aaaa` | `IllegalArgumentException: Too many pattern letters: a` (`a` = am/pm) |
| de | `MMMM jjjj` | `IllegalArgumentException: Unknown pattern letter: j` |
| zh-rCN, zh-rTW | `MMMM 年` | no crash, but renders `八月 年` — no year digits |

`TimelinePainter.drawOverlay` builds this formatter on the **main thread** during the first rendered frame:

```kotlin
DateTimeFormatter.ofPattern(renderText.datePattern, renderText.locale)
```

The import coroutine's `catch (Throwable)` never sees it — the exception is thrown in `View.onDraw` after the import completes, so the app dies exactly when the editor appears. The remembered-import retry then reproduces it on every app start. This matches the reporter demographics in #44 (Spanish/Portuguese/French-language phones) and the crash timing in the attached videos.

I verified against a real 105 MB, 51,823-segment, 227k-point `Rutas.json` (Spanish export) on the JVM: parse → outlier filter → journey → camera track → 100 painted frames all complete comfortably inside a 96 MB heap, so v2.1.1's parser is fine; only the localized pattern crashes the first frame.

## Fix

1. **Resources** — restore valid patterns: `MMMM yyyy` for es/fr/pt-BR/de, and `yyyy年M月` for both Chinese locales (matching ja). Valid localized patterns (ja/ko) are kept, unlike #59 which removes them all. A comment in the default `strings.xml` warns translators that pattern letters are reserved.
2. **Hardening** — `RenderText` now builds the formatter once and falls back to the default `MMMM yyyy` pattern (still with the correct locale, so month names stay translated) when a translated pattern is invalid. A bad future translation degrades gracefully instead of crashing preview and export.
3. **Tests** — `RenderTextTest` covers the fallback for both failure modes, and `LocalizedDatePatternsTest` validates every `values*/strings.xml` `render_date_pattern`: it must compile, and its output must contain the year and change with the month.

Closes #44 (the post-2.1.1 reports). Overlaps with #59, but keeps the valid localized patterns and adds the runtime guard + regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update (after review feedback):** rebased onto v2.1.2 and added `translatable="false"` to the default `render_date_pattern` per the review suggestion. The es/fr/pt-BR/de entries are removed (they now resolve through the default), while ja/ko/zh keep hand-maintained locale-specific overrides with `tools:ignore="ExtraTranslation"`; the resource test also asserts the `translatable="false"` marker stays. `lintGithubDebug` and the unit suite pass.