### PR TITLE
Fix large web Timeline stack overflow

### DIFF
--- a/web/src/camera.test.ts
+++ b/web/src/camera.test.ts
@@ -112,6 +112,37 @@ describe('camera track', () => {
     });
   });
 
+  it('calculates the same overview above browser argument limits', () => {
+    const endpoints = unwrapWorldPoints([project(70, 20), project(-55, 20)]);
+    const denseJourney = {
+      worldPoints: Array.from({ length: 200_000 }, (_, index) => endpoints[index % endpoints.length]),
+      cumulativeDistanceKm: [],
+      totalDistanceKm: 0,
+    };
+    const endpointJourney = {
+      worldPoints: endpoints,
+      cumulativeDistanceKm: [],
+      totalDistanceKm: 0,
+    };
+
+    expect(overviewViewport(denseJourney, 480)).toEqual(overviewViewport(endpointJourney, 480));
+  });
+
+  it('builds the moving camera above browser argument limits', () => {
+    const point = koreanJourney.worldPoints[0];
+    const pointCount = 130_000;
+    const denseJourney = {
+      worldPoints: Array.from({ length: pointCount }, () => point),
+      cumulativeDistanceKm: new Array<number>(pointCount).fill(0),
+      totalDistanceKm: 0,
+    };
+
+    const track = buildCameraTrack(denseJourney, 480, 'steady');
+
+    expect(track.frames).toHaveLength(481);
+    expect(track.frames.every((frame) => Number.isFinite(frame.spanY))).toBe(true);
+  });
+
   it('blends from the final following view to the full-route ending view', () => {
     const track = buildCameraTrack(koreanJourney, 480, 'dynamic');
     const following = cameraViewportAt(track, 1);

--- a/web/src/camera.ts
+++ b/web/src/camera.ts
@@ -1,4 +1,5 @@
 import type { CameraFrame, CameraMovement, CameraTrack, Viewport, WorldPoint } from './types';
+import { worldBounds } from './geo';
 
 interface CameraMovementProfile {
   contextFraction: number;
@@ -222,12 +223,7 @@ export function overviewSafeArea(size: number): OverviewSafeArea {
 }
 
 export function overviewViewport(journey: CameraJourney, size: number): Viewport {
-  const xs = journey.worldPoints.map((point) => point.x);
-  const ys = journey.worldPoints.map((point) => point.y);
-  const minX = Math.min(...xs);
-  const maxX = Math.max(...xs);
-  const minY = Math.min(...ys);
-  const maxY = Math.max(...ys);
+  const { minX, maxX, minY, maxY } = worldBounds(journey.worldPoints);
   const contentCenterX = (minX + maxX) / 2;
   const contentCenterY = (minY + maxY) / 2;
   const contentSpanX = Math.max(maxX - minX, MIN_OVERVIEW_VIEWPORT_SPAN);
@@ -319,10 +315,19 @@ function rawViewport(
   focus.push(current.point, worldPositionAtDistance(journey, lookaheadDistance).point);
 
   const centerX = current.point.x;
-  const wrappedX = focus.map((point) => unwrapNear(point.x, centerX));
-  const ys = focus.map((point) => point.y);
-  const contentSpanX = Math.max(0.00015, Math.max(...wrappedX) - Math.min(...wrappedX));
-  const contentSpanY = Math.max(0.00015, Math.max(...ys) - Math.min(...ys));
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const point of focus) {
+    const x = unwrapNear(point.x, centerX);
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (point.y < minY) minY = point.y;
+    if (point.y > maxY) maxY = point.y;
+  }
+  const contentSpanX = Math.max(0.00015, maxX - minX);
+  const contentSpanY = Math.max(0.00015, maxY - minY);
   const aspect = 1;
   const spanY = clamp(
     Math.max(contentSpanY * padding, contentSpanX * padding / aspect),

--- a/web/src/geo.test.ts
+++ b/web/src/geo.test.ts
@@ -48,6 +48,13 @@ describe('geography helpers', () => {
     expect(segments.flat().every((point) => point.x >= 0 && point.x <= 1)).toBe(true);
   });
 
+  it('calculates the same viewport for a point count above browser argument limits', () => {
+    const endpoints = [project(70, 20), project(-55, 20)];
+    const points = Array.from({ length: 200_000 }, (_, index) => endpoints[index % endpoints.length]);
+
+    expect(viewportFor(points, 480)).toEqual(viewportFor(endpoints, 480));
+  });
+
   it('calculates cumulative distance', () => {
     const points = [
       { instant: new Date(0), latitude: 37.5665, longitude: 126.978 },

--- a/web/src/geo.ts
+++ b/web/src/geo.ts
@@ -55,11 +55,32 @@ export function overviewRouteSegments(points: WorldPoint[]): WorldPoint[][] {
   return segments;
 }
 
+export function worldBounds(points: WorldPoint[]): {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+} {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const point of points) {
+    if (point.x < minX) minX = point.x;
+    if (point.x > maxX) maxX = point.x;
+    if (point.y < minY) minY = point.y;
+    if (point.y > maxY) maxY = point.y;
+  }
+  return { minX, maxX, minY, maxY };
+}
+
 export function viewportFor(points: WorldPoint[], size: number): Viewport {
-  const minPointX = Math.min(...points.map((point) => point.x));
-  const maxPointX = Math.max(...points.map((point) => point.x));
-  const minPointY = Math.min(...points.map((point) => point.y));
-  const maxPointY = Math.max(...points.map((point) => point.y));
+  const {
+    minX: minPointX,
+    maxX: maxPointX,
+    minY: minPointY,
+    maxY: maxPointY,
+  } = worldBounds(points);
   const centerX = (minPointX + maxPointX) / 2;
   const centerY = (minPointY + maxPointY) / 2;
   const span = Math.max(maxPointX - minPointX, maxPointY - minPointY, 0.002) * 1.28;


### PR DESCRIPTION
## Problem

Large or point-dense Timeline selections can fail during web video preparation with `Maximum call stack size exceeded`. Camera bounds use spread arguments with every selected coordinate, which exceeds browser argument limits.

## Fix

- Calculate world and camera bounds with bounded iterative comparisons
- Preserve coordinate order, route geometry, camera behavior, and video output
- Avoid temporary coordinate arrays in the moving-camera path
- Keep Android versions unchanged

## Validation

- `pnpm test` with 35 passing tests on the final merged base
- `pnpm typecheck`
- `pnpm build`
- 130,000-point moving-camera regression
- 200,000-point north-to-south overview regression
- No unsafe spread-based extrema calls in source or the production bundle