### PR TITLE
Release v2.1.3 import reliability update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.1.3
+
+- Fix invalid translated preview date patterns that terminated the first frame in German, Spanish, French, and Portuguese.
+- Render a first preview frame in every supported language during regression testing.
+- Show the initial Timeline preview without synchronously building the complete camera track.
+- Build all 481 smooth camera positions in the background and keep playback controls disabled until ready.
+- Reuse exact route-range bounds instead of rescanning dense routes for every camera position.
+- Reduce temporary allocations in route projection, location filtering, range selection, and transfer preparation.
+- Replace padded import fixtures with point-dense compact and long-gap device coverage.
+- Preserve Timeline points, filtering, ordering, distances, route geometry, and completed camera behavior.
+- Open Create video on a cold launch when the video library is empty, while preserving export recovery and restored navigation state.
+- Explain that an empty Timeline export may mean Timeline was not enabled and Google had no location data to export.
+- Set Android version code 18 and version name 2.1.3.
+
 ## 2.1.2
 
 - Keep interpolated route samples virtual instead of retaining millions of route objects.

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@ Google マップから書き出した Timeline JSON を使い、Android 端末�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.1.2.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.1.3.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,7 +15,7 @@ JSON 파일과 영상 렌더링은 휴대전화 안에서 처리됩니다.
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.1.2.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.1.3.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ exact dates, preview the Journey, and create an MP4 ready to watch or share.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.1.2.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.1.3.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 17
-        versionName = "2.1.2"
+        versionCode = 18
+        versionName = "2.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/DeviceSmokeTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/DeviceSmokeTest.kt
@@ -12,13 +12,9 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class DeviceSmokeTest {
     @Test
-    fun videosFirstLaunchAndBackNavigationWorkOnDevice() {
+    fun emptyLibraryLaunchAndBackNavigationWorkOnDevice() {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
-                assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
-                assertEquals(View.GONE, activity.findViewById<View>(R.id.newVideoScreen).visibility)
-
-                activity.findViewById<View>(R.id.navigationCreate).performClick()
                 assertEquals(View.GONE, activity.findViewById<View>(R.id.videosScreen).visibility)
                 assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.newVideoScreen).visibility)
 

--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/LargeTimelineImportDeviceTest.kt
@@ -7,8 +7,12 @@ import android.view.View
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import dev.mahlernim.timelinevisualizer.data.TimelineSourceStore
 import dev.mahlernim.timelinevisualizer.data.LocationFilterMode
+import dev.mahlernim.timelinevisualizer.ui.TimelineView
 import dev.mahlernim.timelinevisualizer.ui.LocationFilterPreferences
 import java.io.File
 import org.junit.Assert.assertEquals
@@ -19,12 +23,13 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class LargeTimelineImportDeviceTest {
     @Test
-    fun importsDenseLongGapTimelineBelowSixteenMegabytes() {
+    fun importsDenseLongGapTimelineBelowSixteenMegabytesInPortuguese() {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        setAppLocales("pt-BR")
         context.getSharedPreferences("display", Context.MODE_PRIVATE).edit()
             .putBoolean("map_privacy_accepted_v1", true)
             .commit()
-        LocationFilterPreferences(context).save(LocationFilterMode.OFF)
+        LocationFilterPreferences(context).save(LocationFilterMode.CONSERVATIVE)
         TimelineSourceStore(context).clear()
         val source = File(context.cacheDir, "dense-long-gap-timeline.json")
         writeDenseLongGapTimeline(source, 14L * 1024 * 1024)
@@ -34,9 +39,16 @@ class LargeTimelineImportDeviceTest {
             assertTrue(source.length() >= 14L * 1024 * 1024)
             assertTrue(source.length() < 16L * 1024 * 1024)
         } finally {
+            setAppLocales("")
             LocationFilterPreferences(context).reset()
             TimelineSourceStore(context).clear()
             source.delete()
+        }
+    }
+
+    private fun setAppLocales(languageTags: String) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(languageTags))
         }
     }
 
@@ -61,24 +73,25 @@ class LargeTimelineImportDeviceTest {
 
     private fun assertImportCompletes(context: Context, source: File) {
         val intent = Intent(context, MainActivity::class.java).apply {
-            action = Intent.ACTION_VIEW
-            data = Uri.fromFile(source)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        var sawLoading = false
         var imported = false
         val sourceStore = TimelineSourceStore(context)
         ActivityScenario.launch<MainActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.importTimeline(Uri.fromFile(source))
+                assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.loadingGroup).visibility)
+                assertEquals(false, activity.findViewById<View>(R.id.importButton).isEnabled)
+            }
             val deadline = System.currentTimeMillis() + 300_000L
             while (System.currentTimeMillis() < deadline && !imported) {
                 scenario.onActivity { activity ->
                     val loading = activity.findViewById<View>(R.id.loadingGroup).visibility == View.VISIBLE
-                    if (loading) {
-                        sawLoading = true
-                        assertEquals(false, activity.findViewById<View>(R.id.importButton).isEnabled)
-                    }
+                    if (loading) assertEquals(false, activity.findViewById<View>(R.id.importButton).isEnabled)
                     imported = activity.findViewById<View>(R.id.editorGroup).visibility == View.VISIBLE &&
-                        !loading && sourceStore.importInProgress() == null
+                        !loading && sourceStore.importInProgress() == null &&
+                        activity.findViewById<TimelineView>(R.id.timelineView).isCameraReady &&
+                        activity.findViewById<View>(R.id.playButton).isEnabled
                 }
                 if (!imported) Thread.sleep(100)
             }
@@ -86,9 +99,9 @@ class LargeTimelineImportDeviceTest {
                 assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.editorGroup).visibility)
                 assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)
                 assertEquals(true, activity.findViewById<View>(R.id.importButton).isEnabled)
+                assertEquals(true, activity.findViewById<View>(R.id.playButton).isEnabled)
             }
         }
-        assertTrue(sawLoading)
         assertTrue(imported)
         assertEquals(null, sourceStore.importInProgress())
     }
