### PR TITLE
Fix overlapping Timeline histories for v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.2.1
+
+- Prevent repeated or backtracking routes when independent semantic and path histories cover the same time.
+- Treat activity and visit segments as authoritative while retaining standalone path points outside their coverage.
+- Preserve path detail stored inside the same semantic segment and keep path-only exports unchanged.
+- Apply matching reconciliation behavior to Android, the web app, and the Python renderer.
+- Keep processing local without changing the source Timeline file.
+- Set Android version code 20 and version name 2.2.1.
+
 ## 2.2.0
 
 - Add fixed portrait 1080×1920 and landscape 1920×1080 video formats.

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,7 @@ MP4 の作成には H.264 エンコードに対応した Safari 16.4 以降が�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.2.0.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.2.1.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,7 +32,7 @@ MP4를 만들려면 H.264 인코딩을 지원하는 Safari 16.4 이상이 필요
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.2.0.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.2.1.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use Safari's Share menu and choose **Add to Home Screen**.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.2.0.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.2.1.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 19
-        versionName = "2.2.0"
+        versionCode = 20
+        versionName = "2.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TimelineParser.kt
@@ -27,7 +27,9 @@ class TimelineParser {
     }
 
     private fun parseSupportedTimeline(input: InputStream): Timeline {
-        val points = mutableListOf<GeoPoint>()
+        val canonicalPoints = mutableListOf<GeoPoint>()
+        val standalonePathPoints = mutableListOf<GeoPoint>()
+        val semanticIntervals = mutableListOf<TimeInterval>()
         JsonReader(InputStreamReader(input, Charsets.UTF_8)).use { reader ->
             reader.strictness = Strictness.LENIENT
             val rootToken = try {
@@ -39,8 +41,18 @@ class TimelineParser {
                 )
             }
             when (rootToken) {
-                JsonToken.BEGIN_ARRAY -> readSegments(reader, points)
-                JsonToken.BEGIN_OBJECT -> readRootObject(reader, points)
+                JsonToken.BEGIN_ARRAY -> readSegments(
+                    reader,
+                    canonicalPoints,
+                    standalonePathPoints,
+                    semanticIntervals,
+                )
+                JsonToken.BEGIN_OBJECT -> readRootObject(
+                    reader,
+                    canonicalPoints,
+                    standalonePathPoints,
+                    semanticIntervals,
+                )
                 else -> throw TimelineParseException(
                     TimelineParseReason.UNSUPPORTED_FORMAT,
                     "Timeline JSON must start with an object or array",
@@ -48,6 +60,7 @@ class TimelineParser {
             }
         }
 
+        val points = reconcileStandalonePaths(canonicalPoints, standalonePathPoints, semanticIntervals)
         val normalized = normalize(points)
 
         if (normalized.isEmpty()) {
@@ -57,6 +70,47 @@ class TimelineParser {
             )
         }
         return Timeline(normalized)
+    }
+
+    private fun reconcileStandalonePaths(
+        canonicalPoints: MutableList<GeoPoint>,
+        standalonePathPoints: MutableList<GeoPoint>,
+        semanticIntervals: MutableList<TimeInterval>,
+    ): MutableList<GeoPoint> {
+        // Some direct-array exports append an independent path-only history for the same
+        // periods already represented by activity and visit segments. Keep paths that are
+        // attached to their semantic segment, but do not flatten the second history into it.
+        if (standalonePathPoints.isEmpty()) return canonicalPoints
+        if (semanticIntervals.isEmpty()) {
+            canonicalPoints += standalonePathPoints
+            return canonicalPoints
+        }
+
+        semanticIntervals.sortBy(TimeInterval::start)
+        val mergedIntervals = ArrayList<TimeInterval>(semanticIntervals.size)
+        semanticIntervals.forEach { interval ->
+            val previous = mergedIntervals.lastOrNull()
+            if (previous == null || interval.start.isAfter(previous.end)) {
+                mergedIntervals += interval
+            } else if (interval.end.isAfter(previous.end)) {
+                mergedIntervals[mergedIntervals.lastIndex] = previous.copy(end = interval.end)
+            }
+        }
+
+        standalonePathPoints.sortBy(GeoPoint::instant)
+        var intervalIndex = 0
+        standalonePathPoints.forEach { point ->
+            while (
+                intervalIndex < mergedIntervals.size &&
+                mergedIntervals[intervalIndex].end.isBefore(point.instant)
+            ) {
+                intervalIndex += 1
+            }
+            val covered = intervalIndex < mergedIntervals.size &&
+                !point.instant.isBefore(mergedIntervals[intervalIndex].start)
+            if (!covered) canonicalPoints += point
+        }
+        return canonicalPoints
     }
 
     private fun normalize(points: MutableList<GeoPoint>): List<GeoPoint> {
@@ -110,7 +164,12 @@ class TimelineParser {
         return points
     }
 
-    private fun readRootObject(reader: JsonReader, points: MutableList<GeoPoint>) {
+    private fun readRootObject(
+        reader: JsonReader,
+        canonicalPoints: MutableList<GeoPoint>,
+        standalonePathPoints: MutableList<GeoPoint>,
+        semanticIntervals: MutableList<TimeInterval>,
+    ) {
         var foundSegments = false
         var foundRawSignals = false
         var foundLegacyFormat = false
@@ -119,7 +178,7 @@ class TimelineParser {
             when (reader.nextName()) {
                 "semanticSegments" -> {
                     foundSegments = true
-                    readSegments(reader, points)
+                    readSegments(reader, canonicalPoints, standalonePathPoints, semanticIntervals)
                 }
                 "rawSignals" -> {
                     foundRawSignals = true
@@ -143,20 +202,36 @@ class TimelineParser {
         }
     }
 
-    private fun readSegments(reader: JsonReader, points: MutableList<GeoPoint>) {
+    private fun readSegments(
+        reader: JsonReader,
+        canonicalPoints: MutableList<GeoPoint>,
+        standalonePathPoints: MutableList<GeoPoint>,
+        semanticIntervals: MutableList<TimeInterval>,
+    ) {
         reader.beginArray()
         while (reader.hasNext()) {
-            if (reader.peek() == JsonToken.BEGIN_OBJECT) readSegment(reader, points) else reader.skipValue()
+            if (reader.peek() == JsonToken.BEGIN_OBJECT) {
+                readSegment(reader, canonicalPoints, standalonePathPoints, semanticIntervals)
+            } else {
+                reader.skipValue()
+            }
         }
         reader.endArray()
     }
 
-    private fun readSegment(reader: JsonReader, output: MutableList<GeoPoint>) {
+    private fun readSegment(
+        reader: JsonReader,
+        canonicalPoints: MutableList<GeoPoint>,
+        standalonePathPoints: MutableList<GeoPoint>,
+        semanticIntervals: MutableList<TimeInterval>,
+    ) {
         var startTime: String? = null
         var endTime: String? = null
         var visitLocation: String? = null
         var activityStart: String? = null
         var activityEnd: String? = null
+        var hasVisit = false
+        var hasActivity = false
         val path = mutableListOf<TimedCoordinate>()
 
         reader.beginObject()
@@ -165,8 +240,12 @@ class TimelineParser {
                 "startTime" -> startTime = reader.readStringOrNull()
                 "endTime" -> endTime = reader.readStringOrNull()
                 "timelinePath" -> readTimelinePath(reader, path)
-                "visit" -> visitLocation = readVisit(reader)
+                "visit" -> {
+                    hasVisit = true
+                    visitLocation = readVisit(reader)
+                }
                 "activity" -> {
+                    hasActivity = true
                     val activity = readActivity(reader)
                     activityStart = activity.first
                     activityEnd = activity.second
@@ -176,18 +255,34 @@ class TimelineParser {
         }
         reader.endObject()
 
+        val startInstant = parseInstant(startTime)
+        val endInstant = parseInstant(endTime)
+        val pathPoints = ArrayList<GeoPoint>(path.size)
         path.forEach { timed ->
             val instant = parseInstant(timed.time)
                 ?: parseOffsetInstant(startTime, endTime, timed.offsetMinutes)
             val coordinate = parseCoordinate(timed.coordinate)
             if (instant != null && coordinate != null) {
-                output += GeoPoint(instant, coordinate.first, coordinate.second)
+                pathPoints += GeoPoint(instant, coordinate.first, coordinate.second)
             }
         }
 
-        addPoint(output, startTime, visitLocation)
-        addPoint(output, startTime, activityStart)
-        addPoint(output, endTime, activityEnd)
+        val semanticPoints = ArrayList<GeoPoint>(3)
+        addPoint(semanticPoints, startInstant, visitLocation)
+        addPoint(semanticPoints, startInstant, activityStart)
+        addPoint(semanticPoints, endInstant, activityEnd)
+        val hasUsableSemanticRecord = (hasVisit || hasActivity) && semanticPoints.isNotEmpty()
+
+        if (hasUsableSemanticRecord) {
+            canonicalPoints += pathPoints
+            canonicalPoints += semanticPoints
+            if (startInstant != null && endInstant != null && !endInstant.isBefore(startInstant)) {
+                semanticIntervals += TimeInterval(startInstant, endInstant)
+            }
+        } else {
+            standalonePathPoints += pathPoints
+            canonicalPoints += semanticPoints
+        }
     }
 
     private fun readTimelinePath(reader: JsonReader, output: MutableList<TimedCoordinate>) {
@@ -307,8 +402,7 @@ class TimelineParser {
         }
     }
 
-    private fun addPoint(output: MutableList<GeoPoint>, time: String?, rawCoordinate: String?) {
-        val instant = parseInstant(time)
+    private fun addPoint(output: MutableList<GeoPoint>, instant: Instant?, rawCoordinate: String?) {
         val coordinate = parseCoordinate(rawCoordinate)
         if (instant != null && coordinate != null) {
             output += GeoPoint(instant, coordinate.first, coordinate.second)
@@ -362,6 +456,11 @@ class TimelineParser {
         val coordinate: String,
         val time: String?,
         val offsetMinutes: Long?,
+    )
+
+    private data class TimeInterval(
+        val start: Instant,
+        val end: Instant,
     )
 }
 

--- a/app/src/main/res/layout/screen_settings.xml
+++ b/app/src/main/res/layout/screen_settings.xml
@@ -33,7 +33,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="24dp" android:text="@string/about_and_privacy" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
-        <TextView android:id="@+id/versionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:gravity="center_horizontal" android:textAppearance="?attr/textAppearanceBodyMedium" tools:text="Version 2.2.0 (19)" />
+        <TextView android:id="@+id/versionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:gravity="center_horizontal" android:textAppearance="?attr/textAppearanceBodyMedium" tools:text="Version 2.2.1 (20)" />
         <TextView android:id="@+id/privacyText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:text="@string/privacy_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
         <com.google.android.material.button.MaterialButton android:id="@+id/privacyPolicyButton" style="@style/Widget.Material3.Button.TextButton" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center_horizontal" android:maxLines="1" android:text="@string/privacy_policy" />
         <com.google.android.material.button.MaterialButton android:id="@+id/checkUpdatesButton" style="@style/Widget.Material3.Button.TextButton" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center_horizontal" android:maxLines="1" android:text="@string/check_for_updates" />

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/data/TimelineParserTest.kt
@@ -65,6 +65,69 @@ class TimelineParserTest {
     }
 
     @Test
+    fun suppressesStandalonePathPointsCoveredBySemanticSegments() {
+        val timeline = parse(
+            """
+            [
+              {
+                "startTime": "2026-05-11T08:00:00Z",
+                "endTime": "2026-05-11T22:00:00Z",
+                "activity": {"start": "10,10", "end": "20,20"}
+              },
+              {
+                "startTime": "2026-05-12T08:00:00Z",
+                "endTime": "2026-05-12T22:00:00Z",
+                "activity": {"start": "20,20", "end": "10,10"}
+              },
+              {
+                "startTime": "2026-05-11T08:00:00Z",
+                "endTime": "2026-05-12T23:00:00Z",
+                "timelinePath": [
+                  {"point": "20,20", "time": "2026-05-11T13:00:00Z"},
+                  {"point": "10,10", "time": "2026-05-11T17:00:00Z"},
+                  {"point": "10,10", "time": "2026-05-12T13:00:00Z"},
+                  {"point": "20,20", "time": "2026-05-12T17:00:00Z"},
+                  {"point": "30,30", "time": "2026-05-12T22:30:00Z"}
+                ]
+              }
+            ]
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            listOf(
+                Triple("2026-05-11T08:00:00Z", 10.0, 10.0),
+                Triple("2026-05-11T22:00:00Z", 20.0, 20.0),
+                Triple("2026-05-12T08:00:00Z", 20.0, 20.0),
+                Triple("2026-05-12T22:00:00Z", 10.0, 10.0),
+                Triple("2026-05-12T22:30:00Z", 30.0, 30.0),
+            ),
+            timeline.points.map { Triple(it.instant.toString(), it.latitude, it.longitude) },
+        )
+    }
+
+    @Test
+    fun keepsPathDetailInsideTheSameSemanticSegment() {
+        val timeline = parse(
+            """
+            [{
+              "startTime": "2026-01-01T00:00:00Z",
+              "endTime": "2026-01-01T02:00:00Z",
+              "activity": {"start": "10,10", "end": "20,20"},
+              "timelinePath": [
+                {"point": "15,15", "time": "2026-01-01T01:00:00Z"}
+              ]
+            }]
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            listOf(10.0, 15.0, 20.0),
+            timeline.points.map { it.latitude },
+        )
+    }
+
+    @Test
     fun acceptsE7CoordinatesAndRemovesDuplicates() {
         val timeline = parse(
             """
@@ -234,6 +297,40 @@ class TimelineParserTest {
         } finally {
             source.delete()
         }
+    }
+
+    @Test
+    fun reconcilesThousandsOfOverlappingSemanticAndPathSegments() {
+        val segmentCount = 3_000
+        val base = Instant.parse("2026-01-01T00:00:00Z")
+        val json = buildString {
+            append('[')
+            repeat(segmentCount) { index ->
+                if (index > 0) append(',')
+                val start = base.plusSeconds(index * 120L)
+                val end = start.plusSeconds(60)
+                append(
+                    "{\"startTime\":\"$start\",\"endTime\":\"$end\"," +
+                        "\"activity\":{\"start\":\"10,10\",\"end\":\"20,20\"}}",
+                )
+            }
+            repeat(segmentCount) { index ->
+                append(',')
+                val start = base.plusSeconds(index * 120L)
+                val end = start.plusSeconds(60)
+                val middle = start.plusSeconds(30)
+                append(
+                    "{\"startTime\":\"$start\",\"endTime\":\"$end\"," +
+                        "\"timelinePath\":[{\"point\":\"30,30\",\"time\":\"$middle\"}]}",
+                )
+            }
+            append(']')
+        }
+
+        val timeline = parse(json)
+
+        assertEquals(segmentCount * 2, timeline.points.size)
+        assertTrue(timeline.points.none { it.latitude == 30.0 })
     }
 
     private fun parse(json: String) = parser.parse(ByteArrayInputStream(json.toByteArray()))

--- a/docs/release-notes-v2.2.1.md
+++ b/docs/release-notes-v2.2.1.md
@@ -1,0 +1,64 @@
+# Timeline Visualizer 2.2.1
+
+Fix routes that could repeat or backtrack when a Timeline export contains independent
+semantic and path histories for the same time. Activity and visit segments are now
+authoritative during overlap, while same-segment path detail, uncovered path points,
+and path-only exports remain supported. Processing stays local and the source file is
+never changed.
+
+## 한국어
+
+같은 시간대를 나타내는 의미 기반 기록과 경로 기록이 따로 포함된 타임라인 내보내기에서
+경로가 반복되거나 되돌아가던 문제를 수정했습니다. 겹치는 구간에서는 활동 및 방문 구간을
+우선하며, 같은 구간 안의 경로 세부 정보와 겹치지 않는 경로 지점, 경로만 있는 내보내기는
+계속 지원합니다. 처리는 기기에서만 이루어지며 원본 파일은 변경하지 않습니다.
+
+## 日本語
+
+同じ時間帯の意味ベース履歴と経路履歴が別々に含まれるタイムラインの書き出しで、
+経路が重複したり逆戻りしたりする問題を修正しました。重複する時間帯ではアクティビティ
+と訪問を優先し、同じセグメント内の経路情報、重複しない経路地点、経路のみの書き出しは
+引き続き利用できます。処理は端末内で行われ、元のファイルは変更されません。
+
+## 简体中文
+
+修复了时间轴导出中语义记录和路径记录覆盖同一时段时，路线可能重复或折返的问题。
+重叠时段现在以活动和访问记录为准，同时保留同一分段内的路径详情、未重叠的路径点和
+仅含路径的导出。处理仍在本地完成，原始文件不会被修改。
+
+## 繁體中文
+
+修正時間軸匯出中語意記錄與路徑記錄涵蓋相同時段時，路線可能重複或折返的問題。
+重疊時段現在以活動與造訪記錄為準，同時保留同一區段內的路徑細節、未重疊的路徑點及
+僅含路徑的匯出。處理仍在本機完成，原始檔案不會被修改。
+
+## Español
+
+Se corrigieron las rutas que podían repetirse o retroceder cuando una exportación
+contenía historiales semánticos y de ruta independientes para el mismo periodo. Las
+actividades y visitas tienen prioridad durante la superposición, mientras que se
+conservan los detalles de ruta del mismo segmento, los puntos no superpuestos y las
+exportaciones que solo contienen rutas. El procesamiento sigue siendo local.
+
+## Français
+
+Correction des trajets qui pouvaient se répéter ou revenir en arrière lorsqu'une
+exportation contenait des historiques sémantiques et de parcours indépendants pour la
+même période. Les activités et visites sont prioritaires pendant le chevauchement,
+tandis que les détails du même segment, les points non chevauchés et les exportations
+contenant uniquement des parcours sont conservés. Le traitement reste local.
+
+## Deutsch
+
+Routen werden nicht mehr wiederholt oder zurückgeführt, wenn ein Timeline-Export
+getrennte semantische und Pfaddaten für denselben Zeitraum enthält. Bei Überschneidungen
+haben Aktivitäten und Besuche Vorrang. Pfaddetails im selben Segment, nicht überlappende
+Punkte und reine Pfadexporte bleiben erhalten. Die Verarbeitung erfolgt weiterhin lokal.
+
+## Português (Brasil)
+
+Foram corrigidas rotas que podiam se repetir ou voltar quando uma exportação continha
+históricos semânticos e de caminho independentes para o mesmo período. Atividades e
+visitas têm prioridade durante a sobreposição, enquanto detalhes do mesmo segmento,
+pontos sem sobreposição e exportações contendo apenas caminhos são preservados. O
+processamento continua local.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.0` and version code `19`
+- Version name `2.2.1` and version code `20`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,53 @@ def test_ios_array_root_and_activity():
     assert [(p["lat"], p["lon"]) for p in points] == [(35.1, 129.1), (35.2, 129.2), (35.3, 129.3)]
 
 
+def test_standalone_paths_are_suppressed_only_during_semantic_coverage():
+    data = [
+        {
+            "startTime": "2026-05-11T08:00:00Z",
+            "endTime": "2026-05-11T22:00:00Z",
+            "activity": {"start": "10,10", "end": "20,20"},
+        },
+        {
+            "startTime": "2026-05-12T08:00:00Z",
+            "endTime": "2026-05-12T22:00:00Z",
+            "activity": {"start": "20,20", "end": "10,10"},
+        },
+        {
+            "startTime": "2026-05-11T08:00:00Z",
+            "endTime": "2026-05-12T23:00:00Z",
+            "timelinePath": [
+                {"point": "20,20", "time": "2026-05-11T13:00:00Z"},
+                {"point": "10,10", "time": "2026-05-11T17:00:00Z"},
+                {"point": "10,10", "time": "2026-05-12T13:00:00Z"},
+                {"point": "20,20", "time": "2026-05-12T17:00:00Z"},
+                {"point": "30,30", "time": "2026-05-12T22:30:00Z"},
+            ],
+        },
+    ]
+
+    points = extract_timeline_points(data, 2026)
+    assert [(point["dt"].isoformat(), point["lat"]) for point in points] == [
+        ("2026-05-11T08:00:00+00:00", 10.0),
+        ("2026-05-11T22:00:00+00:00", 20.0),
+        ("2026-05-12T08:00:00+00:00", 20.0),
+        ("2026-05-12T22:00:00+00:00", 10.0),
+        ("2026-05-12T22:30:00+00:00", 30.0),
+    ]
+
+
+def test_path_detail_inside_the_same_semantic_segment_is_preserved():
+    data = [{
+        "startTime": "2026-01-01T00:00:00Z",
+        "endTime": "2026-01-01T02:00:00Z",
+        "activity": {"start": "10,10", "end": "20,20"},
+        "timelinePath": [{"point": "15,15", "time": "2026-01-01T01:00:00Z"}],
+    }]
+
+    points = extract_timeline_points(data, 2026)
+    assert [point["lat"] for point in points] == [10.0, 15.0, 20.0]
+
+
 def test_coordinate_parser_supports_e7_and_rejects_invalid():
     assert parse_coordinate("375000000,1270000000") == (37.5, 127.0)
     assert parse_coordinate("geo:91,127") is None

--- a/visualizer.py
+++ b/visualizer.py
@@ -351,7 +351,9 @@ def extract_timeline_points(data, year):
     else:
         raise ValueError('Timeline JSON must start with an object or array')
 
-    points = []
+    canonical_points = []
+    standalone_path_points = []
+    semantic_intervals = []
 
     def parse_timestamp(time_value):
         if isinstance(time_value, datetime):
@@ -388,15 +390,12 @@ def extract_timeline_points(data, year):
             return None
         return timestamp
 
-    def add_point(time_value, coordinate_value):
-        coordinate = parse_coordinate(coordinate_value)
-        if coordinate is None:
-            return
-        timestamp = parse_timestamp(time_value)
-        if timestamp is None:
-            return
+    def add_point(output, timestamp, coordinate):
+        if timestamp is None or coordinate is None:
+            return False
         if timestamp.year == year:
-            points.append({'dt': timestamp, 'lat': coordinate[0], 'lon': coordinate[1]})
+            output.append({'dt': timestamp, 'lat': coordinate[0], 'lon': coordinate[1]})
+        return True
 
     for seg in segments:
         if not isinstance(seg, dict):
@@ -404,24 +403,76 @@ def extract_timeline_points(data, year):
         start_time = seg.get('startTime')
         end_time = seg.get('endTime')
 
+        activity = seg.get('activity')
+        visit = seg.get('visit')
+        candidate = visit.get('topCandidate') if isinstance(visit, dict) else None
+        activity_start = activity.get('start') if isinstance(activity, dict) else None
+        activity_end = activity.get('end') if isinstance(activity, dict) else None
+        visit_location = candidate.get('placeLocation') if isinstance(candidate, dict) else None
+        activity_start_coordinate = parse_coordinate(activity_start)
+        activity_end_coordinate = parse_coordinate(activity_end)
+        visit_coordinate = parse_coordinate(visit_location)
+        has_usable_semantic_record = any(
+            coordinate is not None
+            for coordinate in (activity_start_coordinate, activity_end_coordinate, visit_coordinate)
+        )
+        path_output = canonical_points if has_usable_semantic_record else standalone_path_points
+
         for path_point in seg.get('timelinePath', []):
             if isinstance(path_point, dict):
-                add_point(path_timestamp(path_point, start_time, end_time), path_point.get('point'))
+                add_point(
+                    path_output,
+                    path_timestamp(path_point, start_time, end_time),
+                    parse_coordinate(path_point.get('point')),
+                )
 
-        activity = seg.get('activity')
+        start = parse_timestamp(start_time) if has_usable_semantic_record else None
+        end = parse_timestamp(end_time) if has_usable_semantic_record else None
         if isinstance(activity, dict):
-            add_point(start_time, activity.get('start'))
-            add_point(end_time, activity.get('end'))
+            add_point(canonical_points, start, activity_start_coordinate)
+            add_point(canonical_points, end, activity_end_coordinate)
 
-        visit = seg.get('visit')
-        if isinstance(visit, dict):
-            candidate = visit.get('topCandidate')
-            if isinstance(candidate, dict):
-                add_point(start_time, candidate.get('placeLocation'))
+        if isinstance(candidate, dict):
+            add_point(canonical_points, start, visit_coordinate)
+
+        if has_usable_semantic_record:
+            if (
+                start is not None
+                and end is not None
+                and start.utcoffset() is not None
+                and end.utcoffset() is not None
+                and end >= start
+            ):
+                semantic_intervals.append((start, end))
+
+    semantic_intervals.sort(key=lambda interval: interval[0])
+    merged_intervals = []
+    for start, end in semantic_intervals:
+        if not merged_intervals or start > merged_intervals[-1][1]:
+            merged_intervals.append([start, end])
+        elif end > merged_intervals[-1][1]:
+            merged_intervals[-1][1] = end
+
+    # Some direct-array exports append a second path-only history for periods already
+    # represented by activities and visits. Same-segment path detail stays canonical.
+    interval_index = 0
+    for point in sorted(standalone_path_points, key=lambda item: item['dt']):
+        timestamp = point['dt']
+        if timestamp.utcoffset() is None:
+            canonical_points.append(point)
+            continue
+        while interval_index < len(merged_intervals) and merged_intervals[interval_index][1] < timestamp:
+            interval_index += 1
+        covered = (
+            interval_index < len(merged_intervals)
+            and merged_intervals[interval_index][0] <= timestamp <= merged_intervals[interval_index][1]
+        )
+        if not covered:
+            canonical_points.append(point)
 
     unique = {
         (point['dt'], point['lat'], point['lon']): point
-        for point in points
+        for point in canonical_points
     }
     return sorted(unique.values(), key=lambda point: point['dt'])
 

--- a/web/src/timeline.test.ts
+++ b/web/src/timeline.test.ts
@@ -42,6 +42,51 @@ describe('parseTimelineJson', () => {
     expect(parseTimelineJson({ semanticSegments: directExport })).toHaveLength(3);
   });
 
+  it('suppresses standalone path points covered by semantic segments', () => {
+    const points = parseTimelineJson([
+      {
+        startTime: '2026-05-11T08:00:00Z',
+        endTime: '2026-05-11T22:00:00Z',
+        activity: { start: '10,10', end: '20,20' },
+      },
+      {
+        startTime: '2026-05-12T08:00:00Z',
+        endTime: '2026-05-12T22:00:00Z',
+        activity: { start: '20,20', end: '10,10' },
+      },
+      {
+        startTime: '2026-05-11T08:00:00Z',
+        endTime: '2026-05-12T23:00:00Z',
+        timelinePath: [
+          { point: '20,20', time: '2026-05-11T13:00:00Z' },
+          { point: '10,10', time: '2026-05-11T17:00:00Z' },
+          { point: '10,10', time: '2026-05-12T13:00:00Z' },
+          { point: '20,20', time: '2026-05-12T17:00:00Z' },
+          { point: '30,30', time: '2026-05-12T22:30:00Z' },
+        ],
+      },
+    ]);
+
+    expect(points.map((point) => [point.instant.toISOString(), point.latitude])).toEqual([
+      ['2026-05-11T08:00:00.000Z', 10],
+      ['2026-05-11T22:00:00.000Z', 20],
+      ['2026-05-12T08:00:00.000Z', 20],
+      ['2026-05-12T22:00:00.000Z', 10],
+      ['2026-05-12T22:30:00.000Z', 30],
+    ]);
+  });
+
+  it('keeps path detail inside the same semantic segment', () => {
+    const points = parseTimelineJson([{
+      startTime: '2026-01-01T00:00:00Z',
+      endTime: '2026-01-01T02:00:00Z',
+      activity: { start: '10,10', end: '20,20' },
+      timelinePath: [{ point: '15,15', time: '2026-01-01T01:00:00Z' }],
+    }]);
+
+    expect(points.map((point) => point.latitude)).toEqual([10, 15, 20]);
+  });
+
   it('parses string and numeric offsets from a segment start', () => {
     const points = parseTimelineJson([{
       startTime: '2026-01-01T00:00:00Z',

--- a/web/src/timeline.ts
+++ b/web/src/timeline.ts
@@ -60,6 +60,12 @@ interface ParsedInstant {
 interface ParsedTimelineSegment {
   anchor: Date | null;
   points: GeoPoint[];
+  standalonePath: boolean;
+}
+
+interface TimeInterval {
+  start: number;
+  end: number;
 }
 
 const SEGMENT_DIRECTION_SIGNAL_MS = 36 * 60 * 60 * 1000;
@@ -102,10 +108,10 @@ function parseOffsetInstant(startValue: unknown, endValue: unknown, offsetValue:
   return instant;
 }
 
-function addPoint(output: GeoPoint[], time: unknown, coordinate: unknown): void {
+function addPoint(output: GeoPoint[], time: unknown, coordinate: unknown): boolean {
   const parsedTime = parseInstant(time);
   const parsed = parseCoordinate(coordinate);
-  if (!parsedTime || !parsed) return;
+  if (!parsedTime || !parsed) return false;
   output.push({
     instant: parsedTime.instant,
     latitude: parsed[0],
@@ -113,6 +119,45 @@ function addPoint(output: GeoPoint[], time: unknown, coordinate: unknown): void 
     recordedDate: parsedTime.recordedDate,
     timeZoneMissing: parsedTime.timeZoneMissing,
   });
+  return true;
+}
+
+function semanticInterval(startValue: unknown, endValue: unknown): TimeInterval | null {
+  const start = parseInstant(startValue);
+  const end = parseInstant(endValue);
+  if (!start || !end || start.timeZoneMissing || end.timeZoneMissing) return null;
+  const startMillis = start.instant.getTime();
+  const endMillis = end.instant.getTime();
+  return endMillis >= startMillis ? { start: startMillis, end: endMillis } : null;
+}
+
+function mergeIntervals(intervals: TimeInterval[]): TimeInterval[] {
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  const merged: TimeInterval[] = [];
+  for (const interval of sorted) {
+    const previous = merged.at(-1);
+    if (!previous || interval.start > previous.end) {
+      merged.push({ ...interval });
+    } else if (interval.end > previous.end) {
+      previous.end = interval.end;
+    }
+  }
+  return merged;
+}
+
+function isCovered(point: GeoPoint, intervals: TimeInterval[]): boolean {
+  if (point.timeZoneMissing) return false;
+  const timestamp = point.instant.getTime();
+  let low = 0;
+  let high = intervals.length - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const interval = intervals[middle];
+    if (timestamp < interval.start) high = middle - 1;
+    else if (timestamp > interval.end) low = middle + 1;
+    else return true;
+  }
+  return false;
 }
 
 function normalizeSegmentDirection(segments: ParsedTimelineSegment[]): ParsedTimelineSegment[] {
@@ -159,18 +204,22 @@ export function parseTimelineJson(data: unknown): GeoPoint[] {
   }
 
   const parsedSegments: ParsedTimelineSegment[] = [];
+  const semanticIntervals: TimeInterval[] = [];
   for (const rawSegment of segments) {
     if (!isObject(rawSegment)) continue;
     const startTime = rawSegment.startTime;
     const endTime = rawSegment.endTime;
     const segmentPoints: GeoPoint[] = [];
+    let semanticPointAdded = false;
+    const hasPath = Array.isArray(rawSegment.timelinePath);
 
     if (isObject(rawSegment.activity)) {
-      addPoint(segmentPoints, startTime, rawSegment.activity.start);
+      semanticPointAdded = addPoint(segmentPoints, startTime, rawSegment.activity.start) || semanticPointAdded;
     }
 
     if (isObject(rawSegment.visit) && isObject(rawSegment.visit.topCandidate)) {
-      addPoint(segmentPoints, startTime, rawSegment.visit.topCandidate.placeLocation);
+      semanticPointAdded = addPoint(segmentPoints, startTime, rawSegment.visit.topCandidate.placeLocation)
+        || semanticPointAdded;
     }
 
     if (Array.isArray(rawSegment.timelinePath)) {
@@ -194,17 +243,29 @@ export function parseTimelineJson(data: unknown): GeoPoint[] {
     }
 
     if (isObject(rawSegment.activity)) {
-      addPoint(segmentPoints, endTime, rawSegment.activity.end);
+      semanticPointAdded = addPoint(segmentPoints, endTime, rawSegment.activity.end) || semanticPointAdded;
     }
     if (segmentPoints.length > 0) {
+      if (semanticPointAdded) {
+        const interval = semanticInterval(startTime, endTime);
+        if (interval) semanticIntervals.push(interval);
+      }
       parsedSegments.push({
         anchor: parseInstant(startTime)?.instant ?? segmentPoints[0].instant,
         points: segmentPoints,
+        standalonePath: hasPath && !semanticPointAdded,
       });
     }
   }
 
-  const points = normalizeSegmentDirection(parsedSegments).flatMap((segment) => segment.points);
+  const coverage = mergeIntervals(semanticIntervals);
+  // Direct-array exports can append a second path-only history for periods already
+  // represented by activities and visits. Same-segment path detail remains canonical.
+  const points = normalizeSegmentDirection(parsedSegments).flatMap((segment) => (
+    segment.standalonePath
+      ? segment.points.filter((point) => !isCovered(point, coverage))
+      : segment.points
+  ));
   const unique = new Map<string, GeoPoint>();
   for (const point of points) {
     const key = `${point.instant.getTime()}:${point.latitude}:${point.longitude}`;


### PR DESCRIPTION
## Problem

Some direct-array Timeline exports contain a semantic activity and visit history plus a separate path-only history covering the same periods. The parsers currently flatten both sources, which can repeat long-distance journeys and create backtracking.

## Outcome

- Treat usable activity and visit intervals as authoritative.
- Suppress only standalone path points covered by those intervals.
- Preserve same-segment path detail, uncovered path points, and path-only exports.
- Keep Android, web, and Python behavior aligned.
- Release as version 2.2.1 with version code 20.

## Validation

- Android unit tests for both flavors, lint, and both debug APK assemblies
- Existing 45 MB streaming import test
- New 6,000-segment Android mixed-history stress test
- 26 Python tests
- 37 web tests, TypeScript check, and production build
- 25,000-segment Python benchmark with 10,000 covered path points removed and negligible added processing time

## Privacy and compatibility

Processing remains local and the source Timeline file is unchanged. No permissions, storage migration, analytics, or network behavior is added.

Related to #81.