### PR TITLE
Add portrait and landscape export presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.2.0
+
+- Add fixed portrait 1080×1920 and landscape 1920×1080 video formats.
+- Keep the existing square 480p, 720p, and 1080p formats and the square 480p default unchanged.
+- Match the preview and generated journey overview to the selected output aspect ratio.
+- Keep titles, dates, attribution, markers, and the ending overview proportionate in every format.
+- Check H.264 encoder size, frame-rate, bitrate, alignment, and color-layout support before preparing map tiles.
+- Disable unsupported output with a localized message instead of silently substituting another format.
+- Preserve existing saved settings and pending exports without a storage migration.
+- Retain the original route-stroke appearance for square videos.
+- Credit Rafiqi Rachmat (`@akunlainfiqi`) for the format-preset design and implementation contributed in PR #57.
+- Set Android version code 19 and version name 2.2.0.
+
 ## 2.1.3
 
 - Fix invalid translated preview date patterns that terminated the first frame in German, Spanish, French, and Portuguese.

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,7 @@ MP4 の作成には H.264 エンコードに対応した Safari 16.4 以降が�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.1.3.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.2.0.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,7 +32,7 @@ MP4를 만들려면 H.264 인코딩을 지원하는 Safari 16.4 이상이 필요
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.1.3.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.2.0.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use Safari's Share menu and choose **Add to Home Screen**.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.1.3.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.2.0.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 18
-        versionName = "2.1.3"
+        versionCode = 19
+        versionName = "2.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/export/VideoFormatDeviceTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/export/VideoFormatDeviceTest.kt
@@ -1,0 +1,55 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.mahlernim.timelinevisualizer.render.VideoQuality
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class VideoFormatDeviceTest {
+    @Test
+    fun theDeviceCanEvaluateAndConfigureEveryReportedPreset() {
+        val profiles = VideoEncoderSupport.deviceProfiles()
+        assertTrue("The device exposed no H.264 encoder", profiles.isNotEmpty())
+
+        VideoQuality.values().forEach { preset ->
+            val support = VideoEncoderSupport.select(preset, profiles)
+            Log.i(TAG, "${preset.name}: $support")
+            if (support is EncoderSupport.Supported) configure(preset, support)
+        }
+
+        assertTrue(
+            "The device cannot encode the default square format",
+            VideoEncoderSupport.select(VideoQuality.STANDARD, profiles) is EncoderSupport.Supported,
+        )
+    }
+
+    private fun configure(preset: VideoQuality, support: EncoderSupport.Supported) {
+        val format = MediaFormat.createVideoFormat(
+            MediaFormat.MIMETYPE_VIDEO_AVC,
+            preset.width,
+            preset.height,
+        ).apply {
+            setInteger(MediaFormat.KEY_COLOR_FORMAT, support.colorFormat)
+            setInteger(MediaFormat.KEY_BIT_RATE, preset.bitrate)
+            setInteger(MediaFormat.KEY_FRAME_RATE, preset.frameRate)
+            setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 1)
+        }
+        val codec = MediaCodec.createByCodecName(support.name)
+        try {
+            codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+            codec.start()
+        } finally {
+            runCatching { codec.stop() }
+            codec.release()
+        }
+    }
+
+    private companion object {
+        const val TAG = "VideoFormatDeviceTest"
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -61,6 +61,9 @@ import dev.mahlernim.timelinevisualizer.export.VideoExportRequestStore
 import dev.mahlernim.timelinevisualizer.export.VideoExportService
 import dev.mahlernim.timelinevisualizer.export.VideoExportSnapshot
 import dev.mahlernim.timelinevisualizer.export.VideoExportStatus
+import dev.mahlernim.timelinevisualizer.export.EncoderSupport
+import dev.mahlernim.timelinevisualizer.export.VideoEncoderSupport
+import dev.mahlernim.timelinevisualizer.export.describe
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.model.Timeline
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
@@ -129,7 +132,9 @@ class MainActivity : AppCompatActivity() {
     private val timelineSourceStore by lazy { TimelineSourceStore(applicationContext) }
     private val cameraSettingsPreferences by lazy { CameraSettingsPreferences(applicationContext) }
     private val locationFilterPreferences by lazy { LocationFilterPreferences(applicationContext) }
+    private val videoEncoderProfiles by lazy { VideoEncoderSupport.deviceProfiles() }
     private var cameraSettings = CameraSettings.DEFAULT
+    private var videoFormatSupported = true
     private var locationFilterMode = LocationFilterMode.CONSERVATIVE
     private var routeDurationSeconds = VideoDuration.DEFAULT_SECONDS
     private val applyTitleChanges = Runnable { commitTitlePreferences() }
@@ -897,9 +902,11 @@ class MainActivity : AppCompatActivity() {
             R.string.compression_strong,
         ).map(::getString)
         val qualityLabels = listOf(
-            R.string.quality_standard,
-            R.string.quality_high,
-            R.string.quality_ultra,
+            R.string.format_square_480,
+            R.string.format_square_720,
+            R.string.format_square_1080,
+            R.string.format_portrait_1080,
+            R.string.format_landscape_1080,
         ).map(::getString)
 
         listOf(
@@ -968,7 +975,7 @@ class MainActivity : AppCompatActivity() {
         val ready = editor.timelineView.isCameraReady
         val canCreate = selected?.let(::canCreateVideo) == true && ready
         editor.playButton.isEnabled = !exportingVideo && canCreate
-        editor.exportButton.isEnabled = !exportingVideo && canCreate
+        editor.exportButton.isEnabled = !exportingVideo && canCreate && videoFormatSupported
         editor.timelineSeek.isEnabled = !exportingVideo && ready
         if (selected != null && !ready && !exportingVideo) {
             editor.statusText.setText(R.string.preparing_preview)
@@ -1027,10 +1034,33 @@ class MainActivity : AppCompatActivity() {
             false,
         )
         settingsScreen.videoQualityDropdown.setText(
-            getString(listOf(R.string.quality_standard, R.string.quality_high, R.string.quality_ultra)[settings.videoQuality.ordinal]),
+            videoFormatLabel(settings.videoQuality),
             false,
         )
+        val warning = videoFormatWarning(settings.videoQuality)
+        videoFormatSupported = warning == null
+        settingsScreen.videoFormatWarningText.text = warning
+        settingsScreen.videoFormatWarningText.visibility = if (warning == null) View.GONE else View.VISIBLE
+        updateCameraPreparationUi()
         showProgress(editor.timelineSeek.progress / 1000f)
+    }
+
+    private fun videoFormatLabel(format: VideoQuality): String = getString(
+        when (format) {
+            VideoQuality.STANDARD -> R.string.format_square_480
+            VideoQuality.HIGH -> R.string.format_square_720
+            VideoQuality.ULTRA -> R.string.format_square_1080
+            VideoQuality.PORTRAIT -> R.string.format_portrait_1080
+            VideoQuality.LANDSCAPE -> R.string.format_landscape_1080
+        },
+    )
+
+    private fun videoFormatWarning(format: VideoQuality): String? {
+        if (videoEncoderProfiles.isEmpty()) return null
+        return when (val support = VideoEncoderSupport.select(format, videoEncoderProfiles)) {
+            is EncoderSupport.Supported -> null
+            is EncoderSupport.Unsupported -> support.reason.describe(this, format)
+        }
     }
 
     private fun applyDuration(seconds: Int) {
@@ -1252,7 +1282,7 @@ class MainActivity : AppCompatActivity() {
         home.deleteAllVideosButton.isEnabled = !exporting
         editor.importButton.isEnabled = !exporting && editor.loadingGroup.visibility != View.VISIBLE
         editor.playButton.isEnabled = !exporting && canCreate
-        editor.exportButton.isEnabled = !exporting && canCreate
+        editor.exportButton.isEnabled = !exporting && canCreate && videoFormatSupported
         editor.shareButton.isEnabled = !exporting
         editor.watchVideoButton.isEnabled = !exporting
         editor.createAnotherButton.isEnabled = !exporting

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -5,11 +5,9 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
-import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.media.MediaMuxer
 import android.net.Uri
-import android.os.Build
 import dev.mahlernim.timelinevisualizer.data.TileRepository
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.render.TimelineAnimation
@@ -48,9 +46,16 @@ class Mp4Exporter(
         onProgress: (ExportProgress) -> Unit,
     ): Bitmap = withContext(Dispatchers.Default) {
         require(journey.points.size >= 2) { "At least two location points are needed" }
-        val width = cameraSettings.videoQuality.size
-        val height = cameraSettings.videoQuality.size
-        val fps = 24
+        val videoFormat = cameraSettings.videoQuality
+        val encoder = when (val support = VideoEncoderSupport.evaluate(videoFormat)) {
+            is EncoderSupport.Supported -> support
+            is EncoderSupport.Unsupported -> throw UnsupportedVideoFormatException(support.reason, videoFormat)
+        }
+        val width = videoFormat.width
+        val height = videoFormat.height
+        val fps = videoFormat.frameRate
+        val overviewWidth = overviewWidth(videoFormat)
+        val overviewHeight = overviewHeight(videoFormat)
         val painter = TimelinePainter()
 
         val sampleCount = max(durationSeconds * 2, ceil(journey.totalDistanceKm / 250.0).toInt())
@@ -76,8 +81,8 @@ class Mp4Exporter(
                     painter.viewport(
                         journey,
                         TimelineFrame(1f, 1f),
-                        OVERVIEW_SIZE,
-                        OVERVIEW_SIZE,
+                        overviewWidth,
+                        overviewHeight,
                         cameraSettings,
                     ),
                 ).map { it.id },
@@ -97,10 +102,9 @@ class Mp4Exporter(
             )
         }
 
-        val encoder = selectEncoder(width, height, cameraSettings.videoQuality.bitrate)
         val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, width, height).apply {
             setInteger(MediaFormat.KEY_COLOR_FORMAT, encoder.colorFormat)
-            setInteger(MediaFormat.KEY_BIT_RATE, cameraSettings.videoQuality.bitrate)
+            setInteger(MediaFormat.KEY_BIT_RATE, videoFormat.bitrate)
             setInteger(MediaFormat.KEY_FRAME_RATE, fps)
             setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 1)
         }
@@ -226,11 +230,11 @@ class Mp4Exporter(
                 }
             }
             while (!drain(true)) coroutineContext.ensureActive()
-            val overview = Bitmap.createBitmap(OVERVIEW_SIZE, OVERVIEW_SIZE, Bitmap.Config.ARGB_8888)
+            val overview = Bitmap.createBitmap(overviewWidth, overviewHeight, Bitmap.Config.ARGB_8888)
             painter.draw(
                 Canvas(overview),
-                OVERVIEW_SIZE,
-                OVERVIEW_SIZE,
+                overviewWidth,
+                overviewHeight,
                 journey,
                 TimelineFrame(1f, 1f),
                 durationSeconds,
@@ -249,29 +253,6 @@ class Mp4Exporter(
             descriptor.close()
             bitmap.recycle()
         }
-    }
-
-    private fun selectEncoder(width: Int, height: Int, bitrate: Int): EncoderChoice {
-        val preferredFormats = listOf(
-            MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar,
-            MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420SemiPlanar,
-        )
-        val codecs = MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos.toList()
-            .sortedByDescending { info ->
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && info.isHardwareAccelerated) 1 else 0
-            }
-        for (info in codecs) {
-            if (!info.isEncoder || !info.supportedTypes.any { it.equals(MediaFormat.MIMETYPE_VIDEO_AVC, true) }) continue
-            val capabilities = runCatching { info.getCapabilitiesForType(MediaFormat.MIMETYPE_VIDEO_AVC) }.getOrNull()
-                ?: continue
-            val videoCapabilities = capabilities.videoCapabilities ?: continue
-            if (!videoCapabilities.isSizeSupported(width, height) || !videoCapabilities.bitrateRange.contains(bitrate)) {
-                continue
-            }
-            val formats = capabilities.colorFormats.toSet()
-            preferredFormats.firstOrNull(formats::contains)?.let { return EncoderChoice(info.name, it) }
-        }
-        error("This device does not expose a compatible H.264 encoder")
     }
 
     private fun argbToYuv420(pixels: IntArray, output: ByteArray, width: Int, height: Int, colorFormat: Int) {
@@ -303,13 +284,27 @@ class Mp4Exporter(
         }
     }
 
-    private data class EncoderChoice(val name: String, val colorFormat: Int)
-
     companion object {
         private const val OUTRO_TILE_SAMPLES = 12
-        const val OVERVIEW_SIZE = 1080
+        const val OVERVIEW_MAX_EDGE = 1080
         private const val PREPARING_PROGRESS_WEIGHT = 0.10f
         private const val JOURNEY_PROGRESS_WEIGHT = 0.80f
         private const val FINISHING_PROGRESS_WEIGHT = 0.10f
+
+        internal fun overviewWidth(format: dev.mahlernim.timelinevisualizer.render.VideoQuality): Int =
+            if (format.width >= format.height) {
+                OVERVIEW_MAX_EDGE
+            } else {
+                (OVERVIEW_MAX_EDGE * format.aspectRatio).toInt().coerceAtLeast(1).toEven()
+            }
+
+        internal fun overviewHeight(format: dev.mahlernim.timelinevisualizer.render.VideoQuality): Int =
+            if (format.height >= format.width) {
+                OVERVIEW_MAX_EDGE
+            } else {
+                (OVERVIEW_MAX_EDGE / format.aspectRatio).toInt().coerceAtLeast(1).toEven()
+            }
+
+        private fun Int.toEven(): Int = if (this % 2 == 0) this else this + 1
     }
 }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoEncoderSupport.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoEncoderSupport.kt
@@ -1,0 +1,112 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import android.content.Context
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.media.MediaFormat
+import android.os.Build
+import dev.mahlernim.timelinevisualizer.R
+import dev.mahlernim.timelinevisualizer.render.VideoQuality
+
+internal data class EncoderProfile(
+    val name: String,
+    val hardwareAccelerated: Boolean,
+    val widthRange: IntRange,
+    val heightRange: IntRange,
+    val widthAlignment: Int,
+    val heightAlignment: Int,
+    val bitrateRange: IntRange,
+    val maxFrameRateFor: (Int, Int) -> Double,
+    val colorFormats: Set<Int>,
+)
+
+internal sealed interface EncoderSupport {
+    data class Supported(val name: String, val colorFormat: Int) : EncoderSupport
+
+    data class Unsupported(val reason: Reason) : EncoderSupport
+
+    enum class Reason { NO_ENCODER, SIZE, ALIGNMENT, FRAME_RATE, BITRATE, COLOR_FORMAT }
+}
+
+internal fun EncoderSupport.Reason.describe(context: Context, format: VideoQuality): String =
+    context.getString(R.string.format_not_supported, format.width, format.height)
+
+internal class UnsupportedVideoFormatException(
+    val reason: EncoderSupport.Reason,
+    val format: VideoQuality,
+) : RuntimeException(
+    "No H.264 encoder accepts ${format.width}x${format.height}@${format.frameRate} ($reason)",
+)
+
+internal object VideoEncoderSupport {
+    private val preferredColorFormats = listOf(
+        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar,
+        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420SemiPlanar,
+    )
+
+    fun evaluate(format: VideoQuality): EncoderSupport = select(format, deviceProfiles())
+
+    fun select(format: VideoQuality, profiles: List<EncoderProfile>): EncoderSupport {
+        if (profiles.isEmpty()) return EncoderSupport.Unsupported(EncoderSupport.Reason.NO_ENCODER)
+        var closest = EncoderSupport.Reason.NO_ENCODER
+        profiles.sortedByDescending { it.hardwareAccelerated }.forEach { profile ->
+            when (val result = evaluate(format, profile)) {
+                is EncoderSupport.Supported -> return result
+                is EncoderSupport.Unsupported -> if (result.reason.ordinal > closest.ordinal) {
+                    closest = result.reason
+                }
+            }
+        }
+        return EncoderSupport.Unsupported(closest)
+    }
+
+    fun deviceProfiles(): List<EncoderProfile> =
+        runCatching { MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos.toList() }
+            .getOrDefault(emptyList())
+            .mapNotNull(::toProfile)
+
+    private fun evaluate(format: VideoQuality, profile: EncoderProfile): EncoderSupport {
+        if (format.width !in profile.widthRange || format.height !in profile.heightRange) {
+            return EncoderSupport.Unsupported(EncoderSupport.Reason.SIZE)
+        }
+        if (
+            format.width % profile.widthAlignment.coerceAtLeast(1) != 0 ||
+            format.height % profile.heightAlignment.coerceAtLeast(1) != 0
+        ) {
+            return EncoderSupport.Unsupported(EncoderSupport.Reason.ALIGNMENT)
+        }
+        val maximumFrameRate = runCatching { profile.maxFrameRateFor(format.width, format.height) }
+            .getOrDefault(0.0)
+        if (maximumFrameRate <= 0.0) return EncoderSupport.Unsupported(EncoderSupport.Reason.SIZE)
+        if (format.frameRate > maximumFrameRate) {
+            return EncoderSupport.Unsupported(EncoderSupport.Reason.FRAME_RATE)
+        }
+        if (format.bitrate !in profile.bitrateRange) {
+            return EncoderSupport.Unsupported(EncoderSupport.Reason.BITRATE)
+        }
+        val colorFormat = preferredColorFormats.firstOrNull(profile.colorFormats::contains)
+            ?: return EncoderSupport.Unsupported(EncoderSupport.Reason.COLOR_FORMAT)
+        return EncoderSupport.Supported(profile.name, colorFormat)
+    }
+
+    private fun toProfile(info: MediaCodecInfo): EncoderProfile? {
+        if (!info.isEncoder) return null
+        if (!info.supportedTypes.any { it.equals(MediaFormat.MIMETYPE_VIDEO_AVC, ignoreCase = true) }) return null
+        val capabilities = runCatching { info.getCapabilitiesForType(MediaFormat.MIMETYPE_VIDEO_AVC) }
+            .getOrNull() ?: return null
+        val video = capabilities.videoCapabilities ?: return null
+        return EncoderProfile(
+            name = info.name,
+            hardwareAccelerated = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && info.isHardwareAccelerated,
+            widthRange = video.supportedWidths.lower..video.supportedWidths.upper,
+            heightRange = video.supportedHeights.lower..video.supportedHeights.upper,
+            widthAlignment = video.widthAlignment,
+            heightAlignment = video.heightAlignment,
+            bitrateRange = video.bitrateRange.lower..video.bitrateRange.upper,
+            maxFrameRateFor = { width, height ->
+                runCatching { video.getSupportedFrameRatesFor(width, height).upper }.getOrDefault(0.0)
+            },
+            colorFormats = capabilities.colorFormats.toSet(),
+        )
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
@@ -168,12 +168,17 @@ class VideoExportService : Service() {
             Log.e(TAG, "Video export failed", error)
             GeneratedMediaRepository(applicationContext).discard(uri)
             requestStore.clear()
-            finishWithFailure(request, getString(R.string.video_export_failed), startId)
+            finishWithFailure(request, failureMessage(error), startId)
             return
         } finally {
             exportJob = null
             stopSelf(startId)
         }
+    }
+
+    private fun failureMessage(error: Throwable): String = when (error) {
+        is UnsupportedVideoFormatException -> error.reason.describe(this, error.format)
+        else -> getString(R.string.video_export_failed)
     }
 
     private fun cancelExport(startId: Int) {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
@@ -24,12 +24,18 @@ enum class LongTripCompression(val exponent: Double) {
 }
 
 enum class VideoQuality(
-    val size: Int,
+    val width: Int,
+    val height: Int,
+    val frameRate: Int,
     val bitrate: Int,
 ) {
-    STANDARD(480, 2_500_000),
-    HIGH(720, 5_000_000),
-    ULTRA(1080, 8_000_000),
+    STANDARD(480, 480, 24, 2_500_000),
+    HIGH(720, 720, 24, 5_000_000),
+    ULTRA(1080, 1080, 24, 8_000_000),
+    PORTRAIT(1080, 1920, 30, 12_000_000),
+    LANDSCAPE(1920, 1080, 30, 12_000_000);
+
+    val aspectRatio: Float get() = width.toFloat() / height
 }
 
 data class CameraSettings(

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -95,6 +95,15 @@ class TimelinePainter {
         color = Color.argb(220, 255, 248, 250)
     }
 
+    private fun overlayScale(width: Int, height: Int): Float = min(width, height) / 720f
+
+    internal fun overlayCard(width: Int, height: Int): RectF {
+        val scale = overlayScale(width, height)
+        val cardWidth = min(width - CARD_SIDE_INSET * 2f * scale, MAX_CARD_WIDTH * scale)
+        val left = (width - cardWidth) / 2f
+        return RectF(left, CARD_TOP * scale, left + cardWidth, OVERLAY_BOTTOM * scale)
+    }
+
     internal fun routeWorldPoint(journey: Journey, index: Int): WorldPoint =
         prepare(journey).worldPointAt(index)
 
@@ -478,7 +487,7 @@ class TimelinePainter {
     }
 
     internal fun overviewSafeArea(width: Int, height: Int): RectF {
-        val scale = width / 720f
+        val scale = overlayScale(width, height)
         return RectF(
             OVERVIEW_SIDE_INSET * scale,
             OVERLAY_BOTTOM * scale + OVERVIEW_HEADER_GAP * scale,
@@ -655,8 +664,9 @@ class TimelinePainter {
         headPaint.alpha = markerAlpha
         headRingPaint.alpha = markerAlpha
         if (markerAlpha > 0) {
-            canvas.drawCircle(head.first, head.second, width * 0.013f, headPaint)
-            canvas.drawCircle(head.first, head.second, width * 0.017f, headRingPaint)
+            val markerEdge = min(width, height).toFloat()
+            canvas.drawCircle(head.first, head.second, markerEdge * 0.013f, headPaint)
+            canvas.drawCircle(head.first, head.second, markerEdge * 0.017f, headRingPaint)
         }
         headPaint.alpha = previousHeadAlpha
         headRingPaint.alpha = previousRingAlpha
@@ -706,8 +716,8 @@ class TimelinePainter {
         title: String,
         renderText: RenderText,
     ) {
-        val scale = width / 720f
-        val card = RectF(34f * scale, 28f * scale, width - 34f * scale, OVERLAY_BOTTOM * scale)
+        val scale = overlayScale(width, height)
+        val card = overlayCard(width, height)
         canvas.drawRoundRect(card, 24f * scale, 24f * scale, cardPaint)
         titlePaint.textSize = 34f * scale
         bodyPaint.textSize = 20f * scale
@@ -721,13 +731,13 @@ class TimelinePainter {
             val count = titlePaint.breakText(displayTitle, true, availableWidth - titlePaint.measureText("…"), null)
             displayTitle.take(count.coerceAtLeast(1)).trimEnd() + "…"
         }
-        canvas.drawText(fittedTitle, width / 2f, 72f * scale, titlePaint)
+        canvas.drawText(fittedTitle, card.centerX(), 72f * scale, titlePaint)
         val date = renderText.dateFormatter.format(position.point.instant.atZone(ZoneId.systemDefault()))
         val distance = position.distanceKm
         val number = NumberFormat.getNumberInstance(renderText.locale).apply { maximumFractionDigits = 0 }
         canvas.drawText(
             "$date  ·  ${number.format(distance)} ${renderText.distanceUnit}",
-            width / 2f,
+            card.centerX(),
             108f * scale,
             bodyPaint,
         )
@@ -1083,6 +1093,9 @@ class TimelinePainter {
         private const val OVERVIEW_ROUTE_ALPHA = 190
         private const val OVERVIEW_PADDING = 1.22
         private const val OVERLAY_BOTTOM = 132f
+        private const val CARD_TOP = 28f
+        private const val CARD_SIDE_INSET = 34f
+        private const val MAX_CARD_WIDTH = 720f - CARD_SIDE_INSET * 2f
         private const val OVERVIEW_SIDE_INSET = 34f
         private const val OVERVIEW_HEADER_GAP = 20f
         private const val OVERVIEW_BOTTOM_INSET = 34f

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineView.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineView.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.roundToInt
 
 class TimelineView @JvmOverloads constructor(
     context: Context,
@@ -80,8 +81,16 @@ class TimelineView @JvmOverloads constructor(
         set(value) {
             if (field == value) return
             field = value
+            previewAspectRatio = value.videoQuality.aspectRatio
             markFrameDirty()
             restartCameraPreparation()
+        }
+
+    var previewAspectRatio: Float = 1f
+        private set(value) {
+            if (field == value) return
+            field = value
+            requestLayout()
         }
 
     override fun onAttachedToWindow() {
@@ -109,9 +118,11 @@ class TimelineView @JvmOverloads constructor(
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val width = MeasureSpec.getSize(widthMeasureSpec)
-        val desiredHeight = width.coerceAtLeast((320 * resources.displayMetrics.density).toInt())
-        setMeasuredDimension(width, resolveSize(desiredHeight, heightMeasureSpec))
+        val availableWidth = MeasureSpec.getSize(widthMeasureSpec).coerceAtLeast(1)
+        val maximumHeight = (MAX_PREVIEW_HEIGHT_DP * resources.displayMetrics.density).roundToInt()
+            .coerceAtLeast(1)
+        val (width, height) = previewSize(availableWidth, maximumHeight, previewAspectRatio)
+        setMeasuredDimension(width, height)
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -258,5 +269,22 @@ class TimelineView @JvmOverloads constructor(
         val actions = afterNextFrameRendered.toList()
         afterNextFrameRendered.clear()
         actions.forEach { action -> post { action() } }
+    }
+
+    companion object {
+        private const val MAX_PREVIEW_HEIGHT_DP = 460
+
+        internal fun previewSize(maximumWidth: Int, maximumHeight: Int, aspectRatio: Float): Pair<Int, Int> {
+            val safeWidth = maximumWidth.coerceAtLeast(1)
+            val safeHeight = maximumHeight.coerceAtLeast(1)
+            val safeAspect = aspectRatio.takeIf { it.isFinite() && it > 0f } ?: 1f
+            var width = safeWidth
+            var height = (width / safeAspect).roundToInt().coerceAtLeast(1)
+            if (height > safeHeight) {
+                height = safeHeight
+                width = (height * safeAspect).roundToInt().coerceIn(1, safeWidth)
+            }
+            return width to height
+        }
     }
 }

--- a/app/src/main/res/layout/screen_new_video.xml
+++ b/app/src/main/res/layout/screen_new_video.xml
@@ -197,7 +197,7 @@
             <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="18dp" android:maxLines="1" android:text="@string/journey" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
 
             <com.google.android.material.card.MaterialCardView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="8dp" app:cardCornerRadius="20dp" app:strokeWidth="0dp">
-                <dev.mahlernim.timelinevisualizer.ui.TimelineView android:id="@+id/timelineView" android:layout_width="match_parent" android:layout_height="360dp" android:background="@color/map_surface" android:contentDescription="@string/timeline_preview" android:minHeight="320dp" />
+                <dev.mahlernim.timelinevisualizer.ui.TimelineView android:id="@+id/timelineView" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_gravity="center_horizontal" android:background="@color/map_surface" android:contentDescription="@string/timeline_preview" />
             </com.google.android.material.card.MaterialCardView>
 
             <SeekBar android:id="@+id/timelineSeek" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:contentDescription="@string/playback_position" android:max="1000" />

--- a/app/src/main/res/layout/screen_settings.xml
+++ b/app/src/main/res/layout/screen_settings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent" android:layout_height="match_parent" android:fillViewport="true">
     <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical" android:paddingStart="20dp" android:paddingTop="20dp" android:paddingEnd="20dp" android:paddingBottom="28dp">
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="@string/settings" android:textAppearance="?attr/textAppearanceHeadlineMedium" android:textStyle="bold" />
@@ -14,9 +14,10 @@
         <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:hint="@string/long_trip_compression">
             <AutoCompleteTextView android:id="@+id/longTripDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
         </com.google.android.material.textfield.TextInputLayout>
-        <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:hint="@string/video_quality">
+        <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:hint="@string/video_format">
             <AutoCompleteTextView android:id="@+id/videoQualityDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
         </com.google.android.material.textfield.TextInputLayout>
+        <TextView android:id="@+id/videoFormatWarningText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:textAppearance="?attr/textAppearanceBodySmall" android:visibility="gone" tools:visibility="visible" />
         <com.google.android.material.button.MaterialButton android:id="@+id/resetAdvancedSettingsButton" style="@style/Widget.Material3.Button.OutlinedButton" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:maxLines="1" android:text="@string/restore_advanced_defaults" />
 
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="24dp" android:text="@string/timeline_processing" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -160,7 +160,7 @@
     <string name="save_as_failed">Eine Kopie des Videos konnte nicht gespeichert werden</string>
     <string name="video_copy_saved">Videokopie gespeichert</string>
     <string name="advanced_settings">Erweiterte Einstellungen</string>
-    <string name="advanced_settings_summary">Wählen Sie Kamerabewegung, Langstrecken-Timing und Exportqualität.</string>
+    <string name="advanced_settings_summary">Wählen Sie Kamerabewegung, Langstrecken-Timing und Exportformat.</string>
     <string name="camera_movement">Kamerabewegung</string>
     <string name="camera_fixed">Fest</string>
     <string name="camera_steady">Stetig</string>
@@ -187,10 +187,13 @@
     <string name="compression_gentle">Sanft · 0,92</string>
     <string name="compression_balanced">Ausgewogen · 0,85</string>
     <string name="compression_strong">Stark · 0,75</string>
-    <string name="video_quality">Videoqualität</string>
-    <string name="quality_standard">Standard · 480p</string>
-    <string name="quality_high">Hoch · 720p</string>
-    <string name="quality_ultra">Ultra · 1080p</string>
+    <string name="video_format">Videoformat</string>
+    <string name="format_square_480">Quadratisch · 480p</string>
+    <string name="format_square_720">Quadratisch · 720p</string>
+    <string name="format_square_1080">Quadratisch · 1080p</string>
+    <string name="format_portrait_1080">Hochformat · 1080×1920</string>
+    <string name="format_landscape_1080">Querformat · 1920×1080</string>
+    <string name="format_not_supported">Dieses Gerät kann keine %1$d×%2$d-Videos erstellen. Wählen Sie ein anderes Format.</string>
     <string name="restore_advanced_defaults">Standardeinstellungen wiederherstellen</string>
     <string name="advanced_defaults_restored">Erweiterte Einstellungen wiederhergestellt</string>
     <string name="use_exact_dates">Wählen Sie genaue Daten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -164,7 +164,7 @@
     <string name="save_as_failed">No se pudo guardar una copia del video.</string>
     <string name="video_copy_saved">Copia de vídeo guardada</string>
     <string name="advanced_settings">Configuraciones avanzadas</string>
-    <string name="advanced_settings_summary">Elija el movimiento de la cámara, el tiempo de viaje largo y la calidad de exportación.</string>
+    <string name="advanced_settings_summary">Elija el movimiento de la cámara, el tiempo de viaje largo y el formato de exportación.</string>
     <string name="camera_movement">Movimiento de cámara</string>
     <string name="camera_fixed">Fija</string>
     <string name="camera_steady">Estable</string>
@@ -191,10 +191,13 @@
     <string name="compression_gentle">Suave · 0.92</string>
     <string name="compression_balanced">Equilibrado · 0,85</string>
     <string name="compression_strong">Fuerte · 0,75</string>
-    <string name="video_quality">Calidad de vídeo</string>
-    <string name="quality_standard">Estándar · 480p</string>
-    <string name="quality_high">Alto · 720p</string>
-    <string name="quality_ultra">Ultra · 1080p</string>
+    <string name="video_format">Formato de vídeo</string>
+    <string name="format_square_480">Cuadrado · 480p</string>
+    <string name="format_square_720">Cuadrado · 720p</string>
+    <string name="format_square_1080">Cuadrado · 1080p</string>
+    <string name="format_portrait_1080">Vertical · 1080×1920</string>
+    <string name="format_landscape_1080">Horizontal · 1920×1080</string>
+    <string name="format_not_supported">Este dispositivo no puede crear vídeos de %1$d×%2$d. Elige otro formato.</string>
     <string name="restore_advanced_defaults">Restaurar valores predeterminados</string>
     <string name="advanced_defaults_restored">Configuración avanzada restaurada</string>
     <string name="use_exact_dates">Elige fechas exactas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -164,7 +164,7 @@
     <string name="save_as_failed">Impossible d\'enregistrer une copie de la vidéo</string>
     <string name="video_copy_saved">Copie vidéo enregistrée</string>
     <string name="advanced_settings">Paramètres avancés</string>
-    <string name="advanced_settings_summary">Choisissez le mouvement de la caméra, la synchronisation des longs trajets et la qualité de l\'exportation.</string>
+    <string name="advanced_settings_summary">Choisissez le mouvement de la caméra, la synchronisation des longs trajets et le format de l\'exportation.</string>
     <string name="camera_movement">Mouvement de caméra</string>
     <string name="camera_fixed">Fixe</string>
     <string name="camera_steady">Fluide</string>
@@ -191,10 +191,13 @@
     <string name="compression_gentle">Doux · 0,92</string>
     <string name="compression_balanced">Équilibré · 0,85</string>
     <string name="compression_strong">Fort · 0,75</string>
-    <string name="video_quality">Qualité vidéo</string>
-    <string name="quality_standard">Standard · 480p</string>
-    <string name="quality_high">Élevé · 720p</string>
-    <string name="quality_ultra">Ultra · 1080p</string>
+    <string name="video_format">Format vidéo</string>
+    <string name="format_square_480">Carré · 480p</string>
+    <string name="format_square_720">Carré · 720p</string>
+    <string name="format_square_1080">Carré · 1080p</string>
+    <string name="format_portrait_1080">Portrait · 1080×1920</string>
+    <string name="format_landscape_1080">Paysage · 1920×1080</string>
+    <string name="format_not_supported">Cet appareil ne peut pas créer de vidéos %1$d×%2$d. Choisissez un autre format.</string>
     <string name="restore_advanced_defaults">Restaurer les valeurs par défaut</string>
     <string name="advanced_defaults_restored">Paramètres avancés restaurés</string>
     <string name="use_exact_dates">Choisissez les dates exactes</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -156,7 +156,7 @@
     <string name="save_as_failed">動画のコピーを保存できませんでした</string>
     <string name="video_copy_saved">動画のコピーを保存しました</string>
     <string name="advanced_settings">詳細設定</string>
-    <string name="advanced_settings_summary">カメラの動き、長距離の再生時間、書き出し画質を選択します。</string>
+    <string name="advanced_settings_summary">カメラの動き、長距離の再生時間、書き出し形式を選択します。</string>
     <string name="camera_movement">カメラの動き</string>
     <string name="camera_fixed">固定</string>
     <string name="camera_steady">安定</string>
@@ -183,10 +183,13 @@
     <string name="compression_gentle">弱い · 0.92</string>
     <string name="compression_balanced">標準 · 0.85</string>
     <string name="compression_strong">強い · 0.75</string>
-    <string name="video_quality">動画品質</string>
-    <string name="quality_standard">標準 · 480p</string>
-    <string name="quality_high">高画質 · 720p</string>
-    <string name="quality_ultra">最高画質 · 1080p</string>
+    <string name="video_format">動画形式</string>
+    <string name="format_square_480">正方形 · 480p</string>
+    <string name="format_square_720">正方形 · 720p</string>
+    <string name="format_square_1080">正方形 · 1080p</string>
+    <string name="format_portrait_1080">縦向き · 1080×1920</string>
+    <string name="format_landscape_1080">横向き · 1920×1080</string>
+    <string name="format_not_supported">この端末では %1$d×%2$d の動画を作成できません。別の形式を選んでください。</string>
     <string name="restore_advanced_defaults">初期設定に戻す</string>
     <string name="advanced_defaults_restored">詳細設定を初期値に戻しました</string>
     <string name="use_exact_dates">日付を指定</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -156,7 +156,7 @@
     <string name="save_as_failed">영상 사본을 저장하지 못했습니다</string>
     <string name="video_copy_saved">영상 사본 저장 완료</string>
     <string name="advanced_settings">고급 설정</string>
-    <string name="advanced_settings_summary">카메라 움직임, 장거리 재생 시간, 내보내기 화질을 선택합니다.</string>
+    <string name="advanced_settings_summary">카메라 움직임, 장거리 재생 시간, 내보내기 형식을 선택합니다.</string>
     <string name="camera_movement">카메라 움직임</string>
     <string name="camera_fixed">고정</string>
     <string name="camera_steady">안정적</string>
@@ -183,10 +183,13 @@
     <string name="compression_gentle">약하게 · 0.92</string>
     <string name="compression_balanced">균형 · 0.85</string>
     <string name="compression_strong">강하게 · 0.75</string>
-    <string name="video_quality">동영상 화질</string>
-    <string name="quality_standard">표준 · 480p</string>
-    <string name="quality_high">고화질 · 720p</string>
-    <string name="quality_ultra">최고 화질 · 1080p</string>
+    <string name="video_format">동영상 형식</string>
+    <string name="format_square_480">정사각형 · 480p</string>
+    <string name="format_square_720">정사각형 · 720p</string>
+    <string name="format_square_1080">정사각형 · 1080p</string>
+    <string name="format_portrait_1080">세로 · 1080×1920</string>
+    <string name="format_landscape_1080">가로 · 1920×1080</string>
+    <string name="format_not_supported">이 기기에서는 %1$d×%2$d 동영상을 만들 수 없습니다. 다른 형식을 선택하세요.</string>
     <string name="restore_advanced_defaults">기본값 복원</string>
     <string name="advanced_defaults_restored">고급 설정을 복원했습니다</string>
     <string name="use_exact_dates">정확한 날짜 선택</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -164,7 +164,7 @@
     <string name="save_as_failed">Não foi possível salvar uma cópia do vídeo</string>
     <string name="video_copy_saved">Cópia do vídeo salva</string>
     <string name="advanced_settings">Configurações avançadas</string>
-    <string name="advanced_settings_summary">Escolha o movimento da câmera, o tempo da viagem longa e a qualidade da exportação.</string>
+    <string name="advanced_settings_summary">Escolha o movimento da câmera, o tempo da viagem longa e o formato de exportação.</string>
     <string name="camera_movement">Movimento da câmera</string>
     <string name="camera_fixed">Fixo</string>
     <string name="camera_steady">Estável</string>
@@ -191,10 +191,13 @@
     <string name="compression_gentle">Suave · 0,92</string>
     <string name="compression_balanced">Equilibrado · 0,85</string>
     <string name="compression_strong">Forte · 0,75</string>
-    <string name="video_quality">Qualidade de vídeo</string>
-    <string name="quality_standard">Padrão · 480p</string>
-    <string name="quality_high">Alto · 720p</string>
-    <string name="quality_ultra">Ultra-rápido · 1080p</string>
+    <string name="video_format">Formato de vídeo</string>
+    <string name="format_square_480">Quadrado · 480p</string>
+    <string name="format_square_720">Quadrado · 720p</string>
+    <string name="format_square_1080">Quadrado · 1080p</string>
+    <string name="format_portrait_1080">Retrato · 1080×1920</string>
+    <string name="format_landscape_1080">Paisagem · 1920×1080</string>
+    <string name="format_not_supported">Este dispositivo não consegue criar vídeos de %1$d×%2$d. Escolha outro formato.</string>
     <string name="restore_advanced_defaults">Restaurar padrões</string>
     <string name="advanced_defaults_restored">Configurações avançadas restauradas</string>
     <string name="use_exact_dates">Selecionar datas exatas</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -157,7 +157,7 @@
     <string name="save_as_failed">无法保存视频的副本</string>
     <string name="video_copy_saved">视频副本已保存</string>
     <string name="advanced_settings">高级设置</string>
-    <string name="advanced_settings_summary">选择相机移动、长途拍摄时间和导出质量。</string>
+    <string name="advanced_settings_summary">选择相机移动、长途拍摄时间和导出格式。</string>
     <string name="camera_movement">镜头移动</string>
     <string name="camera_fixed">固定</string>
     <string name="camera_steady">平稳</string>
@@ -184,10 +184,13 @@
     <string name="compression_gentle">温柔·0.92</string>
     <string name="compression_balanced">均衡 · 0.85</string>
     <string name="compression_strong">强·0.75</string>
-    <string name="video_quality">视频画质</string>
-    <string name="quality_standard">标准·480p</string>
-    <string name="quality_high">高·720p</string>
-    <string name="quality_ultra">超·1080p</string>
+    <string name="video_format">视频格式</string>
+    <string name="format_square_480">正方形·480p</string>
+    <string name="format_square_720">正方形·720p</string>
+    <string name="format_square_1080">正方形·1080p</string>
+    <string name="format_portrait_1080">竖屏·1080×1920</string>
+    <string name="format_landscape_1080">横屏·1920×1080</string>
+    <string name="format_not_supported">此设备无法制作 %1$d×%2$d 的视频。请选择其他格式。</string>
     <string name="restore_advanced_defaults">恢复默认设置</string>
     <string name="advanced_defaults_restored">高级设置已恢复</string>
     <string name="use_exact_dates">选择具体日期</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -157,7 +157,7 @@
     <string name="save_as_failed">無法儲存影片的副本</string>
     <string name="video_copy_saved">影片副本已儲存</string>
     <string name="advanced_settings">進階設定</string>
-    <string name="advanced_settings_summary">選擇相機移動、長途拍攝時間和匯出品質。</string>
+    <string name="advanced_settings_summary">選擇相機移動、長途拍攝時間和匯出格式。</string>
     <string name="camera_movement">鏡頭移動</string>
     <string name="camera_fixed">固定</string>
     <string name="camera_steady">平穩</string>
@@ -184,10 +184,13 @@
     <string name="compression_gentle">溫柔·0.92</string>
     <string name="compression_balanced">均衡 · 0.85</string>
     <string name="compression_strong">強·0.75</string>
-    <string name="video_quality">影片畫質</string>
-    <string name="quality_standard">標準·480p</string>
-    <string name="quality_high">高·720p</string>
-    <string name="quality_ultra">超·1080p</string>
+    <string name="video_format">影片格式</string>
+    <string name="format_square_480">正方形·480p</string>
+    <string name="format_square_720">正方形·720p</string>
+    <string name="format_square_1080">正方形·1080p</string>
+    <string name="format_portrait_1080">直式·1080×1920</string>
+    <string name="format_landscape_1080">橫式·1920×1080</string>
+    <string name="format_not_supported">此裝置無法製作 %1$d×%2$d 的影片。請選擇其他格式。</string>
     <string name="restore_advanced_defaults">恢復預設設定</string>
     <string name="advanced_defaults_restored">進階設定已恢復</string>
     <string name="use_exact_dates">選擇確切日期</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,7 +166,7 @@
     <string name="save_as_failed">Could not save a copy of the video</string>
     <string name="video_copy_saved">Video copy saved</string>
     <string name="advanced_settings">Advanced settings</string>
-    <string name="advanced_settings_summary">Choose camera movement, long-trip timing, and export quality.</string>
+    <string name="advanced_settings_summary">Choose camera movement, long-trip timing, and export format.</string>
     <string name="camera_movement">Camera movement</string>
     <string name="camera_fixed">Fixed</string>
     <string name="camera_steady">Steady</string>
@@ -193,10 +193,13 @@
     <string name="compression_gentle">Gentle · 0.92</string>
     <string name="compression_balanced">Balanced · 0.85</string>
     <string name="compression_strong">Strong · 0.75</string>
-    <string name="video_quality">Video quality</string>
-    <string name="quality_standard">Standard · 480p</string>
-    <string name="quality_high">High · 720p</string>
-    <string name="quality_ultra">Ultra · 1080p</string>
+    <string name="video_format">Video format</string>
+    <string name="format_square_480">Square · 480p</string>
+    <string name="format_square_720">Square · 720p</string>
+    <string name="format_square_1080">Square · 1080p</string>
+    <string name="format_portrait_1080">Portrait · 1080×1920</string>
+    <string name="format_landscape_1080">Landscape · 1920×1080</string>
+    <string name="format_not_supported">This device cannot create %1$d×%2$d videos. Choose another format.</string>
     <string name="restore_advanced_defaults">Restore defaults</string>
     <string name="advanced_defaults_restored">Advanced settings restored</string>
     <string name="use_exact_dates">Choose exact dates</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -28,6 +28,9 @@ import dev.mahlernim.timelinevisualizer.export.VideoExportStatus
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
+import dev.mahlernim.timelinevisualizer.render.VideoQuality
+import dev.mahlernim.timelinevisualizer.ui.CameraSettingsPreferences
+import dev.mahlernim.timelinevisualizer.ui.TimelineView
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -292,12 +295,29 @@ class MainActivityTest {
             activity.findViewById<AutoCompleteTextView>(R.id.longTripDropdown).text.toString(),
         )
         assertEquals(
-            activity.getString(R.string.quality_standard),
+            activity.getString(R.string.format_square_480),
             activity.findViewById<AutoCompleteTextView>(R.id.videoQualityDropdown).text.toString(),
         )
         assertEquals(
             activity.getString(R.string.location_filter_conservative),
             activity.findViewById<AutoCompleteTextView>(R.id.locationFilterDropdown).text.toString(),
+        )
+    }
+
+    @Test
+    fun portraitFormatUpdatesTheStoredSettingAndPreviewShape() {
+        val activity = launchActivity()
+        activity.findViewById<View>(R.id.navigationSettings).performClick()
+        val dropdown = activity.findViewById<AutoCompleteTextView>(R.id.videoQualityDropdown)
+
+        dropdown.onItemClickListener?.onItemClick(null, null, VideoQuality.PORTRAIT.ordinal, 0L)
+
+        assertEquals(activity.getString(R.string.format_portrait_1080), dropdown.text.toString())
+        assertEquals(VideoQuality.PORTRAIT, CameraSettingsPreferences(activity).load().videoQuality)
+        assertEquals(
+            VideoQuality.PORTRAIT.aspectRatio,
+            activity.findViewById<TimelineView>(R.id.timelineView).previewAspectRatio,
+            0.001f,
         )
     }
 

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/Mp4ExporterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/Mp4ExporterTest.kt
@@ -1,0 +1,19 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import dev.mahlernim.timelinevisualizer.render.VideoQuality
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class Mp4ExporterTest {
+    @Test
+    fun overviewImageMatchesTheSelectedAspect() {
+        assertEquals(1080, Mp4Exporter.overviewWidth(VideoQuality.STANDARD))
+        assertEquals(1080, Mp4Exporter.overviewHeight(VideoQuality.STANDARD))
+
+        assertEquals(608, Mp4Exporter.overviewWidth(VideoQuality.PORTRAIT))
+        assertEquals(1080, Mp4Exporter.overviewHeight(VideoQuality.PORTRAIT))
+
+        assertEquals(1080, Mp4Exporter.overviewWidth(VideoQuality.LANDSCAPE))
+        assertEquals(608, Mp4Exporter.overviewHeight(VideoQuality.LANDSCAPE))
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoEncoderSupportTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoEncoderSupportTest.kt
@@ -1,0 +1,59 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import android.media.MediaCodecInfo
+import dev.mahlernim.timelinevisualizer.render.VideoQuality
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoEncoderSupportTest {
+    @Test
+    fun acceptsSquarePortraitAndLandscapeWhenTheEncoderSupportsThem() {
+        val profile = profile()
+
+        VideoQuality.values().forEach { format ->
+            assertTrue(format.name, VideoEncoderSupport.select(format, listOf(profile)) is EncoderSupport.Supported)
+        }
+    }
+
+    @Test
+    fun reportsUnsupportedFrameRateWithoutSubstitution() {
+        val profile = profile(maxFrameRate = 24.0)
+
+        val result = VideoEncoderSupport.select(VideoQuality.PORTRAIT, listOf(profile))
+
+        assertEquals(
+            EncoderSupport.Unsupported(EncoderSupport.Reason.FRAME_RATE),
+            result,
+        )
+    }
+
+    @Test
+    fun rejectsMissingColorLayoutAndEmptyEncoderLists() {
+        val missingColor = VideoEncoderSupport.select(
+            VideoQuality.LANDSCAPE,
+            listOf(profile(colorFormats = emptySet())),
+        )
+
+        assertEquals(EncoderSupport.Unsupported(EncoderSupport.Reason.COLOR_FORMAT), missingColor)
+        assertEquals(
+            EncoderSupport.Unsupported(EncoderSupport.Reason.NO_ENCODER),
+            VideoEncoderSupport.select(VideoQuality.STANDARD, emptyList()),
+        )
+    }
+
+    private fun profile(
+        maxFrameRate: Double = 60.0,
+        colorFormats: Set<Int> = setOf(MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar),
+    ) = EncoderProfile(
+        name = "test.encoder",
+        hardwareAccelerated = true,
+        widthRange = 240..3840,
+        heightRange = 240..3840,
+        widthAlignment = 2,
+        heightAlignment = 2,
+        bitrateRange = 1_000_000..20_000_000,
+        maxFrameRateFor = { _, _ -> maxFrameRate },
+        colorFormats = colorFormats,
+    )
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequestStoreTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequestStoreTest.kt
@@ -81,6 +81,23 @@ class VideoExportRequestStoreTest {
     }
 
     @Test
+    fun restoresPortraitAndLandscapePendingExports() {
+        listOf(VideoQuality.PORTRAIT, VideoQuality.LANDSCAPE).forEach { format ->
+            val request = VideoExportRequest(
+                outputUri = "content://documents/${format.name.lowercase()}.mp4",
+                journey = Journey.from(emptyList(), 2026),
+                title = format.name,
+                durationSeconds = 30,
+                cameraSettings = CameraSettings(videoQuality = format),
+            )
+
+            store.save(request)
+
+            assertEquals(format, store.load()!!.cameraSettings.videoQuality)
+        }
+    }
+
+    @Test
     fun readsVersionOneAsASameYearEnglishRequest() {
         val requestFile = File(context.filesDir, "pending-video-export.bin")
         DataOutputStream(requestFile.outputStream().buffered()).use { output ->

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
@@ -152,6 +152,23 @@ class TimelinePainterTest {
     }
 
     @Test
+    fun titleCardFitsAndStaysProportionateInEveryExportShape() {
+        val painter = TimelinePainter()
+        listOf(480 to 480, 1080 to 1080, 1080 to 1920, 1920 to 1080).forEach { (width, height) ->
+            val card = painter.overlayCard(width, height)
+
+            assertTrue("Card escaped ${width}x$height", card.left >= 0f && card.right <= width)
+            assertTrue("Card escaped ${width}x$height", card.top >= 0f && card.bottom <= height)
+            assertEquals(width / 2f, card.centerX(), 0.5f)
+        }
+
+        val square = painter.overlayCard(1080, 1080)
+        val landscape = painter.overlayCard(1920, 1080)
+        assertEquals(square.width(), landscape.width(), 0.5f)
+        assertTrue(landscape.width() < 1920 * 0.75f)
+    }
+
+    @Test
     fun indexedCameraBoundsMatchThePreviousRouteScan() {
         val routes = listOf(
             List(2_000) { index ->

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/VideoQualityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/VideoQualityTest.kt
@@ -1,0 +1,27 @@
+package dev.mahlernim.timelinevisualizer.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoQualityTest {
+    @Test
+    fun squareDefaultsRemainCompatible() {
+        assertEquals(listOf(480, 720, 1080), VideoQuality.values().take(3).map(VideoQuality::width))
+        assertTrue(VideoQuality.values().take(3).all { it.width == it.height && it.frameRate == 24 })
+        assertEquals(VideoQuality.STANDARD, CameraSettings.DEFAULT.videoQuality)
+    }
+
+    @Test
+    fun socialPresetsHaveReciprocalAspectsAndEvenDimensions() {
+        val portrait = VideoQuality.PORTRAIT
+        val landscape = VideoQuality.LANDSCAPE
+
+        assertEquals(portrait.aspectRatio, 1f / landscape.aspectRatio, 0.0001f)
+        listOf(portrait, landscape).forEach { format ->
+            assertEquals(0, format.width % 2)
+            assertEquals(0, format.height % 2)
+            assertEquals(30, format.frameRate)
+        }
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/CameraSettingsPreferencesTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/CameraSettingsPreferencesTest.kt
@@ -50,4 +50,13 @@ class CameraSettingsPreferencesTest {
         assertEquals(LongTripCompression.BALANCED, preferences.load().longTripCompression)
         assertEquals(VideoQuality.STANDARD, preferences.load().videoQuality)
     }
+
+    @Test
+    fun savesAndRestoresPortraitAndLandscapeFormats() {
+        listOf(VideoQuality.PORTRAIT, VideoQuality.LANDSCAPE).forEach { format ->
+            preferences.save(CameraSettings(videoQuality = format))
+
+            assertEquals(format, CameraSettingsPreferences(context).load().videoQuality)
+        }
+    }
 }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/TimelineViewTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/TimelineViewTest.kt
@@ -1,0 +1,27 @@
+package dev.mahlernim.timelinevisualizer.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TimelineViewTest {
+    @Test
+    fun previewSizePreservesEveryExportAspect() {
+        listOf(1f, 9f / 16f, 16f / 9f).forEach { aspect ->
+            val (width, height) = TimelineView.previewSize(1080, 1380, aspect)
+
+            assertTrue(width <= 1080)
+            assertTrue(height <= 1380)
+            assertEquals(aspect, width.toFloat() / height, 0.002f)
+        }
+    }
+
+    @Test
+    fun landscapePreviewDoesNotDistortWhenItIsShorterThanTheOldMinimum() {
+        val (width, height) = TimelineView.previewSize(1080, 1380, 16f / 9f)
+
+        assertEquals(1080, width)
+        assertEquals(608, height)
+        assertEquals(16f / 9f, width.toFloat() / height, 0.002f)
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/VideoMediaTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/VideoMediaTest.kt
@@ -46,10 +46,33 @@ class VideoMediaTest {
         }
     }
 
+    @Test
+    fun portraitAndLandscapeOverviewsKeepTheirThumbnailAspect() {
+        listOf(
+            Triple(608 to 1080, 180, 320),
+            Triple(1080 to 608, 320, 180),
+        ).forEachIndexed { index, (source, expectedWidth, expectedHeight) ->
+            val uri = Uri.parse("content://example/generated-format-$index")
+            val overview = Bitmap.createBitmap(source.first, source.second, Bitmap.Config.ARGB_8888)
+            try {
+                media.saveGeneratedOverview(uri, overview)
+
+                val thumbnail = media.loadThumbnail(uri)
+                assertNotNull(thumbnail)
+                assertEquals(expectedWidth, thumbnail!!.width)
+                assertEquals(expectedHeight, thumbnail.height)
+                thumbnail.recycle()
+            } finally {
+                overview.recycle()
+                media.deleteThumbnail(uri)
+                media.deleteOverview(uri)
+            }
+        }
+    }
+
     companion object {
         private val PNG_HEADER = byteArrayOf(
             0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
         )
     }
 }
-

--- a/docs/release-notes-v2.2.0.md
+++ b/docs/release-notes-v2.2.0.md
@@ -1,0 +1,59 @@
+# Timeline Visualizer 2.2.0
+
+Create square, portrait, or landscape travel videos. The preview and journey overview
+now match the selected shape, while unsupported formats are identified before video
+creation begins. Existing square settings remain unchanged.
+
+Format-preset design and implementation were contributed by Rafiqi Rachmat
+([@akunlainfiqi](https://github.com/akunlainfiqi)) in PR #57 and integrated by the
+maintainer for this release.
+
+## 한국어
+
+정사각형, 세로 또는 가로 여행 영상을 만들 수 있습니다. 미리보기와 여정 개요가 선택한
+형식에 맞게 표시되며, 지원하지 않는 형식은 영상 만들기 전에 안내합니다. 기존 정사각형
+설정은 그대로 유지됩니다.
+
+## 日本語
+
+正方形、縦向き、横向きの旅行動画を作成できるようになりました。プレビューと旅程の
+概要は選択した形式に合わせて表示され、未対応の形式は動画作成前に案内されます。
+既存の正方形設定はそのまま維持されます。
+
+## 简体中文
+
+现在可以制作正方形、竖屏或横屏旅行视频。预览和旅程概览会匹配所选格式，并在开始
+制作视频前提示不受支持的格式。现有正方形设置保持不变。
+
+## 繁體中文
+
+現在可以製作正方形、直式或橫式旅行影片。預覽和旅程概覽會符合所選格式，並在開始
+製作影片前提示不支援的格式。現有正方形設定保持不變。
+
+## Español
+
+Ahora puede crear vídeos de viajes cuadrados, verticales u horizontales. La vista
+previa y el resumen del viaje coinciden con el formato elegido, y los formatos no
+compatibles se indican antes de crear el vídeo. La configuración cuadrada existente
+no cambia.
+
+## Français
+
+Vous pouvez désormais créer des vidéos de voyage carrées, verticales ou horizontales.
+L’aperçu et la vue d’ensemble du trajet correspondent au format choisi, et les formats
+non pris en charge sont signalés avant la création. Les réglages carrés existants ne
+changent pas.
+
+## Deutsch
+
+Reisevideos können jetzt quadratisch, im Hochformat oder im Querformat erstellt
+werden. Vorschau und Reiseübersicht entsprechen dem gewählten Format. Nicht
+unterstützte Formate werden vor der Erstellung gemeldet. Bestehende quadratische
+Einstellungen bleiben unverändert.
+
+## Português (Brasil)
+
+Agora é possível criar vídeos de viagem quadrados, verticais ou horizontais. A
+pré-visualização e o resumo da viagem correspondem ao formato escolhido, e formatos
+incompatíveis são informados antes da criação. As configurações quadradas existentes
+permanecem inalteradas.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.1.3` and version code `18`
+- Version name `2.2.0` and version code `19`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- add fixed portrait 1080 x 1920 and landscape 1920 x 1080 export presets
- retain the existing square presets and default behavior
- make the preview follow the selected export aspect ratio
- check H.264 encoder dimensions, alignment, frame rate, bitrate, and color format before enabling export
- adapt title cards, markers, and overview rendering for non-square frames
- add localized labels and errors across all nine supported locales
- prepare the minor version update as v2.2.0, version code 19

## Scope and credit

This intentionally implements only the fixed-format portion of #57. Custom dimensions, 4K, 60 fps, and parallel rendering remain deferred until there is demonstrated demand and a safe compatibility design.

The proposal and initial implementation direction came from #57 by @akunlainfiqi. Fiqi is credited as a coauthor in the commit, changelog, and release notes.

## Compatibility

Existing square preference values and pending export records continue to deserialize without migration. Unsupported formats are disabled with a localized explanation before export begins.

## Validation

- `./gradlew test lint assembleGithubDebug assemblePlayDebug --stacktrace`
- 22 Python tests
- full API 35 connected test suite, 4 tests with no failures
- direct MediaCodec configuration for every reported supported preset on API 35
- manual settings and format-menu visual inspection at 1080 x 1920
- embedded version name and version code inspection for both debug APK flavors
- APK Signature Scheme v2 verification for both debug APK flavors
- `git diff --check`

The release workflow and production signing are intentionally left for the post-merge release step.