### PR TITLE
Fix repeated world wrapping in web journey overviews

### DIFF
--- a/web/src/geo.test.ts
+++ b/web/src/geo.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { cumulativeDistances, project, unwrapWorldPoints, viewportFor } from './geo';
+import {
+  cumulativeDistances,
+  overviewRouteSegments,
+  project,
+  unwrapWorldPoints,
+  viewportFor,
+} from './geo';
 
 describe('geography helpers', () => {
   it('projects valid Web Mercator coordinates', () => {
@@ -10,6 +16,36 @@ describe('geography helpers', () => {
     const points = unwrapWorldPoints([project(0, 179), project(0, -179)]);
     expect(Math.abs(points[1].x - points[0].x)).toBeLessThan(0.01);
     expect(viewportFor(points, 480).maxX - viewportFor(points, 480).minX).toBeLessThan(0.02);
+  });
+
+  it('collapses accumulated world copies for the ending overview', () => {
+    const continuous = [
+      { x: 0.85, y: 0.45 },
+      { x: 1.15, y: 0.46 },
+      { x: 1.50, y: 0.47 },
+      { x: 1.85, y: 0.45 },
+      { x: 2.15, y: 0.46 },
+    ];
+
+    const segments = overviewRouteSegments(continuous);
+    const points = segments.flat();
+    const viewport = viewportFor(points, 480);
+
+    expect(viewport.maxX - viewport.minX).toBeCloseTo(1.28);
+    expect(points.every((point) => point.x >= 1.65 && point.x <= 2.65)).toBe(true);
+  });
+
+  it('splits overview strokes at the wrapped map edge', () => {
+    const segments = overviewRouteSegments([
+      { x: 0.99, y: 0.40 },
+      { x: 0.01, y: 0.42 },
+      { x: 0.50, y: 0.44 },
+    ]);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0].at(-1)?.x).toBeCloseTo(1);
+    expect(segments[1][0].x).toBeCloseTo(0);
+    expect(segments.flat().every((point) => point.x >= 0 && point.x <= 1)).toBe(true);
   });
 
   it('calculates cumulative distance', () => {

--- a/web/src/geo.ts
+++ b/web/src/geo.ts
@@ -22,6 +22,39 @@ export function unwrapWorldPoints(points: WorldPoint[]): WorldPoint[] {
   return output;
 }
 
+function wrapNear(value: number, reference: number): number {
+  return value - Math.floor(value - reference + 0.5);
+}
+
+export function overviewRouteSegments(points: WorldPoint[]): WorldPoint[][] {
+  if (points.length === 0) return [];
+  const referenceX = points.at(-1)?.x ?? 0.5;
+  const lowerEdge = referenceX - 0.5;
+  const upperEdge = referenceX + 0.5;
+  const wrapped = points.map((point) => ({ x: wrapNear(point.x, referenceX), y: point.y }));
+  const segments: WorldPoint[][] = [[wrapped[0]]];
+  for (let index = 1; index < wrapped.length; index += 1) {
+    const previous = wrapped[index - 1];
+    const current = wrapped[index];
+    const active = segments.at(-1)!;
+    const delta = current.x - previous.x;
+    if (Math.abs(delta) <= 0.5) {
+      active.push(current);
+      continue;
+    }
+
+    const crossingRight = delta < -0.5;
+    const adjustedCurrentX = current.x + (crossingRight ? 1 : -1);
+    const exitX = crossingRight ? upperEdge : lowerEdge;
+    const enterX = crossingRight ? lowerEdge : upperEdge;
+    const fraction = (exitX - previous.x) / (adjustedCurrentX - previous.x);
+    const crossingY = previous.y + (current.y - previous.y) * fraction;
+    active.push({ x: exitX, y: crossingY });
+    segments.push([{ x: enterX, y: crossingY }, current]);
+  }
+  return segments;
+}
+
 export function viewportFor(points: WorldPoint[], size: number): Viewport {
   const minPointX = Math.min(...points.map((point) => point.x));
   const maxPointX = Math.max(...points.map((point) => point.x));

--- a/web/src/renderer.ts
+++ b/web/src/renderer.ts
@@ -6,7 +6,7 @@ import {
   overviewViewport,
   worldPositionAtProgress,
 } from './camera';
-import { cumulativeDistances, project, unwrapWorldPoints } from './geo';
+import { cumulativeDistances, overviewRouteSegments, project, unwrapWorldPoints } from './geo';
 import type {
   CameraMovement,
   GeoPoint,
@@ -159,7 +159,11 @@ export async function prepareJourney(
     totalDistanceKm: distances.at(-1) ?? 0,
   };
   const cameraTrack = buildCameraTrack(journey, size, cameraMovement);
-  const endingOverview = overviewViewport(journey, size);
+  const overviewSegments = overviewRouteSegments(worldPoints);
+  const endingOverview = overviewViewport(
+    { ...journey, worldPoints: overviewSegments.flat() },
+    size,
+  );
   const sampleCount = Math.max(
     20,
     Math.min(durationSeconds * 8, Math.max(durationSeconds * 2, Math.ceil(journey.totalDistanceKm / 250))),
@@ -176,7 +180,13 @@ export async function prepareJourney(
     for (const tile of requiredTiles(ending)) required.set(tileKey(tile), tile);
   }
   const tiles = await loadRequiredTiles([...required.values()], signal, onProgress);
-  return { ...journey, cameraTrack, overviewViewport: endingOverview, tiles };
+  return {
+    ...journey,
+    overviewRouteSegments: overviewSegments,
+    cameraTrack,
+    overviewViewport: endingOverview,
+    tiles,
+  };
 }
 
 function pointAtProgress(journey: PreparedJourney, progress: number): { point: WorldPoint; completedIndex: number } {
@@ -267,13 +277,15 @@ export function drawFrame(
     context.globalAlpha = (190 / 255) * easeInOutCubic(frame.outroProgress);
     context.strokeStyle = '#e90064';
     context.lineWidth = 3.5;
-    strokeRoute(
-      context,
-      journey.worldPoints.slice(0, -1),
-      journey.worldPoints.at(-1) ?? current.point,
-      viewport,
-      size,
-    );
+    for (const segment of journey.overviewRouteSegments) {
+      strokeRoute(
+        context,
+        segment.slice(0, -1),
+        segment.at(-1) ?? current.point,
+        viewport,
+        size,
+      );
+    }
     context.restore();
   }
 

--- a/web/src/timeline.test.ts
+++ b/web/src/timeline.test.ts
@@ -112,6 +112,52 @@ describe('parseTimelineJson', () => {
     expect(points.map((point) => point.longitude)).toEqual([179, -179, -178]);
   });
 
+  it('normalizes a reverse-ordered timezone-less segment array', () => {
+    const points = parseTimelineJson([
+      {
+        startTime: '2026-01-03T10:00:00',
+        visit: { topCandidate: { placeLocation: '35,129' } },
+      },
+      {
+        startTime: '2026-01-02T10:00:00',
+        visit: { topCandidate: { placeLocation: '37,127' } },
+      },
+      {
+        startTime: '2026-01-01T10:00:00',
+        visit: { topCandidate: { placeLocation: '33,126' } },
+      },
+    ]);
+
+    expect(points.map(pointDateKey)).toEqual([
+      '2026-01-01',
+      '2026-01-02',
+      '2026-01-03',
+    ]);
+  });
+
+  it('does not let one timezone-less segment preserve an otherwise reverse export', () => {
+    const points = parseTimelineJson([
+      {
+        startTime: '2026-03-10T10:00:00Z',
+        visit: { topCandidate: { placeLocation: '35,129' } },
+      },
+      {
+        startTime: '2026-02-10T10:00:00',
+        visit: { topCandidate: { placeLocation: '37,127' } },
+      },
+      {
+        startTime: '2026-01-10T10:00:00Z',
+        visit: { topCandidate: { placeLocation: '33,126' } },
+      },
+    ]);
+
+    expect(points.map(pointDateKey)).toEqual([
+      '2026-01-10',
+      '2026-02-10',
+      '2026-03-10',
+    ]);
+  });
+
   it('rejects unsupported or empty exports', () => {
     expect(() => parseTimelineJson({ locations: [] })).toThrow(TimelineParseError);
     expect(() => parseTimelineJson([])).toThrow('no usable location points');

--- a/web/src/timeline.ts
+++ b/web/src/timeline.ts
@@ -57,6 +57,13 @@ interface ParsedInstant {
   timeZoneMissing: boolean;
 }
 
+interface ParsedTimelineSegment {
+  anchor: Date | null;
+  points: GeoPoint[];
+}
+
+const SEGMENT_DIRECTION_SIGNAL_MS = 36 * 60 * 60 * 1000;
+
 function parseInstant(value: unknown): ParsedInstant | null {
   if (typeof value !== 'string' || value.trim() === '') return null;
   const raw = value.trim();
@@ -108,6 +115,26 @@ function addPoint(output: GeoPoint[], time: unknown, coordinate: unknown): void 
   });
 }
 
+function normalizeSegmentDirection(segments: ParsedTimelineSegment[]): ParsedTimelineSegment[] {
+  const anchors = segments
+    .map((segment) => segment.anchor?.getTime())
+    .filter((timestamp): timestamp is number => timestamp !== undefined);
+  let ascendingSignals = 0;
+  let descendingSignals = 0;
+  for (let index = 1; index < anchors.length; index += 1) {
+    const delta = anchors[index] - anchors[index - 1];
+    if (Math.abs(delta) < SEGMENT_DIRECTION_SIGNAL_MS) continue;
+    if (delta > 0) ascendingSignals += 1;
+    else descendingSignals += 1;
+  }
+  const endpointDelta = (anchors.at(-1) ?? 0) - (anchors[0] ?? 0);
+  if (Math.abs(endpointDelta) >= SEGMENT_DIRECTION_SIGNAL_MS) {
+    if (endpointDelta > 0) ascendingSignals += 2;
+    else descendingSignals += 2;
+  }
+  return descendingSignals > ascendingSignals ? [...segments].reverse() : segments;
+}
+
 export function parseTimelineJson(data: unknown): GeoPoint[] {
   let segments: unknown[];
   if (Array.isArray(data)) {
@@ -131,18 +158,19 @@ export function parseTimelineJson(data: unknown): GeoPoint[] {
     );
   }
 
-  const points: GeoPoint[] = [];
+  const parsedSegments: ParsedTimelineSegment[] = [];
   for (const rawSegment of segments) {
     if (!isObject(rawSegment)) continue;
     const startTime = rawSegment.startTime;
     const endTime = rawSegment.endTime;
+    const segmentPoints: GeoPoint[] = [];
 
     if (isObject(rawSegment.activity)) {
-      addPoint(points, startTime, rawSegment.activity.start);
+      addPoint(segmentPoints, startTime, rawSegment.activity.start);
     }
 
     if (isObject(rawSegment.visit) && isObject(rawSegment.visit.topCandidate)) {
-      addPoint(points, startTime, rawSegment.visit.topCandidate.placeLocation);
+      addPoint(segmentPoints, startTime, rawSegment.visit.topCandidate.placeLocation);
     }
 
     if (Array.isArray(rawSegment.timelinePath)) {
@@ -153,7 +181,7 @@ export function parseTimelineJson(data: unknown): GeoPoint[] {
         const coordinate = parseCoordinate(rawPathPoint.point);
         if ((absolute || offsetInstant) && coordinate) {
           const segmentStart = absolute ? null : parseInstant(startTime);
-          points.push({
+          segmentPoints.push({
             instant: absolute?.instant ?? offsetInstant!,
             latitude: coordinate[0],
             longitude: coordinate[1],
@@ -166,10 +194,17 @@ export function parseTimelineJson(data: unknown): GeoPoint[] {
     }
 
     if (isObject(rawSegment.activity)) {
-      addPoint(points, endTime, rawSegment.activity.end);
+      addPoint(segmentPoints, endTime, rawSegment.activity.end);
+    }
+    if (segmentPoints.length > 0) {
+      parsedSegments.push({
+        anchor: parseInstant(startTime)?.instant ?? segmentPoints[0].instant,
+        points: segmentPoints,
+      });
     }
   }
 
+  const points = normalizeSegmentDirection(parsedSegments).flatMap((segment) => segment.points);
   const unique = new Map<string, GeoPoint>();
   for (const point of points) {
     const key = `${point.instant.getTime()}:${point.latitude}:${point.longitude}`;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -46,6 +46,7 @@ export interface TimelineFrame {
 export interface PreparedJourney {
   points: GeoPoint[];
   worldPoints: WorldPoint[];
+  overviewRouteSegments: WorldPoint[][];
   cumulativeDistanceKm: number[];
   totalDistanceKm: number;
   cameraTrack: CameraTrack;


### PR DESCRIPTION
## Summary

- normalize clearly reverse-ordered Timeline segment arrays without disturbing close International Date Line transitions
- collapse accumulated world copies into one ending overview interval
- split overview route strokes at the wrapped map edge
- preserve continuous unwrapped coordinates for the moving camera

## Validation

- 32 web tests passed
- TypeScript check passed
- Vite production build passed
- 22 repository tests passed
- local browser preview completed with a synthetic repeated-wrap journey and no browser errors

Fixes #74