### PR TITLE
Clarify web app analytics privacy disclosure

### DIFF
--- a/docs/privacy-web.md
+++ b/docs/privacy-web.md
@@ -1,0 +1,57 @@
+# Timeline Visualizer web app privacy
+
+**Effective date:** August 20, 2026
+
+**Developer:** MahlerLab
+
+**Contact:** [mahlerlabdiy@gmail.com](mailto:mahlerlabdiy@gmail.com)
+
+Timeline Visualizer processes sensitive location history locally in the browser.
+
+## Timeline data
+
+The web app reads only the `Timeline.json` file that you explicitly select. The
+file, route coordinates, selected dates, title, video frames, and generated MP4
+are not uploaded to the developer or to an application server. Video processing
+and MP4 creation happen in the browser tab.
+
+The web app does not request a Google account, device location, contacts, photos,
+advertising identifier, or broad file permission.
+
+## Hosting and aggregate traffic analytics
+
+The public site is hosted with GitHub Pages and served through Cloudflare. Normal
+web requests expose standard network information such as the IP address, user
+agent, requested page, and request timing to those hosting providers.
+
+The hosted site uses Cloudflare Web Analytics to measure aggregate site traffic.
+Timeline file contents, route coordinates, selected dates, titles, video frames,
+and generated media are not added to analytics events by the application.
+
+## Map requests
+
+After you accept the map privacy notice, the web app requests raster map tiles
+from CARTO. Those requests contain zoom, x, and y tile identifiers plus normal
+network information such as the IP address and user agent. Tile identifiers
+correspond to geographic areas in the selected journey and may reveal those
+areas to CARTO.
+
+The web app does not send the Timeline JSON, a complete route list, titles, video
+frames, or generated videos to CARTO. You can load and inspect a Timeline file
+without accepting the notice or requesting map tiles.
+
+## Browser storage
+
+Selected Timeline data and generated videos remain in the current browser page.
+The service worker may cache static application files so the interface can load
+reliably. It does not cache the selected Timeline JSON or generated MP4. Closing
+or reloading the page clears the active Timeline data. Browser site settings can
+be used to remove cached application files.
+
+## Third parties
+
+- [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
+- [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/)
+- [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/)
+- [CARTO Privacy Notice](https://carto.com/privacy/)
+- [OpenStreetMap Privacy Policy](https://osmfoundation.org/wiki/Privacy_Policy)

--- a/tests/test_web_privacy.py
+++ b/tests/test_web_privacy.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_web_app_links_its_own_privacy_policy() -> None:
+    html = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+    policy = (ROOT / "docs" / "privacy-web.md").read_text(encoding="utf-8")
+
+    assert "docs/privacy-web.md" in html
+    assert "Cloudflare Web Analytics" in policy
+    assert "Timeline file contents" in policy
+
+
+def test_web_privacy_copy_does_not_claim_analytics_are_absent() -> None:
+    html = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+    readme = (ROOT / "web" / "README.md").read_text(encoding="utf-8")
+
+    assert "No account, location permission, or Timeline upload is required." in html
+    assert "No account, location permission, analytics, or upload is required." not in html
+    assert "Cloudflare Web Analytics" in readme

--- a/web/README.md
+++ b/web/README.md
@@ -7,7 +7,10 @@ entirely in the browser.
 ## Privacy
 
 - The Timeline JSON is read locally and is not uploaded.
-- No account, analytics, location permission, or broad file permission is used.
+- No account, location permission, or broad file permission is used.
+- The public site uses Cloudflare Web Analytics for aggregate site traffic. The
+  application does not add Timeline contents, coordinates, selected dates,
+  titles, or generated media to analytics events.
 - CARTO receives requests for the map tiles needed to render the selected route.
 - The browser tab must remain open while video creation is running.
 

--- a/web/index.html
+++ b/web/index.html
@@ -99,7 +99,7 @@
             <input id="map-consent" type="checkbox" />
             <span>I understand and want to load the map</span>
           </label>
-          <a href="https://github.com/mahlernim/google-timeline-visualizer/blob/main/docs/privacy.md" target="_blank" rel="noopener noreferrer">Read the privacy policy</a>
+          <a href="https://github.com/mahlernim/google-timeline-visualizer/blob/main/docs/privacy-web.md" target="_blank" rel="noopener noreferrer">Read the web app privacy policy</a>
         </div>
         <p id="settings-error" class="error hidden" role="alert"></p>
         <div class="actions">
@@ -125,7 +125,7 @@
       </section>
 
       <footer>
-        <p>No account, location permission, analytics, or upload is required.</p>
+        <p>No account, location permission, or Timeline upload is required.</p>
         <p>Map data © OpenStreetMap contributors and © CARTO.</p>
         <p><a href="./third-party-notices.txt">Third-party notices</a></p>
       </footer>


### PR DESCRIPTION
## Problem

The deployed iPhone web app is served through Cloudflare and receives an injected Cloudflare Web Analytics beacon, while the initial web copy said analytics were not used. The privacy link also opened the Android-specific policy.

## Resolution

- add a dedicated web app privacy policy
- disclose GitHub Pages hosting, Cloudflare aggregate traffic analytics, and the metadata those providers may receive
- retain the explicit guarantee that Timeline contents, coordinates, selected dates, titles, video frames, and generated media are not added to analytics events by the application
- point the in-app privacy link to the web policy
- replace the inaccurate footer claim
- add regression tests for the policy link and analytics wording

## Validation

- `python -m pytest` with 22 passing tests
- `pnpm test` with 28 passing tests
- `pnpm typecheck`
- `pnpm build`