@@ -104,9 +117,11 @@ class LargeTimelineImportDeviceTest {
                 writer.write("{\"startTime\":\"2020-01-01T00:00:00Z\",\"timelinePath\":[")
                 repeat(1_000) { offset ->
                     if (offset > 0) writer.write(','.code)
-                    val longitude = if (pointIndex % 2 == 0) 0.0 else 179.0
+                    val region = (pointIndex / 1_000) % 2
+                    val latitude = 35.0 + region * 10.0 + (pointIndex % 1_000) / 1_000_000.0
+                    val longitude = 10.0 + region * 120.0 + (pointIndex % 1_000) / 1_000_000.0
                     writer.write(
-                        "{\"point\":\"0.0,$longitude\"," +
+                        "{\"point\":\"$latitude,$longitude\"," +
                             "\"durationMinutesOffsetFromStartTime\":$pointIndex}",
                     )
                     pointIndex += 1
@@ -129,7 +144,7 @@ class LargeTimelineImportDeviceTest {
                 if (!firstSegment) writer.write(','.code)
                 firstSegment = false
                 writer.write("{\"startTime\":\"2020-01-01T00:00:00Z\",\"timelinePath\":[")
-                repeat(10) { offset ->
+                repeat(1_000) { offset ->
                     if (offset > 0) writer.write(','.code)
                     val latitude = 35.0 + (pointIndex % 100_000) / 1_000_000.0
                     val longitude = 126.0 + (pointIndex % 100_000) / 1_000_000.0
@@ -139,9 +154,7 @@ class LargeTimelineImportDeviceTest {
                     )
                     pointIndex += 1
                 }
-                writer.write("],\"testPadding\":\"")
-                repeat(3_072) { writer.write('x'.code) }
-                writer.write("\"}")
+                writer.write("]}")
                 segmentCount += 1
                 if (segmentCount % 100 == 0) {
                     writer.flush()

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -144,6 +144,8 @@ class MainActivity : AppCompatActivity() {
     private var playerPositionMs = 0L
     private var playerPlayWhenReady = true
     private var syncingBottomNavigation = false
+    private var exportingVideo = false
+    private var pendingImportCompletionUri: Uri? = null
 
     private val openTimeline = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) importTimeline(uri)
@@ -281,6 +283,7 @@ class MainActivity : AppCompatActivity() {
         makeDropdownOpenReliably(editor.durationDropdown)
         configureAdvancedSettings()
         configureLocationFiltering()
+        configureCameraPreparation()
         configureMonthDropdowns()
         configureExactDates()
         renderVideos()
@@ -300,9 +303,19 @@ class MainActivity : AppCompatActivity() {
             requestTimelineImport(incoming)
         } else when (savedInstanceState?.getString(STATE_SCREEN)) {
             Screen.NEW_VIDEO.name -> showNewVideo(loadRemembered = true)
+            Screen.VIDEOS.name -> showVideos()
             Screen.SETTINGS.name -> showSettings()
             Screen.PLAYER.name -> playerUri?.let { showVideoPlayer(it, resetPosition = false) } ?: showVideos()
-            else -> showVideos()
+            else -> showDefaultLaunchScreen()
+        }
+    }
+
+    private fun showDefaultLaunchScreen() {
+        val exportInProgress = VideoExportCoordinator.state.value.status == VideoExportStatus.RUNNING
+        if (videoStore.list().isEmpty() && !exportInProgress) {
+            showNewVideo(loadRemembered = true)
+        } else {
+            showVideos()
         }
     }
 
@@ -477,10 +490,11 @@ class MainActivity : AppCompatActivity() {
         fallback = getString(R.string.default_title),
     )
 
-    private fun importTimeline(uri: Uri, remembered: Boolean = false) {
+    internal fun importTimeline(uri: Uri, remembered: Boolean = false) {
         if (importJob?.isActive == true) return
         if (!remembered) interruptedTimelineRecovered = false
         timelineSourceStore.beginImport(uri)
+        pendingImportCompletionUri = null
         animation?.cancel()
         editor.editorGroup.visibility = View.GONE
         setTimelineLoading(true, R.string.opening_timeline)
@@ -497,18 +511,17 @@ class MainActivity : AppCompatActivity() {
                 }
                 timeline = prepared.source
                 renderTimeline = prepared.render
-                editor.timelineView.runAfterNextFrameRendered {
-                    timelineSourceStore.completeImport(uri)
-                }
+                pendingImportCompletionUri = uri
                 configureYears(loaded, prepared.initialJourney, prepared.ignoredCount)
                 editor.editorGroup.visibility = View.VISIBLE
-                editor.statusText.text = ""
+                updateCameraPreparationUi()
                 if (!remembered) rememberTimelineSource(uri)
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (error: TimelineParseException) {
                 Log.e(TAG, "Timeline import failed", error)
                 timelineSourceStore.completeImport(uri)
+                pendingImportCompletionUri = null
                 timeline = null
                 renderTimeline = null
                 if (remembered) {
@@ -523,6 +536,7 @@ class MainActivity : AppCompatActivity() {
             } catch (error: Throwable) {
                 Log.e(TAG, "Timeline import failed", error)
                 timelineSourceStore.completeImport(uri)
+                pendingImportCompletionUri = null
                 timeline = null
                 renderTimeline = null
                 if (remembered) {
@@ -543,6 +557,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun timelineParseMessage(reason: TimelineParseReason): Int = when (reason) {
         TimelineParseReason.MALFORMED_JSON -> R.string.timeline_error_malformed
+        TimelineParseReason.EMPTY_EXPORT -> R.string.timeline_error_no_locations
         TimelineParseReason.LEGACY_FORMAT -> R.string.timeline_error_legacy
         TimelineParseReason.RAW_SIGNALS_ONLY -> R.string.timeline_error_raw_only
         TimelineParseReason.NO_USABLE_LOCATIONS -> R.string.timeline_error_no_locations
@@ -632,9 +647,7 @@ class MainActivity : AppCompatActivity() {
         showProgress(0f)
         editor.videoReadyGroup.visibility = View.GONE
         editor.periodSummaryText.text = selectedPeriodSummary(selected, ignoredCount)
-        val canCreate = canCreateVideo(selected)
-        editor.playButton.isEnabled = canCreate
-        editor.exportButton.isEnabled = canCreate
+        updateCameraPreparationUi()
     }
 
     internal fun selectedPeriodSummary(selected: Journey, ignoredCount: Int = 0): String {
@@ -934,6 +947,36 @@ class MainActivity : AppCompatActivity() {
         updateLocationFilterLabel()
     }
 
+    private fun configureCameraPreparation() {
+        editor.timelineView.onCameraPreparationChanged = { ready ->
+            if (ready) {
+                editor.timelineView.runAfterNextFrameRendered {
+                    pendingImportCompletionUri?.let(timelineSourceStore::completeImport)
+                    pendingImportCompletionUri = null
+                }
+            }
+            updateCameraPreparationUi()
+        }
+        editor.timelineView.onCameraPreparationFailed = { error ->
+            Log.e(TAG, "Timeline camera preparation failed", error)
+            editor.statusText.setText(R.string.import_failed_detail)
+        }
+    }
+
+    private fun updateCameraPreparationUi() {
+        val selected = journey
+        val ready = editor.timelineView.isCameraReady
+        val canCreate = selected?.let(::canCreateVideo) == true && ready
+        editor.playButton.isEnabled = !exportingVideo && canCreate
+        editor.exportButton.isEnabled = !exportingVideo && canCreate
+        editor.timelineSeek.isEnabled = !exportingVideo && ready
+        if (selected != null && !ready && !exportingVideo) {
+            editor.statusText.setText(R.string.preparing_preview)
+        } else if (editor.statusText.text?.toString() == getString(R.string.preparing_preview)) {
+            editor.statusText.text = ""
+        }
+    }
+
     private fun updateLocationFilterLabel() {
         settingsScreen.locationFilterDropdown.setText(
             getString(
@@ -1202,7 +1245,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setExporting(exporting: Boolean) {
-        val canCreate = journey?.let(::canCreateVideo) == true
+        exportingVideo = exporting
+        val canCreate = journey?.let(::canCreateVideo) == true && editor.timelineView.isCameraReady
         editor.exportProgress.visibility = if (exporting) View.VISIBLE else View.GONE
         editor.cancelExportButton.visibility = if (exporting) View.VISIBLE else View.GONE
         home.deleteAllVideosButton.isEnabled = !exporting
@@ -1230,6 +1274,7 @@ class MainActivity : AppCompatActivity() {
         settingsScreen.videoQualityDropdown.isEnabled = !exporting
         settingsScreen.resetAdvancedSettingsButton.isEnabled = !exporting
         if (exporting) editor.videoReadyGroup.visibility = View.GONE
+        if (!exporting) updateCameraPreparationUi()
     }
 
     private fun prepareAnotherVideo() {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/LocationOutlierFilter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/LocationOutlierFilter.kt
@@ -24,7 +24,7 @@ object LocationOutlierFilter {
             return LocationFilterResult(points, 0)
         }
 
-        val kept = mutableListOf(points.first())
+        val kept = ArrayList<GeoPoint>(points.size).apply { add(points.first()) }
         var removedCount = 0
         var index = 1
         while (index < points.lastIndex) {
@@ -44,7 +44,7 @@ object LocationOutlierFilter {
     private fun suspiciousRunEnd(points: List<GeoPoint>, before: GeoPoint, start: Int): Int? {
         val latestEnd = min(start + MAX_OUTLIER_RUN_POINTS - 1, points.lastIndex - 1)
         for (end in latestEnd downTo start) {
-            if (isSuspiciousExcursion(before, points.subList(start, end + 1), points[end + 1])) {
+            if (isSuspiciousExcursion(before, points, start, end, points[end + 1])) {
                 return end
             }
         }
@@ -53,28 +53,32 @@ object LocationOutlierFilter {
 
     private fun isSuspiciousExcursion(
         before: GeoPoint,
-        candidates: List<GeoPoint>,
+        points: List<GeoPoint>,
+        start: Int,
+        end: Int,
         after: GeoPoint,
     ): Boolean {
         val window = Duration.between(before.instant, after.instant)
         if (window.isNegative || window > MAX_EXCURSION_DURATION) return false
         if (haversineKm(before, after) > MAX_REJOIN_DISTANCE_KM) return false
 
-        val first = candidates.first()
-        val last = candidates.last()
+        val first = points[start]
+        val last = points[end]
         val ingressKm = haversineKm(before, first)
         val egressKm = haversineKm(last, after)
         if (ingressKm < MIN_OUTLIER_HOP_KM || egressKm < MIN_OUTLIER_HOP_KM) return false
         if (speedKmPerHour(before, first, ingressKm) <= MAX_PLAUSIBLE_SPEED_KMH) return false
         if (speedKmPerHour(last, after, egressKm) <= MAX_PLAUSIBLE_SPEED_KMH) return false
 
-        val clusterAnchor = candidates.first()
-        if (candidates.any { haversineKm(clusterAnchor, it) > MAX_OUTLIER_CLUSTER_SPAN_KM }) return false
-        if (candidates.any {
-                haversineKm(before, it) < MIN_OUTLIER_HOP_KM ||
-                    haversineKm(it, after) < MIN_OUTLIER_HOP_KM
-            }
-        ) return false
+        val clusterAnchor = first
+        for (index in start..end) {
+            val candidate = points[index]
+            if (haversineKm(clusterAnchor, candidate) > MAX_OUTLIER_CLUSTER_SPAN_KM) return false
+            if (
+                haversineKm(before, candidate) < MIN_OUTLIER_HOP_KM ||
+                haversineKm(candidate, after) < MIN_OUTLIER_HOP_KM
+            ) return false
+        }
         return true
     }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
@@ -29,7 +29,15 @@ class TimelineParser {
         val points = mutableListOf<GeoPoint>()
         JsonReader(InputStreamReader(input, Charsets.UTF_8)).use { reader ->
             reader.isLenient = true
-            when (reader.peek()) {
+            val rootToken = try {
+                reader.peek()
+            } catch (_: EOFException) {
+                throw TimelineParseException(
+                    TimelineParseReason.EMPTY_EXPORT,
+                    "Timeline JSON is empty",
+                )
+            }
+            when (rootToken) {
                 JsonToken.BEGIN_ARRAY -> readSegments(reader, points)
                 JsonToken.BEGIN_OBJECT -> readRootObject(reader, points)
                 else -> throw TimelineParseException(
@@ -358,6 +366,7 @@ class TimelineParser {
 
 enum class TimelineParseReason {
     MALFORMED_JSON,
+    EMPTY_EXPORT,
     LEGACY_FORMAT,
     RAW_SIGNALS_ONLY,
     UNSUPPORTED_FORMAT,

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -179,7 +179,7 @@ class Mp4Exporter(
                     title,
                     renderText,
                     cameraSettings,
-                    tileRepository::cached,
+                    tiles = tileRepository::cached,
                 )
                 bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
                 argbToYuv420(pixels, yuv, width, height, encoder.colorFormat)
@@ -237,7 +237,7 @@ class Mp4Exporter(
                 title,
                 renderText,
                 cameraSettings,
-                tileRepository::cached,
+                tiles = tileRepository::cached,
             )
             onProgress(ExportProgress(1f, ExportPhase.COMPLETE, 1, 1))
             overview

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
@@ -28,6 +28,15 @@ data class GeoPoint(
 data class Timeline(
     val points: List<GeoPoint>,
 ) {
+    private val chronological = run {
+        var ordered = true
+        var index = 1
+        while (index < points.size && ordered) {
+            ordered = points[index - 1].instant <= points[index].instant
+            index += 1
+        }
+        ordered
+    }
     val years: List<Int> = points.asSequence().map { it.year }.distinct().sortedDescending().toList()
 
     fun forYear(year: Int): Journey {
@@ -46,10 +55,16 @@ data class Timeline(
 
     fun forRange(period: TimelinePeriod): Journey {
         val zone = ZoneId.systemDefault()
-        val selected = points.filter {
-            val date = it.instant.atZone(zone)
-            val month = YearMonth.of(date.year, date.monthValue)
-            month >= period.start && month <= period.endInclusive
+        val selected = if (chronological) {
+            chronologicalRange(
+                lowerMatches = { point -> yearMonth(point, zone) >= period.start },
+                upperMatches = { point -> yearMonth(point, zone) > period.endInclusive },
+            )
+        } else {
+            points.filter {
+                val month = yearMonth(it, zone)
+                month >= period.start && month <= period.endInclusive
+            }
         }
         return Journey.from(selected, period)
     }
@@ -66,9 +81,16 @@ data class Timeline(
     fun forDateRange(start: LocalDate, endInclusive: LocalDate): Journey {
         require(endInclusive >= start)
         val zone = ZoneId.systemDefault()
-        val selected = points.filter {
-            val date = it.instant.atZone(zone).toLocalDate()
-            date >= start && date <= endInclusive
+        val selected = if (chronological) {
+            chronologicalRange(
+                lowerMatches = { point -> point.instant.atZone(zone).toLocalDate() >= start },
+                upperMatches = { point -> point.instant.atZone(zone).toLocalDate() > endInclusive },
+            )
+        } else {
+            points.filter {
+                val date = it.instant.atZone(zone).toLocalDate()
+                date >= start && date <= endInclusive
+            }
         }
         return Journey.from(
             selected,
@@ -83,6 +105,29 @@ data class Timeline(
             val date = it.instant.atZone(zone).toLocalDate()
             date >= start && date <= endInclusive
         }
+    }
+
+    private fun chronologicalRange(
+        lowerMatches: (GeoPoint) -> Boolean,
+        upperMatches: (GeoPoint) -> Boolean,
+    ): List<GeoPoint> {
+        fun lowerBound(predicate: (GeoPoint) -> Boolean): Int {
+            var low = 0
+            var high = points.size
+            while (low < high) {
+                val middle = (low + high) ushr 1
+                if (predicate(points[middle])) high = middle else low = middle + 1
+            }
+            return low
+        }
+        val fromIndex = lowerBound(lowerMatches)
+        val toIndex = lowerBound(upperMatches).coerceAtLeast(fromIndex)
+        return points.subList(fromIndex, toIndex)
+    }
+
+    private fun yearMonth(point: GeoPoint, zone: ZoneId): YearMonth {
+        val date = point.instant.atZone(zone)
+        return YearMonth.of(date.year, date.monthValue)
     }
 }
 
@@ -129,6 +174,14 @@ internal data class RenderSampleLocation(
     val fraction: Double get() = step.toDouble() / steps
 }
 
+internal class MutableRenderSampleLocation(
+    var toPointIndex: Int = 0,
+    var step: Int = 0,
+    var steps: Int = 0,
+) {
+    val fraction: Double get() = step.toDouble() / steps
+}
+
 private class JourneyRenderPath(
     private val points: List<GeoPoint>,
     private val cumulativeDistanceKm: DoubleArray,
@@ -164,6 +217,12 @@ private class JourneyRenderPath(
     }
 
     fun locationAt(index: Int): RenderSampleLocation {
+        val location = MutableRenderSampleLocation()
+        fillLocationAt(index, location)
+        return RenderSampleLocation(location.toPointIndex, location.step, location.steps)
+    }
+
+    fun fillLocationAt(index: Int, location: MutableRenderSampleLocation) {
         require(index in 1 until size)
         var low = 0
         var high = segmentEnds.size
@@ -173,7 +232,9 @@ private class JourneyRenderPath(
         }
         val previousEnd = if (low == 0) 1 else segmentEnds[low - 1]
         val steps = segmentEnds[low] - previousEnd
-        return RenderSampleLocation(low + 1, index - previousEnd + 1, steps)
+        location.toPointIndex = low + 1
+        location.step = index - previousEnd + 1
+        location.steps = steps
     }
 }
 
@@ -253,6 +314,12 @@ data class Journey(
     internal fun renderSampleLocation(index: Int): RenderSampleLocation? =
         if (index == 0 || renderPath.isEmpty()) null else renderPathData.locationAt(index)
 
+    internal fun fillRenderSampleLocation(index: Int, location: MutableRenderSampleLocation): Boolean {
+        if (index == 0 || renderPath.isEmpty()) return false
+        renderPathData.fillLocationAt(index, location)
+        return true
+    }
+
     private fun calculateTransferThresholdKm(): Double {
         val candidates = DoubleArray((cumulativeDistanceKm.size - 1).coerceAtLeast(0))
         var count = 0
@@ -275,18 +342,24 @@ data class Journey(
 
     private fun buildLegs(thresholdKm: Double): List<JourneyLeg> {
         if (points.size < 2 || totalDistanceKm <= 0.0) return emptyList()
-        return buildList {
-            var localStartKm = 0.0
-            for (index in 1..points.lastIndex) {
-                val transferStartKm = cumulativeDistanceKm[index - 1]
-                val transferEndKm = cumulativeDistanceKm[index]
-                if (transferEndKm - transferStartKm < thresholdKm.coerceAtLeast(1.0)) continue
-                if (transferStartKm > localStartKm) add(JourneyLeg(localStartKm, transferStartKm, false))
-                add(JourneyLeg(transferStartKm, transferEndKm, true))
-                localStartKm = transferEndKm
-            }
-            if (totalDistanceKm > localStartKm) add(JourneyLeg(localStartKm, totalDistanceKm, false))
+        val cutoff = thresholdKm.coerceAtLeast(1.0)
+        var transferCount = 0
+        for (index in 1..points.lastIndex) {
+            if (cumulativeDistanceKm[index] - cumulativeDistanceKm[index - 1] >= cutoff) transferCount += 1
         }
+        val capacity = (transferCount.toLong() * 2L + 1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        val result = ArrayList<JourneyLeg>(capacity)
+        var localStartKm = 0.0
+        for (index in 1..points.lastIndex) {
+            val transferStartKm = cumulativeDistanceKm[index - 1]
+            val transferEndKm = cumulativeDistanceKm[index]
+            if (transferEndKm - transferStartKm < cutoff) continue
+            if (transferStartKm > localStartKm) result.add(JourneyLeg(localStartKm, transferStartKm, false))
+            result.add(JourneyLeg(transferStartKm, transferEndKm, true))
+            localStartKm = transferEndKm
+        }
+        if (totalDistanceKm > localStartKm) result.add(JourneyLeg(localStartKm, totalDistanceKm, false))
+        return result
     }
 
     companion object {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/JourneyTiming.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/JourneyTiming.kt
@@ -34,23 +34,23 @@ class JourneyTiming private constructor(
             if (compression == LongTripCompression.OFF || journey.points.size < 2) {
                 return JourneyTiming(doubleArrayOf(), doubleArrayOf(), doubleArrayOf(), journey.totalDistanceKm)
             }
-            val distances = ArrayList<Double>(journey.cumulativeDistanceKm.size)
-            val effective = ArrayList<Double>(journey.cumulativeDistanceKm.size)
-            distances += 0.0
-            effective += 0.0
+            val distances = DoubleArray(journey.cumulativeDistanceKm.size)
+            val effective = DoubleArray(journey.cumulativeDistanceKm.size)
+            var count = 1
             var effectiveTotal = 0.0
             for (index in 1..journey.cumulativeDistanceKm.lastIndex) {
                 val segmentKm = journey.cumulativeDistanceKm[index] - journey.cumulativeDistanceKm[index - 1]
                 if (segmentKm <= 0.0) continue
                 effectiveTotal += segmentKm.pow(compression.exponent)
-                distances += journey.cumulativeDistanceKm[index]
-                effective += effectiveTotal
+                distances[count] = journey.cumulativeDistanceKm[index]
+                effective[count] = effectiveTotal
+                count += 1
             }
-            if (effectiveTotal <= 0.0 || distances.size < 2) {
+            if (effectiveTotal <= 0.0 || count < 2) {
                 return JourneyTiming(doubleArrayOf(), doubleArrayOf(), doubleArrayOf(), journey.totalDistanceKm)
             }
-            val x = DoubleArray(effective.size) { effective[it] / effectiveTotal }
-            val y = distances.toDoubleArray()
+            val x = DoubleArray(count) { effective[it] / effectiveTotal }
+            val y = distances.copyOf(count)
             return JourneyTiming(x, y, monotoneSlopes(x, y), null)
         }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -10,6 +10,7 @@ import android.graphics.RectF
 import android.graphics.Shader
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.model.JourneyPosition
+import dev.mahlernim.timelinevisualizer.model.MutableRenderSampleLocation
 import dev.mahlernim.timelinevisualizer.model.WebMercator
 import dev.mahlernim.timelinevisualizer.model.WorldPoint
 import java.time.ZoneId
@@ -43,6 +44,8 @@ class TimelinePainter {
     private var cachedTimingJourney: Journey? = null
     private var cachedCompression = LongTripCompression.BALANCED
     private var cachedTiming: JourneyTiming? = null
+    internal val cameraRoutePointEvaluations: Long
+        get() = cachedPrepared?.pointEvaluations ?: 0L
     private val oldTrailPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = Color.rgb(233, 0, 100)
         style = Paint.Style.STROKE
@@ -101,8 +104,16 @@ class TimelinePainter {
         width: Int,
         height: Int,
         cameraSettings: CameraSettings = CameraSettings.DEFAULT,
+        allowCameraTrackBuild: Boolean = true,
     ): Viewport {
-        return viewport(journey, TimelineFrame(progress, 0f), width, height, cameraSettings)
+        return viewport(
+            journey,
+            TimelineFrame(progress, 0f),
+            width,
+            height,
+            cameraSettings,
+            allowCameraTrackBuild,
+        )
     }
 
     fun viewport(
@@ -111,11 +122,15 @@ class TimelinePainter {
         width: Int,
         height: Int,
         cameraSettings: CameraSettings = CameraSettings.DEFAULT,
+        allowCameraTrackBuild: Boolean = true,
     ): Viewport {
         if (width <= 0 || height <= 0) {
             return rawViewport(journey, frame.journeyProgress, width, height, cameraSettings)
         }
-        val journeyViewport = cameraTrack(journey, width, height, cameraSettings).viewportAt(frame.journeyProgress)
+        val track = cachedCameraTrack(journey, width, height, cameraSettings)
+            ?: if (allowCameraTrackBuild) cameraTrack(journey, width, height, cameraSettings) else null
+        val journeyViewport = track?.viewportAt(frame.journeyProgress)
+            ?: lightweightViewport(journey, frame.journeyProgress, width, height, cameraSettings)
         if (frame.outroProgress <= 0f) return journeyViewport
         return blendViewport(
             journeyViewport,
@@ -126,12 +141,48 @@ class TimelinePainter {
         )
     }
 
+    private fun lightweightViewport(
+        journey: Journey,
+        progress: Float,
+        width: Int,
+        height: Int,
+        cameraSettings: CameraSettings,
+    ): Viewport {
+        val current = if (progress <= 0f) {
+            journey.positionAtDistance(0.0)
+        } else {
+            playbackPosition(journey, progress, cameraSettings)
+        }
+        val movement = cameraSettings.cameraMovement
+        val proportionalContextKm = (journey.totalDistanceKm * movement.contextFraction)
+            .coerceIn(movement.minimumContextKm, movement.maximumContextKm)
+        val tail = journey.positionAtDistance(max(0.0, current.distanceKm - proportionalContextKm)).point
+        val lookahead = journey.positionAtDistance(min(journey.totalDistanceKm, current.distanceKm + proportionalContextKm)).point
+        val center = WebMercator.project(current.point)
+        val before = WebMercator.project(tail)
+        val after = WebMercator.project(lookahead)
+        val beforeX = unwrapNear(before.x, center.x)
+        val afterX = unwrapNear(after.x, center.x)
+        val contentSpanX = max(0.00015, max(center.x, max(beforeX, afterX)) - min(center.x, min(beforeX, afterX)))
+        val contentSpanY = max(0.00015, max(center.y, max(before.y, after.y)) - min(center.y, min(before.y, after.y)))
+        val aspect = width.toDouble() / height.coerceAtLeast(1)
+        val spanY = max(contentSpanY * movement.padding, contentSpanX * movement.padding / aspect)
+            .coerceIn(movement.minimumViewportSpan, MAX_VIEWPORT_SPAN)
+        val spanX = spanY * aspect
+        val minY = (center.y - spanY / 2).coerceAtLeast(0.0)
+        val maxY = (center.y + spanY / 2).coerceAtMost(1.0)
+        val zoom = floor(log2(width.coerceAtLeast(1) / (256.0 * spanX))).toInt()
+            .coerceIn(MIN_TILE_ZOOM, MAX_TILE_ZOOM)
+        return Viewport(center.x - spanX / 2, center.x + spanX / 2, minY, maxY, zoom)
+    }
+
     private fun rawViewport(
         journey: Journey,
         progress: Float,
         width: Int,
         height: Int,
         cameraSettings: CameraSettings,
+        useRangeIndex: Boolean = true,
     ): Viewport {
         val prepared = prepare(journey)
         val current = playbackPosition(journey, progress, cameraSettings)
@@ -165,8 +216,20 @@ class TimelinePainter {
         include(WebMercator.project(journey.positionAtDistance(tailDistance).point))
         val start = prepared.lowerBound(tailDistance)
         val end = prepared.upperBound(lookaheadDistance)
-        for (index in start..end) {
-            if (index in 0 until prepared.size) include(prepared.worldPointAt(index))
+        if (useRangeIndex) {
+            prepared.boundsForRange(start, end, centerX)?.let { bounds ->
+                minFocusX = min(minFocusX, bounds.minX)
+                maxFocusX = max(maxFocusX, bounds.maxX)
+                minFocusY = min(minFocusY, bounds.minY)
+                maxFocusY = max(maxFocusY, bounds.maxY)
+            }
+        } else {
+            for (index in start..end) {
+                if (index in 0 until prepared.size) {
+                    prepared.countPointEvaluation()
+                    include(prepared.worldPointAt(index))
+                }
+            }
         }
         include(WebMercator.project(journey.positionAtDistance(lookaheadDistance).point))
         val contentSpanX = max(0.00015, maxFocusX - minFocusX)
@@ -184,6 +247,15 @@ class TimelinePainter {
             .coerceIn(2, 15)
         return Viewport(minX, maxX, minY, maxY, zoom)
     }
+
+    internal fun rawViewportForTest(
+        journey: Journey,
+        progress: Float,
+        width: Int,
+        height: Int,
+        cameraSettings: CameraSettings = CameraSettings.DEFAULT,
+        useRangeIndex: Boolean,
+    ): Viewport = rawViewport(journey, progress, width, height, cameraSettings, useRangeIndex)
 
     private fun playbackPosition(
         journey: Journey,
@@ -221,21 +293,66 @@ class TimelinePainter {
         return track
     }
 
+    private fun cachedCameraTrack(
+        journey: Journey,
+        width: Int,
+        height: Int,
+        cameraSettings: CameraSettings,
+    ): CameraTrack? = cachedCameraTrack?.takeIf {
+        cachedCameraJourney === journey &&
+            cachedCameraWidth == width &&
+            cachedCameraHeight == height &&
+            cachedCameraSettings == cameraSettings
+    }
+
+    internal fun buildCameraTrackForBackground(
+        journey: Journey,
+        width: Int,
+        height: Int,
+        cameraSettings: CameraSettings,
+        onProgress: (completed: Int, total: Int) -> Unit = { _, _ -> },
+    ): CameraPreparation {
+        val track = buildCameraTrack(journey, width, height, cameraSettings, onProgress)
+        return CameraPreparation(track, prepare(journey))
+    }
+
+    internal fun installCameraPreparation(
+        journey: Journey,
+        width: Int,
+        height: Int,
+        cameraSettings: CameraSettings,
+        preparation: CameraPreparation,
+    ) {
+        cachedJourney = journey
+        cachedPrepared = preparation.prepared
+        cachedCameraJourney = journey
+        cachedCameraWidth = width
+        cachedCameraHeight = height
+        cachedCameraSettings = cameraSettings
+        cachedCameraTrack = preparation.track
+    }
+
     private fun buildCameraTrack(
         journey: Journey,
         width: Int,
         height: Int,
         cameraSettings: CameraSettings,
+        onProgress: (completed: Int, total: Int) -> Unit = { _, _ -> },
     ): CameraTrack {
         val aspect = width.toDouble() / height.coerceAtLeast(1)
         val movement = cameraSettings.cameraMovement
         val rawSamples = (0..CAMERA_TRACK_SAMPLES).map { sample ->
             val progress = sample.toFloat() / CAMERA_TRACK_SAMPLES
             val raw = rawViewport(journey, progress, width, height, cameraSettings)
-            RawCameraSample(
+            val result = RawCameraSample(
                 viewport = raw,
                 marker = WebMercator.project(playbackPosition(journey, progress, cameraSettings).point),
             )
+            val completed = sample + 1
+            if (sample == 0 || completed % CAMERA_PROGRESS_INTERVAL == 0 || sample == CAMERA_TRACK_SAMPLES) {
+                onProgress(completed, CAMERA_TRACK_SAMPLES + 1)
+            }
+            result
         }
         val fixedSpanY = if (movement.fixedZoom) {
             val spans = rawSamples.map { it.viewport.maxY - it.viewport.minY }.sorted()
@@ -444,6 +561,7 @@ class TimelinePainter {
         progress: Float,
         title: String,
         cameraSettings: CameraSettings = CameraSettings.DEFAULT,
+        allowCameraTrackBuild: Boolean = true,
         tiles: (TileId) -> Bitmap?,
     ) {
         draw(
@@ -456,6 +574,7 @@ class TimelinePainter {
             title,
             RenderText.ENGLISH,
             cameraSettings,
+            allowCameraTrackBuild,
             tiles,
         )
     }
@@ -470,36 +589,48 @@ class TimelinePainter {
         title: String,
         renderText: RenderText = RenderText.ENGLISH,
         cameraSettings: CameraSettings = CameraSettings.DEFAULT,
+        allowCameraTrackBuild: Boolean = true,
         tiles: (TileId) -> Bitmap?,
     ) {
         if (journey.points.isEmpty() || width <= 0 || height <= 0) return
-        val viewport = viewport(journey, frame, width, height, cameraSettings)
-        val prepared = prepare(journey)
+        val viewport = viewport(journey, frame, width, height, cameraSettings, allowCameraTrackBuild)
+        val prepared = if (allowCameraTrackBuild) prepare(journey) else null
         drawBackground(canvas, width, height)
         drawTiles(canvas, width, height, viewport, tiles)
 
-        val current = playbackPosition(journey, frame.journeyProgress, cameraSettings)
-        val currentScreen = screenPoint(current, prepared, viewport, width, height)
+        val current = if (!allowCameraTrackBuild && frame.journeyProgress <= 0f) {
+            journey.positionAtDistance(0.0)
+        } else {
+            playbackPosition(journey, frame.journeyProgress, cameraSettings)
+        }
+        val currentScreen = if (prepared == null) {
+            val projected = WebMercator.project(current.point)
+            worldToScreen(projected, viewport, width, height)
+        } else {
+            screenPoint(current, prepared, viewport, width, height)
+        }
         val trailWindow = trailWindowDistance(journey, journeyDurationSeconds)
         val trailStart = max(0.0, current.distanceKm - trailWindow)
         val visibleTrail = current.distanceKm - trailStart
         val oldEnd = trailStart + visibleTrail * 0.45
         val middleEnd = trailStart + visibleTrail * 0.75
         val activeAlpha = (255 * (1f - easeOutCubic(frame.outroProgress))).toInt().coerceIn(0, 255)
-        drawRouteRange(
-            canvas, journey, prepared, viewport, width, height,
-            trailStart, min(oldEnd, current.distanceKm), oldTrailPaint, activeAlpha,
-        )
-        drawRouteRange(
-            canvas, journey, prepared, viewport, width, height,
-            min(oldEnd, current.distanceKm), min(middleEnd, current.distanceKm), middleTrailPaint, activeAlpha,
-        )
-        drawRouteRange(
-            canvas, journey, prepared, viewport, width, height,
-            min(middleEnd, current.distanceKm), current.distanceKm, recentTrailPaint, activeAlpha,
-        )
+        if (prepared != null) {
+            drawRouteRange(
+                canvas, journey, prepared, viewport, width, height,
+                trailStart, min(oldEnd, current.distanceKm), oldTrailPaint, activeAlpha,
+            )
+            drawRouteRange(
+                canvas, journey, prepared, viewport, width, height,
+                min(oldEnd, current.distanceKm), min(middleEnd, current.distanceKm), middleTrailPaint, activeAlpha,
+            )
+            drawRouteRange(
+                canvas, journey, prepared, viewport, width, height,
+                min(middleEnd, current.distanceKm), current.distanceKm, recentTrailPaint, activeAlpha,
+            )
+        }
 
-        if (frame.outroProgress > 0f) {
+        if (frame.outroProgress > 0f && prepared != null) {
             overviewCompositePaint.alpha = (OVERVIEW_ROUTE_ALPHA * easeInOutCubic(frame.outroProgress))
                 .toInt()
                 .coerceIn(0, 255)
@@ -685,13 +816,18 @@ class TimelinePainter {
         return result
     }
 
-    private class PreparedJourney(private val journey: Journey) {
+    internal class PreparedJourney(private val journey: Journey) {
         private val unwrappedPointX = DoubleArray(journey.points.size)
+        private val pointY = DoubleArray(journey.points.size)
+        private val blockBounds = mutableMapOf<Int, RouteBounds>()
+        var pointEvaluations: Long = 0L
+            private set
         val size: Int get() = journey.renderPath.size
 
         init {
             for (index in journey.points.indices) {
                 val projected = WebMercator.project(journey.points[index])
+                pointY[index] = projected.y
                 unwrappedPointX[index] = if (index == 0) projected.x else {
                     unwrap(projected.x, unwrappedPointX[index - 1])
                 }
@@ -699,17 +835,111 @@ class TimelinePainter {
         }
 
         fun worldPointAt(index: Int): WorldPoint {
-            val sample = journey.renderPath[index]
-            val projected = WebMercator.project(sample.point)
-            val location = journey.renderSampleLocation(index)
-            val reference = if (location == null) {
-                unwrappedPointX.firstOrNull() ?: 0.5
-            } else {
-                val from = location.toPointIndex - 1
-                unwrappedPointX[from] +
-                    (unwrappedPointX[location.toPointIndex] - unwrappedPointX[from]) * location.fraction
+            val point = MutableWorldPoint()
+            fillWorldPoint(index, point)
+            return WorldPoint(point.x, point.y)
+        }
+
+        private fun fillWorldPoint(index: Int, point: MutableWorldPoint) {
+            val location = point.location
+            if (!journey.fillRenderSampleLocation(index, location)) {
+                point.x = unwrappedPointX.firstOrNull() ?: 0.5
+                point.y = pointY.firstOrNull() ?: 0.5
+                return
             }
-            return WorldPoint(unwrap(projected.x, reference), projected.y)
+            if (location.step == location.steps) {
+                point.x = unwrappedPointX[location.toPointIndex]
+                point.y = pointY[location.toPointIndex]
+                return
+            }
+            val from = location.toPointIndex - 1
+            val interpolated = Journey.interpolate(
+                journey.points[from],
+                journey.points[location.toPointIndex],
+                location.fraction,
+            )
+            val projected = WebMercator.project(interpolated)
+            val reference = unwrappedPointX[from] +
+                (unwrappedPointX[location.toPointIndex] - unwrappedPointX[from]) * location.fraction
+            point.x = unwrap(projected.x, reference)
+            point.y = projected.y
+        }
+
+        fun countPointEvaluation() {
+            pointEvaluations += 1
+        }
+
+        fun boundsForRange(firstIndex: Int, lastIndex: Int, referenceX: Double): RouteBounds? {
+            if (size == 0) return null
+            val first = firstIndex.coerceIn(0, size - 1)
+            val last = lastIndex.coerceIn(-1, size - 1)
+            if (first > last) return null
+
+            val result = MutableRouteBounds()
+            val point = MutableWorldPoint()
+            var index = first
+            while (index <= last && index % ROUTE_BOUNDS_BLOCK_SIZE != 0) {
+                includePoint(result, point, index, referenceX)
+                index += 1
+            }
+            while (index + ROUTE_BOUNDS_BLOCK_SIZE - 1 <= last) {
+                val block = index / ROUTE_BOUNDS_BLOCK_SIZE
+                val bounds = blockBounds.getOrPut(block) {
+                    calculateBlockBounds(index, index + ROUTE_BOUNDS_BLOCK_SIZE - 1)
+                }
+                val adjustedMinX = unwrap(bounds.minX, referenceX)
+                val adjustedMaxX = unwrap(bounds.maxX, referenceX)
+                val minShift = adjustedMinX - bounds.minX
+                val maxShift = adjustedMaxX - bounds.maxX
+                if (minShift == maxShift) {
+                    val adjusted = RouteBounds(
+                        minX = adjustedMinX,
+                        maxX = adjustedMaxX,
+                        minY = bounds.minY,
+                        maxY = bounds.maxY,
+                    )
+                    result.include(adjusted)
+                } else {
+                    for (pointIndex in index until index + ROUTE_BOUNDS_BLOCK_SIZE) {
+                        includePoint(result, point, pointIndex, referenceX)
+                    }
+                }
+                index += ROUTE_BOUNDS_BLOCK_SIZE
+            }
+            while (index <= last) {
+                includePoint(result, point, index, referenceX)
+                index += 1
+            }
+            return result.toRouteBounds()
+        }
+
+        private fun calculateBlockBounds(firstIndex: Int, lastIndex: Int): RouteBounds {
+            val point = MutableWorldPoint()
+            evaluatedWorldPoint(firstIndex, point)
+            val firstX = point.x
+            val firstY = point.y
+            val result = MutableRouteBounds().apply { include(firstX, firstY) }
+            for (index in firstIndex + 1..lastIndex) {
+                evaluatedWorldPoint(index, point)
+                result.include(point.x, point.y)
+            }
+            return result.toRouteBounds()
+        }
+
+        private fun includePoint(
+            bounds: MutableRouteBounds,
+            point: MutableWorldPoint,
+            index: Int,
+            referenceX: Double,
+        ) {
+            evaluatedWorldPoint(index, point)
+            val x = unwrap(point.x, referenceX)
+            bounds.include(x, point.y)
+        }
+
+        private fun evaluatedWorldPoint(index: Int, point: MutableWorldPoint) {
+            pointEvaluations += 1
+            fillWorldPoint(index, point)
         }
 
         private fun distanceAt(index: Int): Double = journey.renderPath[index].distanceKm
@@ -755,7 +985,7 @@ class TimelinePainter {
         }
     }
 
-    private data class CameraFrame(
+    internal data class CameraFrame(
         val centerX: Double,
         val centerY: Double,
         val spanY: Double,
@@ -767,9 +997,52 @@ class TimelinePainter {
         val marker: WorldPoint,
     )
 
-    private data class CameraTrack(
-        val frames: List<CameraFrame>,
-        val aspect: Double,
+    internal data class RouteBounds(
+        val minX: Double,
+        val maxX: Double,
+        val minY: Double,
+        val maxY: Double,
+    )
+
+    private class MutableRouteBounds {
+        private var initialized = false
+        private var minX = 0.0
+        private var maxX = 0.0
+        private var minY = 0.0
+        private var maxY = 0.0
+
+        fun include(x: Double, y: Double) {
+            if (!initialized) {
+                initialized = true
+                minX = x
+                maxX = x
+                minY = y
+                maxY = y
+                return
+            }
+            minX = min(minX, x)
+            maxX = max(maxX, x)
+            minY = min(minY, y)
+            maxY = max(maxY, y)
+        }
+
+        fun include(bounds: RouteBounds) {
+            include(bounds.minX, bounds.minY)
+            include(bounds.maxX, bounds.maxY)
+        }
+
+        fun toRouteBounds(): RouteBounds = RouteBounds(minX, maxX, minY, maxY)
+    }
+
+    private class MutableWorldPoint(
+        var x: Double = 0.0,
+        var y: Double = 0.0,
+        val location: MutableRenderSampleLocation = MutableRenderSampleLocation(),
+    )
+
+    internal class CameraTrack(
+        private val frames: List<CameraFrame>,
+        private val aspect: Double,
     ) {
         fun viewportAt(progress: Float): Viewport {
             if (frames.size == 1) return frames.first().toViewport(aspect)
@@ -795,6 +1068,11 @@ class TimelinePainter {
         }
     }
 
+    internal data class CameraPreparation(
+        val track: CameraTrack,
+        val prepared: PreparedJourney,
+    )
+
     companion object {
         private const val TRANSFER_PADDING = 2.8
         private const val DEFAULT_JOURNEY_DURATION_SECONDS = 30
@@ -809,6 +1087,8 @@ class TimelinePainter {
         private const val OVERVIEW_HEADER_GAP = 20f
         private const val OVERVIEW_BOTTOM_INSET = 34f
         private const val CAMERA_TRACK_SAMPLES = 480
+        private const val CAMERA_PROGRESS_INTERVAL = 32
+        private const val ROUTE_BOUNDS_BLOCK_SIZE = 256
         private const val CAMERA_DEAD_ZONE_HALF = 0.20
         private const val FIXED_ZOOM_PERCENTILE = 0.80
         private const val TILE_ZOOM_HYSTERESIS = 0.15

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineView.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineView.kt
@@ -14,10 +14,13 @@ import dev.mahlernim.timelinevisualizer.render.TimelinePainter
 import dev.mahlernim.timelinevisualizer.render.RenderText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 
 class TimelineView @JvmOverloads constructor(
@@ -32,12 +35,20 @@ class TimelineView @JvmOverloads constructor(
     private var frameCanvas: Canvas? = null
     private var frameDirty = true
     private var redrawPosted = false
-    private var afterNextFrameRendered: (() -> Unit)? = null
+    private val afterNextFrameRendered = mutableListOf<() -> Unit>()
+    private var cameraPreparationJob: Job? = null
+    private var cameraPreparationGeneration = 0
+
+    var onCameraPreparationChanged: ((ready: Boolean) -> Unit)? = null
+    var onCameraPreparationFailed: ((error: Throwable) -> Unit)? = null
+    var isCameraReady: Boolean = false
+        private set
 
     var journey: Journey? = null
         set(value) {
             field = value
             markFrameDirty()
+            restartCameraPreparation()
         }
     var progress: Float = 0f
         set(value) {
@@ -70,6 +81,7 @@ class TimelineView @JvmOverloads constructor(
             if (field == value) return
             field = value
             markFrameDirty()
+            restartCameraPreparation()
         }
 
     override fun onAttachedToWindow() {
@@ -78,10 +90,12 @@ class TimelineView @JvmOverloads constructor(
             scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
         }
         if (frame == null && width > 0 && height > 0) allocateFrame(width, height)
+        restartCameraPreparation()
     }
 
     override fun onDetachedFromWindow() {
         scope.cancel()
+        cameraPreparationJob = null
         frame?.recycle()
         frame = null
         frameCanvas = null
@@ -91,6 +105,7 @@ class TimelineView @JvmOverloads constructor(
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         allocateFrame(w, h)
         frameDirty = true
+        if (w != oldw || h != oldh) restartCameraPreparation()
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -112,10 +127,24 @@ class TimelineView @JvmOverloads constructor(
         }
         val animationFrame = TimelineAnimation.frameAtOverallProgress(progress, journeyDurationSeconds)
         val tilesToLoad = buildSet {
-            listOf(progress, (progress + 0.015f).coerceAtMost(1f), (progress + 0.03f).coerceAtMost(1f)).forEach {
+            val tileProgress = if (isCameraReady) {
+                listOf(progress, (progress + 0.015f).coerceAtMost(1f), (progress + 0.03f).coerceAtMost(1f))
+            } else {
+                listOf(progress)
+            }
+            tileProgress.forEach {
                 val lookahead = TimelineAnimation.frameAtOverallProgress(it, journeyDurationSeconds)
                 addAll(
-                    painter.requiredTiles(painter.viewport(data, lookahead, width, height, cameraSettings))
+                    painter.requiredTiles(
+                        painter.viewport(
+                            data,
+                            lookahead,
+                            width,
+                            height,
+                            cameraSettings,
+                            allowCameraTrackBuild = isCameraReady,
+                        ),
+                    )
                         .map { tile -> tile.id },
                 )
             }
@@ -141,7 +170,8 @@ class TimelineView @JvmOverloads constructor(
             videoTitle,
             renderText,
             cameraSettings,
-            tiles::cached,
+            allowCameraTrackBuild = isCameraReady,
+            tiles = tiles::cached,
         )
         frameDirty = false
         canvas.drawBitmap(target, 0f, 0f, null)
@@ -149,8 +179,57 @@ class TimelineView @JvmOverloads constructor(
     }
 
     fun runAfterNextFrameRendered(action: () -> Unit) {
-        afterNextFrameRendered = action
+        afterNextFrameRendered += action
         markFrameDirty()
+    }
+
+    private fun restartCameraPreparation() {
+        cameraPreparationJob?.cancel()
+        cameraPreparationGeneration += 1
+        val generation = cameraPreparationGeneration
+        val data = journey
+        val targetWidth = width
+        val targetHeight = height
+        val settings = cameraSettings
+        if (data == null || data.points.isEmpty()) {
+            setCameraReady(data != null)
+            return
+        }
+        setCameraReady(false)
+        if (targetWidth <= 0 || targetHeight <= 0 || !isAttachedToWindow) return
+
+        cameraPreparationJob = scope.launch(Dispatchers.Default) {
+            try {
+                val preparation = TimelinePainter().buildCameraTrackForBackground(
+                    data,
+                    targetWidth,
+                    targetHeight,
+                    settings,
+                ) { _, _ ->
+                    coroutineContext.ensureActive()
+                }
+                withContext(Dispatchers.Main.immediate) {
+                    if (generation != cameraPreparationGeneration || journey !== data || cameraSettings != settings) {
+                        return@withContext
+                    }
+                    painter.installCameraPreparation(data, targetWidth, targetHeight, settings, preparation)
+                    setCameraReady(true)
+                    markFrameDirty()
+                }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                withContext(Dispatchers.Main.immediate) {
+                    if (generation == cameraPreparationGeneration) onCameraPreparationFailed?.invoke(error)
+                }
+            }
+        }
+    }
+
+    private fun setCameraReady(ready: Boolean) {
+        if (isCameraReady == ready) return
+        isCameraReady = ready
+        onCameraPreparationChanged?.invoke(ready)
     }
 
     private fun allocateFrame(width: Int, height: Int) {
@@ -175,8 +254,9 @@ class TimelineView @JvmOverloads constructor(
     }
 
     private fun notifyFrameRendered() {
-        val action = afterNextFrameRendered ?: return
-        afterNextFrameRendered = null
-        post(action)
+        if (afterNextFrameRendered.isEmpty()) return
+        val actions = afterNextFrameRendered.toList()
+        afterNextFrameRendered.clear()
+        actions.forEach { action -> post { action() } }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -26,7 +26,7 @@
     <string name="timeline_error_malformed">Diese Datei enthält kein gültiges oder vollständiges JSON.</string>
     <string name="timeline_error_legacy">Dies ist ein älteres Google Takeout-Format. Exportieren Sie die Timeline-Daten stattdessen vom Telefon.</string>
     <string name="timeline_error_raw_only">Dieser Export enthält Rohsignale, aber keine rekonstruierten Timeline-Reisen.</string>
-    <string name="timeline_error_no_locations">Dieser Timeline-Export enthält keine verwendbaren Standortpunkte.</string>
+    <string name="timeline_error_no_locations">Dieser Timeline-Export enthält keine Standortdaten. Timeline war möglicherweise nicht aktiviert, sodass Google keine Daten exportieren konnte.</string>
     <string name="remembered_timeline_unavailable">Der bisher verwendete Timeline ist nicht mehr verfügbar.</string>
     <string name="choose_timeline_again">Wählen Sie erneut die Datei Timeline.json.</string>
     <string name="video_export_failed">Video konnte nicht erstellt werden</string>
@@ -211,6 +211,7 @@
     <string name="location_filter_summary">Die vorsichtige Filterung ignoriert nur kurze, unmögliche Hin- und Rückwege. Ihre Timeline-Datei wird nicht verändert.</string>
     <string name="location_filter_conservative">Vorsichtig</string>
     <string name="location_filter_off">Aus</string>
+    <string name="preparing_preview">Vorschau wird vorbereitet…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="one">%1$d verdächtiger Standort ignoriert</item>
         <item quantity="other">%1$d verdächtige Standorte ignoriert</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -26,7 +26,7 @@
     <string name="timeline_error_malformed">Este archivo no es un JSON válido o completo.</string>
     <string name="timeline_error_legacy">Este es un formato antiguo de Google Takeout. Exporte los datos de Timeline desde su teléfono.</string>
     <string name="timeline_error_raw_only">Esta exportación contiene señales sin procesar, pero no viajes reconstruidos de Timeline.</string>
-    <string name="timeline_error_no_locations">Esta exportación de Timeline no contiene puntos de ubicación utilizables.</string>
+    <string name="timeline_error_no_locations">Esta exportación de Timeline no contiene datos de ubicación. Es posible que Timeline no estuviera activado y que Google no tuviera datos para exportar.</string>
     <string name="remembered_timeline_unavailable">El modelo Timeline usado anteriormente ya no está disponible.</string>
     <string name="choose_timeline_again">Elija el archivo Timeline.json nuevamente.</string>
     <string name="video_export_failed">No se pudo crear el vídeo</string>
@@ -215,6 +215,7 @@
     <string name="location_filter_summary">El filtro conservador solo ignora viajes de ida y vuelta breves e imposibles. El archivo de Timeline no se modifica.</string>
     <string name="location_filter_conservative">Conservador</string>
     <string name="location_filter_off">Desactivado</string>
+    <string name="preparing_preview">Preparando la vista previa…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="one">Se ignoró %1$d ubicación sospechosa</item>
         <item quantity="many">Se ignoraron %1$d ubicaciones sospechosas</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -26,7 +26,7 @@
     <string name="timeline_error_malformed">Ce fichier ne contient pas de JSON valide ou complet.</string>
     <string name="timeline_error_legacy">Il s\'agit d\'un ancien format Google Takeout. Exportez les données Timeline depuis votre téléphone.</string>
     <string name="timeline_error_raw_only">Cette exportation contient des signaux bruts, mais aucun trajet Timeline reconstruit.</string>
-    <string name="timeline_error_no_locations">Cette exportation Timeline ne contient aucun point de localisation utilisable.</string>
+    <string name="timeline_error_no_locations">Cette exportation Timeline ne contient aucune donnée de localisation. Timeline n’était peut-être pas activé, donc Google n’avait aucune donnée à exporter.</string>
     <string name="remembered_timeline_unavailable">Le Timeline précédemment utilisé n’est plus disponible.</string>
     <string name="choose_timeline_again">Choisissez à nouveau le fichier Timeline.json.</string>
     <string name="video_export_failed">Impossible de créer une vidéo</string>
@@ -215,6 +215,7 @@
     <string name="location_filter_summary">Le filtrage prudent ignore uniquement les courts allers-retours impossibles. Votre fichier Timeline n\'est jamais modifié.</string>
     <string name="location_filter_conservative">Prudent</string>
     <string name="location_filter_off">Désactivé</string>
+    <string name="preparing_preview">Préparation de l’aperçu…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="one">%1$d position suspecte ignorée</item>
         <item quantity="many">%1$d positions suspectes ignorées</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -25,7 +25,7 @@
     <string name="timeline_error_malformed">有効または完全な JSON ファイルではありません。</string>
     <string name="timeline_error_legacy">以前の Google Takeout 形式です。端末からタイムライン データを書き出してください。</string>
     <string name="timeline_error_raw_only">この書き出しには生の信号だけがあり、再構成された移動経路がありません。</string>
-    <string name="timeline_error_no_locations">このタイムラインの書き出しには使用できる位置情報がありません。</string>
+    <string name="timeline_error_no_locations">このタイムラインの書き出しには位置情報がありません。タイムラインが有効になっていなかったため、Google に書き出すデータがなかった可能性があります。</string>
     <string name="remembered_timeline_unavailable">前回使用したタイムラインを開けなくなりました。</string>
     <string name="choose_timeline_again">Timeline.jsonをもう一度選択してください。</string>
     <string name="video_export_failed">動画を作成できませんでした</string>
@@ -207,6 +207,7 @@
     <string name="location_filter_summary">慎重なフィルターで、短時間では不可能な往復移動だけを無視します。タイムライン ファイルは変更されません。</string>
     <string name="location_filter_conservative">慎重</string>
     <string name="location_filter_off">オフ</string>
+    <string name="preparing_preview">プレビューを準備しています…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="other">疑わしい位置情報を%1$d件無視しました</item>
     </plurals>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -25,7 +25,7 @@
     <string name="timeline_error_malformed">올바르거나 완전한 JSON 파일이 아닙니다.</string>
     <string name="timeline_error_legacy">이 파일은 이전 Google 테이크아웃 형식입니다. 휴대전화에서 타임라인 데이터를 내보내 주세요.</string>
     <string name="timeline_error_raw_only">이 내보내기에는 원시 신호만 있고 재구성된 타임라인 이동 경로가 없습니다.</string>
-    <string name="timeline_error_no_locations">이 타임라인 내보내기에는 사용할 수 있는 위치 지점이 없습니다.</string>
+    <string name="timeline_error_no_locations">이 타임라인 내보내기에는 위치 데이터가 없습니다. 타임라인이 활성화되지 않아 Google에서 내보낼 데이터가 없었을 수 있습니다.</string>
     <string name="remembered_timeline_unavailable">이전에 사용한 타임라인 파일을 더 이상 열 수 없습니다.</string>
     <string name="choose_timeline_again">Timeline.json 파일을 다시 선택해 주세요.</string>
     <string name="video_export_failed">영상을 만들지 못했습니다</string>
@@ -207,6 +207,7 @@
     <string name="location_filter_summary">보수적 필터링은 짧고 불가능한 왕복 이동만 무시합니다. 타임라인 파일은 변경되지 않습니다.</string>
     <string name="location_filter_conservative">보수적</string>
     <string name="location_filter_off">끄기</string>
+    <string name="preparing_preview">미리보기 준비 중…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="other">의심스러운 위치 %1$d개를 무시함</item>
     </plurals>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -26,7 +26,7 @@
     <string name="timeline_error_malformed">Este arquivo não contém um JSON válido ou completo.</string>
     <string name="timeline_error_legacy">Este é um formato antigo do Google Takeout. Exporte os dados do Timeline pelo telefone.</string>
     <string name="timeline_error_raw_only">Esta exportação contém sinais brutos, mas não contém viagens reconstruídas do Timeline.</string>
-    <string name="timeline_error_no_locations">Esta exportação do Timeline não contém pontos de localização utilizáveis.</string>
+    <string name="timeline_error_no_locations">Esta exportação do Timeline não contém dados de localização. Talvez o Timeline não estivesse ativado e o Google não tivesse dados para exportar.</string>
     <string name="remembered_timeline_unavailable">O Timeline usado anteriormente não está mais disponível.</string>
     <string name="choose_timeline_again">Escolha o arquivo Timeline.json novamente.</string>
     <string name="video_export_failed">Não foi possível criar o vídeo</string>
@@ -215,6 +215,7 @@
     <string name="location_filter_summary">O filtro conservador ignora apenas viagens curtas de ida e volta impossíveis. O arquivo da Timeline nunca é alterado.</string>
     <string name="location_filter_conservative">Conservador</string>
     <string name="location_filter_off">Desativado</string>
+    <string name="preparing_preview">Preparando visualização…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="one">%1$d local suspeito ignorado</item>
         <item quantity="many">%1$d locais suspeitos ignorados</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -26,7 +26,7 @@
     <string name="timeline_error_malformed">此文件不是有效或完整的 JSON。</string>
     <string name="timeline_error_legacy">这是旧版 Google Takeout 格式。请改为从手机导出 Timeline 数据。</string>
     <string name="timeline_error_raw_only">此导出仅包含原始信号，没有重建的 Timeline 行程。</string>
-    <string name="timeline_error_no_locations">此 Timeline 导出不包含可用的位置点。</string>
+    <string name="timeline_error_no_locations">此 Timeline 导出不包含位置数据。Timeline 可能未启用，因此 Google 没有可导出的数据。</string>
     <string name="remembered_timeline_unavailable">之前使用的Timeline不再可用。</string>
     <string name="choose_timeline_again">再次选择 Timeline.json 文件。</string>
     <string name="video_export_failed">无法创建视频</string>
@@ -208,6 +208,7 @@
     <string name="location_filter_summary">保守过滤仅忽略短时间内不可能的往返移动。不会更改您的时间轴文件。</string>
     <string name="location_filter_conservative">保守</string>
     <string name="location_filter_off">关闭</string>
+    <string name="preparing_preview">正在准备预览…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="other">已忽略%1$d个可疑位置</item>
     </plurals>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -26,7 +26,7 @@
     <string name="timeline_error_malformed">此檔案不是有效或完整的 JSON。</string>
     <string name="timeline_error_legacy">這是舊版 Google Takeout 格式。請改為從手機匯出 Timeline 資料。</string>
     <string name="timeline_error_raw_only">此匯出僅包含原始訊號，沒有重建的 Timeline 行程。</string>
-    <string name="timeline_error_no_locations">此 Timeline 匯出不包含可用的位置點。</string>
+    <string name="timeline_error_no_locations">此 Timeline 匯出不包含位置資料。Timeline 可能未啟用，因此 Google 沒有可匯出的資料。</string>
     <string name="remembered_timeline_unavailable">之前使用的Timeline不再可用。</string>
     <string name="choose_timeline_again">再次選擇 Timeline.json 檔案。</string>
     <string name="video_export_failed">無法創建視頻</string>
@@ -208,6 +208,7 @@
     <string name="location_filter_summary">保守篩選只會忽略短時間內不可能的往返移動，不會變更您的時間軸檔案。</string>
     <string name="location_filter_conservative">保守</string>
     <string name="location_filter_off">關閉</string>
+    <string name="preparing_preview">正在準備預覽…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="other">已忽略%1$d個可疑位置</item>
     </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="timeline_error_malformed">This file is not valid or complete JSON.</string>
     <string name="timeline_error_legacy">This is an older Google Takeout format. Export Timeline data from your phone instead.</string>
     <string name="timeline_error_raw_only">This export contains raw signals but no reconstructed Timeline journeys.</string>
-    <string name="timeline_error_no_locations">This Timeline export contains no usable location points.</string>
+    <string name="timeline_error_no_locations">This Timeline export contains no location data. Timeline may not have been enabled, so Google had no data to export.</string>
     <string name="remembered_timeline_unavailable">The previously used Timeline is no longer available.</string>
     <string name="choose_timeline_again">Choose the Timeline.json file again.</string>
     <string name="video_export_failed">Could not create video</string>
@@ -217,6 +217,7 @@
     <string name="location_filter_summary">Conservative filtering ignores only short, impossible round trips. Your Timeline file is never changed.</string>
     <string name="location_filter_conservative">Conservative</string>
     <string name="location_filter_off">Off</string>
+    <string name="preparing_preview">Preparing preview…</string>
     <plurals name="location_outliers_ignored">
         <item quantity="one">%1$d suspicious location ignored</item>
         <item quantity="other">%1$d suspicious locations ignored</item>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -128,6 +128,23 @@ class MainActivityTest {
     }
 
     @Test
+    fun emptyTimelineExplainsThatTimelineMayNotHaveBeenEnabled() {
+        acceptPrivacyDisclosure()
+        val empty = File.createTempFile("empty-timeline", ".json", context.cacheDir)
+        try {
+            val activity = launchActivity(Intent(Intent.ACTION_VIEW, Uri.fromFile(empty)))
+            waitUntil { activity.findViewById<View>(R.id.loadingGroup).visibility == View.GONE }
+
+            assertEquals(
+                activity.getString(R.string.timeline_error_no_locations),
+                activity.findViewById<TextView>(R.id.statusText).text.toString(),
+            )
+        } finally {
+            empty.delete()
+        }
+    }
+
+    @Test
     fun privacyPolicyOpensPublicEnglishPolicy() {
         val activity = launchActivity()
         activity.findViewById<View>(R.id.privacyPolicyButton).performClick()
@@ -353,8 +370,6 @@ class MainActivityTest {
         acceptPrivacyDisclosure()
 
         val activity = launchActivity()
-        assertEquals(missing, timelineSourceStore.load())
-        activity.findViewById<View>(R.id.navigationCreate).performClick()
         waitUntil { timelineSourceStore.load() == null }
 
         assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)
@@ -421,16 +436,67 @@ class MainActivityTest {
     fun compactBrazilianPortugueseButtonsRemainSingleLine() = assertCompactButtons()
 
     @Test
-    fun normalLaunchOpensVideosAndDefersRememberedTimeline() {
-        val remembered = Uri.fromFile(File(context.cacheDir, "missing-deferred.json"))
-        assertTrue(timelineSourceStore.replace(remembered))
-        acceptPrivacyDisclosure()
+    fun normalLaunchOpensCreateVideoWhenLibraryIsEmpty() {
+        val activity = launchActivity()
+
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.videosScreen).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.newVideoScreen).visibility)
+        assertEquals(R.id.navigationCreate, activity.findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(R.id.bottomNavigation).selectedItemId)
+    }
+
+    @Test
+    fun normalLaunchOpensVideosWhenLibraryIsNotEmpty() {
+        store.upsert(
+            VideoRecord(
+                uri = "content://example/video",
+                title = "Trip",
+                fileName = "trip.mp4",
+                createdAtMillis = 1L,
+                durationSeconds = 30,
+            ),
+        )
 
         val activity = launchActivity()
 
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
         assertEquals(View.GONE, activity.findViewById<View>(R.id.newVideoScreen).visibility)
-        assertEquals(remembered, timelineSourceStore.load())
+    }
+
+    @Test
+    fun runningExportOpensVideosWhenLibraryIsEmpty() {
+        VideoExportStateStore(context).save(
+            VideoExportSnapshot(status = VideoExportStatus.RUNNING, startedAtMillis = 123L),
+        )
+
+        val activity = launchActivity()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.homeExportGroup).visibility)
+    }
+
+    @Test
+    fun recreatedActivityRestoresVideosInsteadOfReapplyingEmptyLibraryRule() {
+        val activity = launchActivity()
+        activity.findViewById<View>(R.id.navigationVideos).performClick()
+
+        controller.recreate()
+        val recreated = controller.get()
+
+        assertEquals(View.VISIBLE, recreated.findViewById<View>(R.id.videosScreen).visibility)
+        assertEquals(View.GONE, recreated.findViewById<View>(R.id.newVideoScreen).visibility)
+    }
+
+    @Test
+    fun emptyVideosRemainsReachableAndBackFromAutomaticCreateDoesNotLoop() {
+        val activity = launchActivity()
+
+        activity.onBackPressedDispatcher.onBackPressed()
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
+
+        activity.findViewById<View>(R.id.navigationCreate).performClick()
+        activity.onBackPressedDispatcher.onBackPressed()
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
     }
 
     @Test
@@ -586,8 +652,10 @@ class MainActivityTest {
 
         val activity = launchActivity(Intent(Intent.ACTION_VIEW, explicit))
         waitUntil { activity.findViewById<View>(R.id.editorGroup).visibility == View.VISIBLE }
-        drawActivity(activity)
-        waitUntil { timelineSourceStore.importInProgress() == null }
+        waitUntil {
+            drawActivity(activity)
+            timelineSourceStore.importInProgress() == null
+        }
 
         assertEquals(explicit, timelineSourceStore.load())
         assertEquals(View.GONE, activity.findViewById<View>(R.id.loadingGroup).visibility)

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
@@ -187,6 +187,8 @@ class TimelineParserTest {
             TimelineParseReason.NO_USABLE_LOCATIONS,
             parseFailure("""{"semanticSegments": []}""").reason,
         )
+        assertEquals(TimelineParseReason.EMPTY_EXPORT, parseFailure("").reason)
+        assertEquals(TimelineParseReason.EMPTY_EXPORT, parseFailure("  \n\t").reason)
         assertEquals(
             TimelineParseReason.MALFORMED_JSON,
             parseFailure("""{"semanticSegments": [""").reason,

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/LocalizedDatePatternsTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/LocalizedDatePatternsTest.kt
@@ -21,9 +21,10 @@ class LocalizedDatePatternsTest {
         val resources = sequenceOf(File("src/main/res"), File("app/src/main/res"))
             .firstOrNull(File::isDirectory)
             ?: error("Resource directory not found from ${File(".").absolutePath}")
-        val patternFiles = resources.listFiles { file -> file.name.startsWith("values") }
+        val patternFiles: List<File> = resources.listFiles { file -> file.name.startsWith("values") }
+            ?.filterNotNull()
+            ?.mapNotNull { valuesDir -> File(valuesDir, "strings.xml").takeIf(File::isFile) }
             .orEmpty()
-            .mapNotNull { valuesDir -> File(valuesDir, "strings.xml").takeIf(File::isFile) }
         assertTrue("No strings.xml files found", patternFiles.isNotEmpty())
 
         val sample = ZonedDateTime.of(2025, 8, 19, 12, 0, 0, 0, ZoneOffset.UTC)
@@ -32,7 +33,7 @@ class LocalizedDatePatternsTest {
         patternFiles.forEach { stringsFile ->
             val resource = renderDatePattern(stringsFile) ?: return@forEach
             patternsChecked += 1
-            val folder = stringsFile.parentFile.name
+            val folder = stringsFile.parentFile?.name ?: stringsFile.path
             if (folder == "values" && resource.translatable != "false") {
                 problems += "$folder: render_date_pattern must stay translatable=\"false\" so translation tooling skips it"
             }
@@ -40,15 +41,15 @@ class LocalizedDatePatternsTest {
             val formatter = try {
                 DateTimeFormatter.ofPattern(pattern)
             } catch (error: IllegalArgumentException) {
-                problems += "${stringsFile.parentFile.name}: pattern \"$pattern\" is invalid (${error.message})"
+                problems += "$folder: pattern \"$pattern\" is invalid (${error.message})"
                 return@forEach
             }
             val formatted = formatter.format(sample)
             if (!formatted.contains("2025")) {
-                problems += "${stringsFile.parentFile.name}: pattern \"$pattern\" renders \"$formatted\" without the year"
+                problems += "$folder: pattern \"$pattern\" renders \"$formatted\" without the year"
             }
             if (formatted == formatter.format(sample.withMonth(9))) {
-                problems += "${stringsFile.parentFile.name}: pattern \"$pattern\" renders \"$formatted\" without the month"
+                problems += "$folder: pattern \"$pattern\" renders \"$formatted\" without the month"
             }
         }
         assertTrue("render_date_pattern missing from default resources", patternsChecked > 0)

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
@@ -3,9 +3,14 @@ package dev.mahlernim.timelinevisualizer.render
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.content.Context
+import android.content.res.Configuration
+import androidx.test.core.app.ApplicationProvider
+import dev.mahlernim.timelinevisualizer.R
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
 import java.time.Instant
+import java.util.Locale
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -18,6 +23,48 @@ import org.robolectric.annotation.GraphicsMode
 @Config(sdk = [35])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class TimelinePainterTest {
+    @Test
+    fun firstPreviewFrameRendersInEverySupportedLocale() {
+        val application = ApplicationProvider.getApplicationContext<Context>()
+        val journey = Journey.from(
+            listOf(
+                GeoPoint(Instant.parse("2025-01-01T00:00:00Z"), 37.50, 126.90),
+                GeoPoint(Instant.parse("2025-02-01T00:00:00Z"), 37.55, 126.95),
+            ),
+            2025,
+        )
+
+        listOf("en", "de", "es", "fr", "ja", "ko", "pt-BR", "zh-CN", "zh-TW").forEach { tag ->
+            val locale = Locale.forLanguageTag(tag)
+            val configuration = Configuration(application.resources.configuration).apply { setLocale(locale) }
+            val localized = application.createConfigurationContext(configuration)
+            val renderText = RenderText(
+                localeTag = tag,
+                fallbackTitle = localized.getString(R.string.default_title),
+                datePattern = localized.getString(R.string.render_date_pattern),
+                distanceUnit = localized.getString(R.string.distance_unit),
+                attribution = localized.getString(R.string.map_attribution),
+            )
+            val bitmap = Bitmap.createBitmap(SIZE, SIZE, Bitmap.Config.ARGB_8888)
+            try {
+                TimelinePainter().draw(
+                    canvas = Canvas(bitmap),
+                    width = SIZE,
+                    height = SIZE,
+                    journey = journey,
+                    frame = TimelineFrame(0f, 0f),
+                    journeyDurationSeconds = 45,
+                    title = renderText.fallbackTitle,
+                    renderText = renderText,
+                    allowCameraTrackBuild = false,
+                    tiles = { null },
+                )
+            } finally {
+                bitmap.recycle()
+            }
+        }
+    }
+
     @Test
     fun fixedCameraKeepsTheSameZoomSpanAcrossTheJourney() {
         val journey = Journey.from(
@@ -102,6 +149,90 @@ class TimelinePainterTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun indexedCameraBoundsMatchThePreviousRouteScan() {
+        val routes = listOf(
+            List(2_000) { index ->
+                GeoPoint(
+                    Instant.parse("2025-01-01T00:00:00Z").plusSeconds(index.toLong()),
+                    37.45 + (index % 100) * 0.00001,
+                    126.90 + index * 0.00001,
+                )
+            },
+            listOf(point(10.0, 179.0), point(20.0, -179.0), point(-15.0, 170.0)),
+            listOf(point(70.0, -150.0), point(-55.0, 0.0), point(60.0, 150.0)),
+        )
+        val settings = listOf(
+            CameraSettings.DEFAULT,
+            CameraSettings(cameraMovement = CameraMovement.FIXED, longTripCompression = LongTripCompression.OFF),
+            CameraSettings(cameraMovement = CameraMovement.DYNAMIC, longTripCompression = LongTripCompression.STRONG),
+        )
+
+        routes.forEach { points ->
+            val journey = Journey.from(points, 2025)
+            settings.forEach { cameraSettings ->
+                listOf(0f, 0.17f, 0.5f, 0.83f, 1f).forEach { progress ->
+                    val indexed = TimelinePainter().rawViewportForTest(
+                        journey, progress, SIZE, SIZE, cameraSettings, useRangeIndex = true,
+                    )
+                    val previous = TimelinePainter().rawViewportForTest(
+                        journey, progress, SIZE, SIZE, cameraSettings, useRangeIndex = false,
+                    )
+                    assertEquals(previous, indexed)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun denseCameraTrackDoesNotRescanEveryPointForEveryCameraSample() {
+        val points = List(20_000) { index ->
+            GeoPoint(
+                Instant.parse("2025-01-01T00:00:00Z").plusSeconds(index.toLong()),
+                37.50 + (index % 100) * 0.000001,
+                126.95 + index * 0.000001,
+            )
+        }
+        val journey = Journey.from(points, 2025)
+        val painter = TimelinePainter()
+
+        painter.viewport(journey, 0f, SIZE, SIZE)
+
+        assertTrue(
+            "Camera evaluated ${painter.cameraRoutePointEvaluations} route points",
+            painter.cameraRoutePointEvaluations < 100_000,
+        )
+    }
+
+    @Test
+    fun lightweightInitialFrameDoesNotPrepareTheFullRoute() {
+        val points = List(5_000) { index ->
+            GeoPoint(
+                Instant.parse("2025-01-01T00:00:00Z").plusSeconds(index.toLong()),
+                37.50 + (index % 100) * 0.000001,
+                126.95 + index * 0.000001,
+            )
+        }
+        val journey = Journey.from(points, 2025)
+        val painter = TimelinePainter()
+        val bitmap = Bitmap.createBitmap(SIZE, SIZE, Bitmap.Config.ARGB_8888)
+
+        painter.draw(
+            canvas = Canvas(bitmap),
+            width = SIZE,
+            height = SIZE,
+            journey = journey,
+            frame = TimelineFrame(0f, 0f),
+            journeyDurationSeconds = 45,
+            title = "Timeline",
+            allowCameraTrackBuild = false,
+            tiles = { null },
+        )
+
+        assertEquals(0L, painter.cameraRoutePointEvaluations)
+        bitmap.recycle()
     }
 
     private fun point(latitude: Double, longitude: Double) = GeoPoint(

--- a/docs/release-notes-v2.1.3.md
+++ b/docs/release-notes-v2.1.3.md
@@ -1,0 +1,55 @@
+# Timeline Visualizer 2.1.3
+
+This update fixes a first-preview crash in several device languages and improves dense
+Timeline loading. Empty exports now explain that Timeline may not have been enabled.
+Create video also opens first when the video library is empty.
+
+## 한국어
+
+일부 기기 언어에서 발생하던 첫 미리보기 오류를 수정하고, 밀집된 Timeline 경로가 해당
+화면을 지연시키지 않도록 개선했습니다. 빈 내보내기에는 타임라인이 활성화되지 않았을 수
+있다는 안내를 표시합니다. 영상 목록이 비어 있으면 영상 만들기 화면이 먼저 열립니다.
+
+## 日本語
+
+一部の端末言語で発生していた最初のプレビューのクラッシュを修正し、密度の高い
+Timeline 経路がその画面を停止させないよう改善しました。空の書き出しには Timeline が
+有効でなかった可能性を表示します。動画一覧が空の場合は動画作成画面が最初に開きます。
+
+## 简体中文
+
+修复了部分设备语言下首个预览画面崩溃的问题，并避免密集 Timeline 路线阻塞该画面。
+空导出现在会提示 Timeline 可能未启用。视频库为空时会首先打开创建视频页面。
+
+## 繁體中文
+
+修正部分裝置語言下第一個預覽畫面當機的問題，並避免密集 Timeline 路線阻塞該畫面。
+空白匯出現在會提示 Timeline 可能未啟用。影片庫為空時會先開啟建立影片頁面。
+
+## Español
+
+Esta actualización corrige un cierre inesperado de la primera vista previa en varios
+idiomas del dispositivo y mejora la carga de rutas densas. Las exportaciones vacías
+ahora explican que Timeline podría no estar activado. Crear video se abre primero
+cuando la biblioteca está vacía.
+
+## Français
+
+Cette mise à jour corrige un plantage du premier aperçu dans plusieurs langues de
+l’appareil et améliore le chargement des itinéraires denses. Les exportations vides
+expliquent désormais que Timeline n’était peut-être pas activé. Créer une vidéo
+s’ouvre en premier lorsque la bibliothèque est vide.
+
+## Deutsch
+
+Dieses Update behebt einen Absturz der ersten Vorschau in mehreren Gerätesprachen und
+verbessert das Laden dichter Timeline-Routen. Bei leeren Exporten wird nun erklärt,
+dass Timeline möglicherweise nicht aktiviert war. Bei einer leeren Bibliothek wird
+zuerst Video erstellen geöffnet.
+
+## Português (Brasil)
+
+Esta atualização corrige uma falha na primeira visualização em vários idiomas do
+dispositivo e melhora o carregamento de rotas densas. Exportações vazias agora explicam
+que o Timeline pode não ter sido ativado. Criar vídeo abre primeiro quando a biblioteca
+está vazia.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.1.2` and version code `17`
+- Version name `2.1.3` and version code `18`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

Prepare v2.1.3 as a focused reliability release.

This branch builds on the confirmed first-frame locale crash fix from #61 and improves dense Timeline preparation without changing final route geometry or camera output. It also includes the empty-library launch behavior requested in #47 and a clearer explanation for empty Timeline exports.

References #44
References #47

## Changes

- keep the first preview frame lightweight while exact camera preparation runs off the main thread
- replace 481 repeated full-route scans with exact cached range bounds
- reduce temporary allocations in filtering, range selection, journey timing, and transfer preparation
- keep import controls disabled until the complete camera track is ready
- clear the interrupted-import marker only after the first exact-camera frame
- open Create video on a cold launch when the library is empty
- preserve My videos for nonempty libraries and active export recovery
- distinguish blank Timeline files from malformed JSON and explain that Timeline may not have been enabled
- update version metadata and localized v2.1.3 release notes

## Validation

- full Android unit and Robolectric suites
- lint
- GitHub and Play debug APK builds
- instrumentation APK build
- 20 Python tests
- API 35 emulator with 14 MB Portuguese, 45 MB dense import, and navigation smoke tests
- API 36 emulator with the same three device tests
- exact camera-output equivalence tests against the previous route-scan implementation
- first-frame rendering tests for all nine supported locales

The public release artifacts and final installed-APK checks will be completed after merge and tagging.