### PR TITLE
Add an option to use raw GPS signals

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -44,6 +44,7 @@ import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import dev.mahlernim.timelinevisualizer.data.LocationFilterMode
 import dev.mahlernim.timelinevisualizer.data.LocationOutlierFilter
+import dev.mahlernim.timelinevisualizer.data.RawSignalPoint
 import dev.mahlernim.timelinevisualizer.data.TimelineParseException
 import dev.mahlernim.timelinevisualizer.data.TimelineParseReason
 import dev.mahlernim.timelinevisualizer.data.TimelineParser
@@ -66,6 +67,7 @@ import dev.mahlernim.timelinevisualizer.export.EncoderSupport
 import dev.mahlernim.timelinevisualizer.export.VideoEncoderSupport
 import dev.mahlernim.timelinevisualizer.export.describe
 import dev.mahlernim.timelinevisualizer.model.Journey
+import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Timeline
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
 import dev.mahlernim.timelinevisualizer.model.TitleTemplate
@@ -98,6 +100,7 @@ import java.time.YearMonth
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import androidx.core.util.Pair as AndroidPair
@@ -111,6 +114,8 @@ class MainActivity : AppCompatActivity() {
     private lateinit var playerScreen: ScreenPlayerBinding
     private var timeline: Timeline? = null
     private var renderTimeline: Timeline? = null
+    private var rawSignalPoints: List<RawSignalPoint> = emptyList()
+    private var renderRawSignalsTimeline: Timeline? = null
     private var journey: Journey? = null
     private var animation: ValueAnimator? = null
     private var pendingExport: VideoExportRequest? = null
@@ -124,6 +129,7 @@ class MainActivity : AppCompatActivity() {
     private var selectedStartMonth = 1
     private var selectedEndMonth = 12
     private var exactDateRangeEnabled = false
+    private var rawSignalsEnabled = false
     private var selectedStartDate: LocalDate? = null
     private var selectedEndDate: LocalDate? = null
     private val titleHandler = Handler(Looper.getMainLooper())
@@ -494,7 +500,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun updateResolvedTitle() {
-        val period = currentPeriod() ?: return
+        val period = if (rawSignalsEnabled) journey?.period else currentPeriod()
+        if (period == null) return
         editor.timelineView.videoTitle = resolvedTitle(period)
     }
 
@@ -516,16 +523,19 @@ class MainActivity : AppCompatActivity() {
         importJob = lifecycleScope.launch {
             try {
                 editor.loadingStageText.setText(R.string.reading_timeline)
-                val loaded = withContext(Dispatchers.IO) {
-                    contentResolver.openInputStream(uri)?.use(TimelineParser()::parse)
+                val parsed = withContext(Dispatchers.IO) {
+                    contentResolver.openInputStream(uri)?.use(TimelineParser()::parseWithRawSignals)
                         ?: throw java.io.FileNotFoundException()
                 }
+                val loaded = parsed.timeline
                 editor.loadingStageText.setText(R.string.preparing_trips)
                 val prepared = withContext(Dispatchers.Default) {
                     prepareTimeline(loaded)
                 }
                 timeline = prepared.source
                 renderTimeline = prepared.render
+                rawSignalPoints = parsed.rawSignals
+                rebuildRawSignalsTimeline()
                 pendingImportCompletionUri = uri
                 configureYears(loaded, prepared.initialJourney, prepared.ignoredCount)
                 editor.editorGroup.visibility = View.VISIBLE
@@ -539,6 +549,8 @@ class MainActivity : AppCompatActivity() {
                 pendingImportCompletionUri = null
                 timeline = null
                 renderTimeline = null
+                rawSignalPoints = emptyList()
+                renderRawSignalsTimeline = null
                 if (remembered) {
                     timelineSourceStore.clear()
                     releaseUriAccess(uri)
@@ -554,6 +566,8 @@ class MainActivity : AppCompatActivity() {
                 pendingImportCompletionUri = null
                 timeline = null
                 renderTimeline = null
+                rawSignalPoints = emptyList()
+                renderRawSignalsTimeline = null
                 if (remembered) {
                     timelineSourceStore.clear()
                     releaseUriAccess(uri)
@@ -609,6 +623,11 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
+    private fun filterTimeline(source: Timeline): Timeline {
+        val filtered = LocationOutlierFilter.filter(source.points, locationFilterMode)
+        return if (filtered.points === source.points) source else Timeline(filtered.points)
+    }
+
     private fun configureYears(loaded: Timeline, initialJourney: Journey, ignoredCount: Int) {
         val years = loaded.years
         val labels = years.map { NumberFormat.getIntegerInstance().apply { isGroupingUsed = false }.format(it) }
@@ -627,16 +646,27 @@ class MainActivity : AppCompatActivity() {
         selectedStartYear = years.first()
         selectedEndYear = years.first()
         exactDateRangeEnabled = false
+        rawSignalsEnabled = false
         selectedStartDate = null
         selectedEndDate = null
         editor.exactDateSwitch.isChecked = false
+        editor.rawSignalsSwitch.isChecked = false
+        editor.rawAccuracyInput.setText(DEFAULT_RAW_ACCURACY_METERS.toString())
+        editor.rawSignalsSwitch.visibility = if (rawSignalPoints.isNotEmpty()) View.VISIBLE else View.GONE
         updateExactDateControls()
+        updateRawSignalsControls()
         updateYearDropdowns()
         updateResolvedTitle()
         applySelectedJourney(initialJourney, ignoredCount)
     }
 
     private fun selectRange() {
+        if (rawSignalsEnabled) {
+            val period = rawSignalsPeriod() ?: return
+            val selected = renderRawSignalsTimeline?.forRange(period) ?: Journey.from(emptyList(), period)
+            applySelectedJourney(selected, 0)
+            return
+        }
         val period = currentPeriod() ?: return
         val selected = if (exactDateRangeEnabled) {
             val start = selectedStartDate ?: return
@@ -673,6 +703,13 @@ class MainActivity : AppCompatActivity() {
             return withOutlierSummary(
                 getString(R.string.selected_period_no_movement, number.format(selected.points.size)),
                 ignoredCount,
+            )
+        }
+        if (rawSignalsEnabled) {
+            return getString(
+                R.string.raw_signals_summary,
+                number.format(selected.points.size),
+                number.format(selected.totalDistanceKm),
             )
         }
         val range = selected.period
@@ -755,7 +792,51 @@ class MainActivity : AppCompatActivity() {
             selectRange()
         }
         editor.exactDateRangeButton.setOnClickListener { showExactDatePicker() }
+        editor.rawSignalsSwitch.setOnCheckedChangeListener { _, checked ->
+            rawSignalsEnabled = checked && rawSignalPoints.isNotEmpty()
+            rebuildRawSignalsTimeline()
+            updateRawSignalsControls()
+            updateResolvedTitle()
+            selectRange()
+        }
+        editor.rawAccuracyInput.doAfterTextChanged {
+            if (rawSignalsEnabled) {
+                rebuildRawSignalsTimeline()
+                selectRange()
+            }
+        }
         updateExactDateControls()
+        updateRawSignalsControls()
+    }
+
+    private fun updateRawSignalsControls() {
+        editor.periodDateControlsGroup.visibility = if (rawSignalsEnabled) View.GONE else View.VISIBLE
+        editor.exactDateSwitch.visibility = if (rawSignalsEnabled) View.GONE else View.VISIBLE
+        editor.exactDateRangeButton.visibility = if (!rawSignalsEnabled && exactDateRangeEnabled) View.VISIBLE else View.GONE
+        editor.rawSignalsDescription.visibility = if (rawSignalsEnabled) View.VISIBLE else View.GONE
+        editor.rawAccuracyLayout.visibility = if (rawSignalsEnabled) View.VISIBLE else View.GONE
+    }
+
+    private fun rebuildRawSignalsTimeline() {
+        val maximumAccuracy = editor.rawAccuracyInput.text?.toString()?.trim().orEmpty()
+            .takeIf(String::isNotEmpty)
+            ?.toDoubleOrNull()
+        val selected = rawSignalPoints.asSequence()
+            .filter { maximumAccuracy == null || it.accuracyMeters <= maximumAccuracy }
+            .map(RawSignalPoint::point)
+            .toList()
+        renderRawSignalsTimeline = selected.takeIf(List<GeoPoint>::isNotEmpty)
+            ?.let(::Timeline)
+            ?.let(::filterTimeline)
+    }
+
+    private fun rawSignalsPeriod(): TimelinePeriod? {
+        if (rawSignalPoints.isEmpty()) return null
+        val zone = ZoneId.systemDefault()
+        return TimelinePeriod(
+            YearMonth.from(rawSignalPoints.first().point.instant.atZone(zone)),
+            YearMonth.from(rawSignalPoints.last().point.instant.atZone(zone)),
+        )
     }
 
     private fun showExactDatePicker() {
@@ -1046,6 +1127,7 @@ class MainActivity : AppCompatActivity() {
         }
         val result = LocationOutlierFilter.filter(source.points, locationFilterMode)
         renderTimeline = Timeline(result.points)
+        rebuildRawSignalsTimeline()
         if (reselect && selectedStartYear != null && selectedEndYear != null) selectRange()
     }
 
@@ -1337,6 +1419,8 @@ class MainActivity : AppCompatActivity() {
         editor.startMonthDropdown.isEnabled = !exporting
         editor.endMonthDropdown.isEnabled = !exporting
         editor.exactDateSwitch.isEnabled = !exporting
+        editor.rawSignalsSwitch.isEnabled = !exporting
+        editor.rawAccuracyInput.isEnabled = !exporting
         editor.exactDateRangeButton.isEnabled = !exporting
         editor.ownerInput.isEnabled = !exporting
         editor.titleInput.isEnabled = !exporting
@@ -1872,6 +1956,7 @@ class MainActivity : AppCompatActivity() {
     )
 
     companion object {
+        private const val DEFAULT_RAW_ACCURACY_METERS = 100
         private const val TITLE_UPDATE_DELAY_MS = 450L
         private const val COLLAPSED_CREATION_COUNT = 3
         private const val MAP_PRIVACY_ACCEPTED = "map_privacy_accepted_v1"

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
@@ -14,8 +14,12 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeParseException
 
 class TimelineParser {
-    fun parse(input: InputStream): Timeline = try {
-        parseSupportedTimeline(input)
+    fun parse(input: InputStream): Timeline = parseDocument(input, includeRawSignals = false).timeline
+
+    fun parseWithRawSignals(input: InputStream): ParsedTimeline = parseDocument(input, includeRawSignals = true)
+
+    private fun parseDocument(input: InputStream, includeRawSignals: Boolean): ParsedTimeline = try {
+        parseSupportedTimeline(input, includeRawSignals)
     } catch (error: TimelineParseException) {
         throw error
     } catch (error: MalformedJsonException) {
@@ -26,8 +30,9 @@ class TimelineParser {
         throw TimelineParseException(TimelineParseReason.MALFORMED_JSON, "Timeline JSON has an invalid structure", error)
     }
 
-    private fun parseSupportedTimeline(input: InputStream): Timeline {
+    private fun parseSupportedTimeline(input: InputStream, includeRawSignals: Boolean): ParsedTimeline {
         val points = mutableListOf<GeoPoint>()
+        val rawSignalPoints = mutableListOf<RawSignalPoint>()
         JsonReader(InputStreamReader(input, Charsets.UTF_8)).use { reader ->
             reader.strictness = Strictness.LENIENT
             val rootToken = try {
@@ -40,7 +45,11 @@ class TimelineParser {
             }
             when (rootToken) {
                 JsonToken.BEGIN_ARRAY -> readSegments(reader, points)
-                JsonToken.BEGIN_OBJECT -> readRootObject(reader, points)
+                JsonToken.BEGIN_OBJECT -> readRootObject(
+                    reader,
+                    points,
+                    rawSignalPoints.takeIf { includeRawSignals },
+                )
                 else -> throw TimelineParseException(
                     TimelineParseReason.UNSUPPORTED_FORMAT,
                     "Timeline JSON must start with an object or array",
@@ -56,7 +65,15 @@ class TimelineParser {
                 "No supported location points were found in this export",
             )
         }
-        return Timeline(normalized)
+        return ParsedTimeline(
+            timeline = Timeline(normalized),
+            rawSignals = normalizeRawSignals(rawSignalPoints),
+        )
+    }
+
+    private fun normalizeRawSignals(points: MutableList<RawSignalPoint>): List<RawSignalPoint> {
+        points.sortWith(compareBy { it.point.instant })
+        return points.distinctBy { Triple(it.point.instant, it.point.latitude, it.point.longitude) }
     }
 
     private fun normalize(points: MutableList<GeoPoint>): List<GeoPoint> {
@@ -110,7 +127,11 @@ class TimelineParser {
         return points
     }
 
-    private fun readRootObject(reader: JsonReader, points: MutableList<GeoPoint>) {
+    private fun readRootObject(
+        reader: JsonReader,
+        points: MutableList<GeoPoint>,
+        rawSignalPoints: MutableList<RawSignalPoint>?,
+    ) {
         var foundSegments = false
         var foundRawSignals = false
         var foundLegacyFormat = false
@@ -123,7 +144,7 @@ class TimelineParser {
                 }
                 "rawSignals" -> {
                     foundRawSignals = true
-                    reader.skipValue()
+                    if (rawSignalPoints != null) readRawSignals(reader, rawSignalPoints) else reader.skipValue()
                 }
                 "timelineObjects", "locations" -> {
                     foundLegacyFormat = true
@@ -141,6 +162,56 @@ class TimelineParser {
             }
             throw TimelineParseException(reason, "This JSON does not contain semanticSegments")
         }
+    }
+
+    private fun readRawSignals(reader: JsonReader, output: MutableList<RawSignalPoint>) {
+        if (reader.peek() != JsonToken.BEGIN_ARRAY) {
+            reader.skipValue()
+            return
+        }
+        reader.beginArray()
+        while (reader.hasNext()) {
+            if (reader.peek() != JsonToken.BEGIN_OBJECT) {
+                reader.skipValue()
+                continue
+            }
+            var point: RawSignalPoint? = null
+            reader.beginObject()
+            while (reader.hasNext()) {
+                if (reader.nextName() == "position") point = readRawPosition(reader)
+                else reader.skipValue()
+            }
+            reader.endObject()
+            point?.let(output::add)
+        }
+        reader.endArray()
+    }
+
+    private fun readRawPosition(reader: JsonReader): RawSignalPoint? {
+        if (reader.peek() != JsonToken.BEGIN_OBJECT) {
+            reader.skipValue()
+            return null
+        }
+        var coordinate: String? = null
+        var timestamp: String? = null
+        var accuracyMeters: Double? = null
+        reader.beginObject()
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "LatLng", "latLng" -> coordinate = reader.readStringOrNull()
+                "timestamp" -> timestamp = reader.readStringOrNull()
+                "accuracyMeters" -> accuracyMeters = reader.readDoubleOrNull()
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        if (accuracyMeters == null || !accuracyMeters.isFinite() || accuracyMeters < 0.0) return null
+        val instant = parseInstant(timestamp) ?: return null
+        val parsedCoordinate = parseCoordinate(coordinate) ?: return null
+        return RawSignalPoint(
+            point = GeoPoint(instant, parsedCoordinate.first, parsedCoordinate.second),
+            accuracyMeters = accuracyMeters,
+        )
     }
 
     private fun readSegments(reader: JsonReader, points: MutableList<GeoPoint>) {
@@ -307,6 +378,18 @@ class TimelineParser {
         }
     }
 
+    private fun JsonReader.readDoubleOrNull(): Double? = when (peek()) {
+        JsonToken.STRING, JsonToken.NUMBER -> nextString().toDoubleOrNull()
+        JsonToken.NULL -> {
+            nextNull()
+            null
+        }
+        else -> {
+            skipValue()
+            null
+        }
+    }
+
     private fun addPoint(output: MutableList<GeoPoint>, time: String?, rawCoordinate: String?) {
         val instant = parseInstant(time)
         val coordinate = parseCoordinate(rawCoordinate)
@@ -363,7 +446,18 @@ class TimelineParser {
         val time: String?,
         val offsetMinutes: Long?,
     )
+
 }
+
+data class ParsedTimeline(
+    val timeline: Timeline,
+    val rawSignals: List<RawSignalPoint>,
+)
+
+data class RawSignalPoint(
+    val point: GeoPoint,
+    val accuracyMeters: Double,
+)
 
 enum class TimelineParseReason {
     MALFORMED_JSON,

--- a/app/src/main/res/layout/screen_new_video.xml
+++ b/app/src/main/res/layout/screen_new_video.xml
@@ -126,7 +126,13 @@
                 android:textAppearance="?attr/textAppearanceTitleMedium"
                 android:textStyle="bold" />
 
-            <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:baselineAligned="false" android:orientation="horizontal">
+            <LinearLayout
+                android:id="@+id/periodDateControlsGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:baselineAligned="false" android:orientation="horizontal">
                 <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:hint="@string/start_year">
                     <AutoCompleteTextView android:id="@+id/startYearDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
                 </com.google.android.material.textfield.TextInputLayout>
@@ -134,9 +140,9 @@
                 <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:hint="@string/end_year">
                     <AutoCompleteTextView android:id="@+id/endYearDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
                 </com.google.android.material.textfield.TextInputLayout>
-            </LinearLayout>
+                </LinearLayout>
 
-            <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:baselineAligned="false" android:orientation="horizontal">
+                <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:baselineAligned="false" android:orientation="horizontal">
                 <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:hint="@string/start_month">
                     <AutoCompleteTextView android:id="@+id/startMonthDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
                 </com.google.android.material.textfield.TextInputLayout>
@@ -144,6 +150,8 @@
                 <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:hint="@string/end_month">
                     <AutoCompleteTextView android:id="@+id/endMonthDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
                 </com.google.android.material.textfield.TextInputLayout>
+                </LinearLayout>
+
             </LinearLayout>
 
             <TextView
@@ -170,6 +178,42 @@
                 android:maxLines="1"
                 android:text="@string/choose_exact_dates"
                 android:visibility="gone" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/rawSignalsSwitch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/use_raw_gps_signals"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/rawSignalsDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/raw_gps_signals_description"
+                android:textAppearance="?attr/textAppearanceBodySmall"
+                android:visibility="gone" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/rawAccuracyLayout"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="@string/raw_gps_accuracy_limit"
+                app:helperText="@string/raw_gps_accuracy_helper"
+                android:visibility="gone">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/rawAccuracyInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="numberDecimal"
+                    android:maxLines="1"
+                    android:text="100" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="18dp" android:maxLines="1" android:text="@string/video_details" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -197,6 +197,11 @@
     <string name="restore_advanced_defaults">Standardeinstellungen wiederherstellen</string>
     <string name="advanced_defaults_restored">Erweiterte Einstellungen wiederhergestellt</string>
     <string name="use_exact_dates">Wählen Sie genaue Daten</string>
+    <string name="use_raw_gps_signals">GPS-Rohsignale des letzten Monats verwenden</string>
+    <string name="raw_gps_signals_description">Ein Zeitachse-Export enthält normalerweise die GPS-Rohsignale aus ungefähr dem Monat vor dem Exportdatum.</string>
+    <string name="raw_gps_accuracy_limit">Genauigkeitsgrenze (Meter)</string>
+    <string name="raw_gps_accuracy_helper">Ungenauere Signale werden ausgeschlossen. Leer lassen, um alle zu verwenden.</string>
+    <string name="raw_signals_summary">%1$s Punkte · etwa %2$s km</string>
     <string name="choose_exact_dates">Wählen Sie ein Start- und Enddatum</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">Alle Videos löschen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -201,6 +201,11 @@
     <string name="restore_advanced_defaults">Restaurar valores predeterminados</string>
     <string name="advanced_defaults_restored">Configuración avanzada restaurada</string>
     <string name="use_exact_dates">Elige fechas exactas</string>
+    <string name="use_raw_gps_signals">Usar señales GPS sin procesar del último mes</string>
+    <string name="raw_gps_signals_description">Una exportación de Timeline suele incluir las señales GPS sin procesar de aproximadamente el mes anterior a la fecha de exportación.</string>
+    <string name="raw_gps_accuracy_limit">Límite de precisión (metros)</string>
+    <string name="raw_gps_accuracy_helper">Se excluyen las señales menos precisas. Déjalo en blanco para usar todas.</string>
+    <string name="raw_signals_summary">%1$s puntos · aproximadamente %2$s km</string>
     <string name="choose_exact_dates">Seleccione una fecha de inicio y finalización</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">Eliminar todos los vídeos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -201,6 +201,11 @@
     <string name="restore_advanced_defaults">Restaurer les valeurs par défaut</string>
     <string name="advanced_defaults_restored">Paramètres avancés restaurés</string>
     <string name="use_exact_dates">Choisissez les dates exactes</string>
+    <string name="use_raw_gps_signals">Utiliser les signaux GPS bruts du dernier mois</string>
+    <string name="raw_gps_signals_description">Une exportation de Timeline contient généralement les signaux GPS bruts du mois environ précédant la date d’exportation.</string>
+    <string name="raw_gps_accuracy_limit">Limite de précision (mètres)</string>
+    <string name="raw_gps_accuracy_helper">Les signaux moins précis sont exclus. Laissez vide pour tous les utiliser.</string>
+    <string name="raw_signals_summary">%1$s points · environ %2$s km</string>
     <string name="choose_exact_dates">Sélectionnez une date de début et de fin</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">Supprimer toutes les vidéos</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -193,6 +193,11 @@
     <string name="restore_advanced_defaults">初期設定に戻す</string>
     <string name="advanced_defaults_restored">詳細設定を初期値に戻しました</string>
     <string name="use_exact_dates">日付を指定</string>
+    <string name="use_raw_gps_signals">直近1か月の生のGPS信号を使用</string>
+    <string name="raw_gps_signals_description">タイムラインのエクスポートには通常、エクスポート日より前の約1か月分の生のGPS信号が含まれます。</string>
+    <string name="raw_gps_accuracy_limit">精度の上限（メートル）</string>
+    <string name="raw_gps_accuracy_helper">精度の低い信号は除外されます。すべて使用する場合は空欄にしてください。</string>
+    <string name="raw_signals_summary">位置 %1$s件 · 約%2$s km</string>
     <string name="choose_exact_dates">開始日と終了日を選択</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">すべての動画を削除</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -193,6 +193,11 @@
     <string name="restore_advanced_defaults">기본값 복원</string>
     <string name="advanced_defaults_restored">고급 설정을 복원했습니다</string>
     <string name="use_exact_dates">정확한 날짜 선택</string>
+    <string name="use_raw_gps_signals">최근 한 달의 원시 GPS 신호 사용</string>
+    <string name="raw_gps_signals_description">타임라인 내보내기에는 일반적으로 내보낸 날짜 이전 약 한 달간의 원시 GPS 신호가 포함됩니다.</string>
+    <string name="raw_gps_accuracy_limit">정확도 한도(미터)</string>
+    <string name="raw_gps_accuracy_helper">정확도가 낮은 신호는 제외됩니다. 모든 신호를 사용하려면 비워 두세요.</string>
+    <string name="raw_signals_summary">위치 %1$s개 · 약 %2$s km</string>
     <string name="choose_exact_dates">시작일과 종료일 선택</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">모든 동영상 삭제</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -201,6 +201,11 @@
     <string name="restore_advanced_defaults">Restaurar padrões</string>
     <string name="advanced_defaults_restored">Configurações avançadas restauradas</string>
     <string name="use_exact_dates">Selecionar datas exatas</string>
+    <string name="use_raw_gps_signals">Usar sinais GPS brutos do último mês</string>
+    <string name="raw_gps_signals_description">Uma exportação do Timeline geralmente inclui os sinais GPS brutos de aproximadamente um mês antes da data de exportação.</string>
+    <string name="raw_gps_accuracy_limit">Limite de precisão (metros)</string>
+    <string name="raw_gps_accuracy_helper">Sinais menos precisos são excluídos. Deixe em branco para usar todos.</string>
+    <string name="raw_signals_summary">%1$s pontos · cerca de %2$s km</string>
     <string name="choose_exact_dates">Selecione uma data de início e término</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">Excluir todos os vídeos</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -194,6 +194,11 @@
     <string name="restore_advanced_defaults">恢复默认设置</string>
     <string name="advanced_defaults_restored">高级设置已恢复</string>
     <string name="use_exact_dates">选择具体日期</string>
+    <string name="use_raw_gps_signals">使用最近一个月的原始 GPS 信号</string>
+    <string name="raw_gps_signals_description">导出的 Timeline 通常包含导出日前约一个月的原始 GPS 信号。</string>
+    <string name="raw_gps_accuracy_limit">精度上限（米）</string>
+    <string name="raw_gps_accuracy_helper">精度较低的信号会被过滤；留空则使用全部信号。</string>
+    <string name="raw_signals_summary">%1$s 个位置点 · 约 %2$s km</string>
     <string name="choose_exact_dates">选择开始和结束日期</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">删除所有视频</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -194,6 +194,11 @@
     <string name="restore_advanced_defaults">恢復預設設定</string>
     <string name="advanced_defaults_restored">進階設定已恢復</string>
     <string name="use_exact_dates">選擇確切日期</string>
+    <string name="use_raw_gps_signals">使用最近一個月的原始 GPS 訊號</string>
+    <string name="raw_gps_signals_description">匯出的時間軸通常包含匯出日前約一個月的原始 GPS 訊號。</string>
+    <string name="raw_gps_accuracy_limit">精確度上限（公尺）</string>
+    <string name="raw_gps_accuracy_helper">精確度較低的訊號會被排除；留空則使用全部訊號。</string>
+    <string name="raw_signals_summary">%1$s 個位置點 · 約 %2$s km</string>
     <string name="choose_exact_dates">選擇開始和結束日期</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">刪除所有影片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,11 @@
     <string name="restore_advanced_defaults">Restore defaults</string>
     <string name="advanced_defaults_restored">Advanced settings restored</string>
     <string name="use_exact_dates">Choose exact dates</string>
+    <string name="use_raw_gps_signals">Use raw GPS signals from the last month</string>
+    <string name="raw_gps_signals_description">A Timeline export usually includes raw GPS signals from approximately the month before the export date.</string>
+    <string name="raw_gps_accuracy_limit">Accuracy limit (meters)</string>
+    <string name="raw_gps_accuracy_helper">Signals with lower accuracy are excluded. Leave blank to use all signals.</string>
+    <string name="raw_signals_summary">%1$s points · about %2$s km</string>
     <string name="choose_exact_dates">Select a start and end date</string>
     <string name="exact_date_range">%1$s – %2$s</string>
     <string name="delete_all_videos">Delete all videos</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
@@ -236,6 +236,33 @@ class TimelineParserTest {
         }
     }
 
+    @Test
+    fun exposesAccurateRawPositionsWithoutChangingSemanticTimeline() {
+        val parsed = parser.parseWithRawSignals(
+            ByteArrayInputStream(
+                """
+                {
+                  "semanticSegments": [{
+                    "startTime": "2026-01-01T00:00:00Z",
+                    "visit": {"topCandidate": {"placeLocation": "37.0,127.0"}}
+                  }],
+                  "rawSignals": [
+                    {"position": {"LatLng": "37.1,127.1", "timestamp": "2026-02-01T00:00:00Z", "accuracyMeters": 20}},
+                    {"position": {"LatLng": "37.2,127.2", "timestamp": "2026-02-01T00:01:00Z", "accuracyMeters": 101}},
+                    {"activityRecord": {"timestamp": "2026-02-01T00:02:00Z"}}
+                  ]
+                }
+                """.trimIndent().toByteArray(),
+            ),
+        )
+
+        assertEquals(1, parsed.timeline.points.size)
+        assertEquals(37.0, parsed.timeline.points.single().latitude, 0.00001)
+        assertEquals(2, parsed.rawSignals.size)
+        assertEquals(37.1, parsed.rawSignals.first().point.latitude, 0.00001)
+        assertEquals(20.0, parsed.rawSignals.first().accuracyMeters, 0.00001)
+    }
+
     private fun parse(json: String) = parser.parse(ByteArrayInputStream(json.toByteArray()))
 
     private fun parseFailure(json: String): TimelineParseException = try {

--- a/web/index.html
+++ b/web/index.html
@@ -44,11 +44,22 @@
 
       <section id="settings-card" class="card hidden" aria-labelledby="settings-heading">
         <h2 id="settings-heading">Create your journey</h2>
-        <label class="checkbox-row">
-          <input id="exact-date-toggle" type="checkbox" />
-          <span>Select exact dates</span>
+        <label id="raw-signals-row" class="checkbox-row hidden">
+          <input id="raw-signals-toggle" type="checkbox" />
+          <span>Use raw GPS signals from the last month</span>
         </label>
-        <div id="month-range-fields" class="field-grid">
+        <p id="raw-signals-description" class="status hidden">A Timeline export usually includes raw GPS signals from approximately the month before the export date.</p>
+        <label id="raw-accuracy-field" class="hidden">
+          Accuracy limit (meters)
+          <input id="raw-accuracy-limit" type="number" min="0" step="1" inputmode="decimal" value="100" />
+          <span class="field-help">Signals whose accuracy value exceeds this limit are excluded. Leave blank to use all signals.</span>
+        </label>
+        <div id="period-controls">
+          <label class="checkbox-row">
+            <input id="exact-date-toggle" type="checkbox" />
+            <span>Select exact dates</span>
+          </label>
+          <div id="month-range-fields" class="field-grid">
           <label>
             From
             <select id="start-month"></select>
@@ -57,8 +68,8 @@
             To
             <select id="end-month"></select>
           </label>
-        </div>
-        <div id="exact-date-fields" class="field-grid hidden">
+          </div>
+          <div id="exact-date-fields" class="field-grid hidden">
           <label>
             Start date
             <input id="start-date" type="date" />
@@ -67,6 +78,7 @@
             End date
             <input id="end-date" type="date" />
           </label>
+          </div>
         </div>
         <label>
           Video title

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -4,14 +4,17 @@ import { cumulativeDistances } from './geo';
 import { drawFrame, prepareJourney } from './renderer';
 import {
   availableMonths,
+  filterRawSignalPoints,
   localDateKey,
   parseTimelineJson,
+  parseRawSignalsJson,
   pointDateKey,
   selectDateRange,
   selectRange,
   TimelineParseError,
 } from './timeline';
 import type { CameraMovement, GeoPoint, MonthOption, PreparedJourney } from './types';
+import type { RawSignalPoint } from './timeline';
 import { canCreateMp4, createJourneyMp4 } from './video';
 
 function element<T extends HTMLElement>(id: string): T {
@@ -26,6 +29,12 @@ const fileStatus = element<HTMLParagraphElement>('file-status');
 const compatibilityStatus = element<HTMLParagraphElement>('compatibility-status');
 const settingsCard = element<HTMLElement>('settings-card');
 const exactDateToggle = element<HTMLInputElement>('exact-date-toggle');
+const periodControls = element<HTMLElement>('period-controls');
+const rawSignalsRow = element<HTMLElement>('raw-signals-row');
+const rawSignalsToggle = element<HTMLInputElement>('raw-signals-toggle');
+const rawSignalsDescription = element<HTMLElement>('raw-signals-description');
+const rawAccuracyField = element<HTMLElement>('raw-accuracy-field');
+const rawAccuracyInput = element<HTMLInputElement>('raw-accuracy-limit');
 const monthRangeFields = element<HTMLElement>('month-range-fields');
 const exactDateFields = element<HTMLElement>('exact-date-fields');
 const startSelect = element<HTMLSelectElement>('start-month');
@@ -56,6 +65,7 @@ if (import.meta.env.VITE_PREVIEW === 'true') {
 }
 
 let allPoints: GeoPoint[] = [];
+let rawSignalPoints: RawSignalPoint[] = [];
 let months: MonthOption[] = [];
 let prepared: PreparedJourney | null = null;
 let selectedSignature = '';
@@ -83,6 +93,11 @@ function populateMonths(select: HTMLSelectElement, options: MonthOption[]): void
 }
 
 function currentPoints(): GeoPoint[] {
+  if (rawSignalsToggle.checked) {
+    const rawLimit = rawAccuracyInput.value.trim();
+    const maximumAccuracy = rawLimit === '' ? null : Number(rawLimit);
+    return filterRawSignalPoints(rawSignalPoints, maximumAccuracy);
+  }
   if (exactDateToggle.checked) {
     return selectDateRange(allPoints, startDateInput.value, endDateInput.value);
   }
@@ -95,6 +110,7 @@ function formatInputDate(value: string): string {
 }
 
 function currentPeriodLabel(): string {
+  if (rawSignalsToggle.checked) return 'Raw GPS signals from the last month';
   if (exactDateToggle.checked) {
     const start = formatInputDate(startDateInput.value);
     const end = formatInputDate(endDateInput.value);
@@ -106,6 +122,7 @@ function currentPeriodLabel(): string {
 }
 
 function currentRangeSignature(): string {
+  if (rawSignalsToggle.checked) return 'raw-signals';
   return exactDateToggle.checked
     ? `dates:${startDateInput.value}:${endDateInput.value}`
     : `months:${startSelect.value}:${endSelect.value}`;
@@ -195,6 +212,7 @@ function parseTimelineText(text: string): unknown {
 
 function applyTimeline(data: unknown, sourceName: string): void {
   allPoints = parseTimelineJson(data);
+  rawSignalPoints = parseRawSignalsJson(data);
   months = availableMonths(allPoints);
   populateMonths(startSelect, months);
   populateMonths(endSelect, months);
@@ -210,6 +228,12 @@ function applyTimeline(data: unknown, sourceName: string): void {
   startDateInput.value = firstDate;
   endDateInput.value = lastDate;
   exactDateToggle.checked = false;
+  rawSignalsToggle.checked = false;
+  rawAccuracyInput.value = '100';
+  rawSignalsRow.classList.toggle('hidden', rawSignalPoints.length === 0);
+  rawSignalsDescription.classList.add('hidden');
+  rawAccuracyField.classList.add('hidden');
+  periodControls.classList.remove('hidden');
   monthRangeFields.classList.remove('hidden');
   exactDateFields.classList.add('hidden');
   mapConsent.checked = false;
@@ -278,6 +302,13 @@ exactDateToggle.addEventListener('change', () => {
   exactDateFields.classList.toggle('hidden', !exactDateToggle.checked);
   updateSelection();
 });
+rawSignalsToggle.addEventListener('change', () => {
+  periodControls.classList.toggle('hidden', rawSignalsToggle.checked);
+  rawSignalsDescription.classList.toggle('hidden', !rawSignalsToggle.checked);
+  rawAccuracyField.classList.toggle('hidden', !rawSignalsToggle.checked);
+  updateSelection();
+});
+rawAccuracyInput.addEventListener('input', updateSelection);
 mapConsent.addEventListener('change', () => {
   if (mapConsent.checked) setSettingsError(null);
 });

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -96,6 +96,8 @@ input, select {
   font-size: 16px;
 }
 
+.field-help { color: #7b6570; font-size: 13px; font-weight: 400; line-height: 1.4; }
+
 .field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
 .actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 18px; }
 .status { margin: 12px 0 0; font-size: 14px; }

--- a/web/src/timeline.test.ts
+++ b/web/src/timeline.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   availableMonths,
+  filterRawSignalPoints,
   localDateKey,
   parseCoordinate,
+  parseRawSignalsJson,
   parseTimelineJson,
   pointDateKey,
   selectDateRange,
@@ -21,6 +23,23 @@ describe('parseCoordinate', () => {
   it('rejects invalid coordinates', () => {
     expect(parseCoordinate('91,127')).toBeNull();
     expect(parseCoordinate('not a coordinate')).toBeNull();
+  });
+});
+
+describe('parseRawSignalsJson', () => {
+  it('uses accurate positions and ignores non-position signals', () => {
+    const points = parseRawSignalsJson({
+      rawSignals: [
+        { position: { LatLng: '37.1,127.1', timestamp: '2026-02-01T00:00:00Z', accuracyMeters: 20 } },
+        { position: { LatLng: '37.2,127.2', timestamp: '2026-02-01T00:01:00Z', accuracyMeters: 101 } },
+        { activityRecord: { timestamp: '2026-02-01T00:02:00Z' } },
+      ],
+    });
+
+    expect(points).toHaveLength(2);
+    expect(points[0].latitude).toBe(37.1);
+    expect(filterRawSignalPoints(points, 100)).toHaveLength(1);
+    expect(filterRawSignalPoints(points, null)).toHaveLength(2);
   });
 });
 

--- a/web/src/timeline.ts
+++ b/web/src/timeline.ts
@@ -62,6 +62,14 @@ interface ParsedTimelineSegment {
   points: GeoPoint[];
 }
 
+export interface RawSignalPoint extends GeoPoint {
+  accuracyMeters: number;
+}
+
+export function filterRawSignalPoints(points: RawSignalPoint[], maximumAccuracy: number | null): GeoPoint[] {
+  return points.filter((point) => maximumAccuracy === null || point.accuracyMeters <= maximumAccuracy);
+}
+
 const SEGMENT_DIRECTION_SIGNAL_MS = 36 * 60 * 60 * 1000;
 
 function parseInstant(value: unknown): ParsedInstant | null {
@@ -221,6 +229,30 @@ export function parseTimelineJson(data: unknown): GeoPoint[] {
     );
   }
   return normalized;
+}
+
+export function parseRawSignalsJson(data: unknown): RawSignalPoint[] {
+  if (!isObject(data) || !Array.isArray(data.rawSignals)) return [];
+  const unique = new Map<string, RawSignalPoint>();
+  for (const rawSignal of data.rawSignals) {
+    if (!isObject(rawSignal) || !isObject(rawSignal.position)) continue;
+    const position = rawSignal.position;
+    const accuracy = position.accuracyMeters;
+    if (typeof accuracy !== 'number' || !Number.isFinite(accuracy) || accuracy < 0) continue;
+    const parsedTime = parseInstant(position.timestamp);
+    const coordinate = parseCoordinate(position.LatLng ?? position.latLng);
+    if (!parsedTime || !coordinate) continue;
+    const point: RawSignalPoint = {
+      instant: parsedTime.instant,
+      latitude: coordinate[0],
+      longitude: coordinate[1],
+      recordedDate: parsedTime.recordedDate,
+      timeZoneMissing: parsedTime.timeZoneMissing,
+      accuracyMeters: accuracy,
+    };
+    unique.set(`${point.instant.getTime()}:${point.latitude}:${point.longitude}`, point);
+  }
+  return [...unique.values()].sort((a, b) => a.instant.getTime() - b.instant.getTime());
 }
 
 export function monthKey(date: Date): string {


### PR DESCRIPTION
## Feature
Google Timeline exports may include `rawSignals.position` records from approximately the month before the export date, in addition to `semanticSegments`. This PR adds an option to use only those raw signals when creating a video.

<img width="1205" height="1280" alt="add_raw_singals_support" src="https://github.com/user-attachments/assets/20f05287-b252-4027-9a05-19a4d40c671a" />

## Testing
Tested using my own timeline file Pixel 4a and Chrome.

## Details
- Parse `rawSignals[].position` separately from `semanticSegments`
- Preserve each raw position's `timestamp`, `LatLng`, and `accuracyMeters`
- Add **Use raw GPS signals from the last month** to period selection
- Use only raw GPS positions while the option is enabled
- Keep raw GPS positions separate from semantic segments; the two sources are
  never merged
- Hide the year, month, and exact-date controls while raw GPS is selected
- Keep the existing point-count and distance summary in its original position
- Add a configurable accuracy limit in meters
  - Defaults to 100 meters
  - Updates the route and distance summary when changed
  - Can be left blank to include all valid raw positions
- Continue applying the existing conservative location-outlier filter
- Add translations for all currently supported Android languages