### PR TITLE
Prepare v2.2.2 visual fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.2
+
+- Follow the Android system setting with matching light and dark app interfaces.
+- Keep Road map tiles and exported video appearance unchanged in both system themes.
+- Extend the bottom-navigation surface behind the gesture indicator or navigation-button area.
+- Preserve complete bottom-navigation icons and labels without applying the system inset twice.
+- Set Android version code 21 and version name 2.2.2.
+
 ## 2.2.1
 
 - Prevent repeated or backtracking routes when independent semantic and path histories cover the same time.

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,7 @@ MP4 の作成には H.264 エンコードに対応した Safari 16.4 以降が�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.2.1.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.2.2.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,7 +32,7 @@ MP4를 만들려면 H.264 인코딩을 지원하는 Safari 16.4 이상이 필요
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.2.1.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.2.2.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use Safari's Share menu and choose **Add to Home Screen**.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.2.1.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.2.2.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 20
-        versionName = "2.2.1"
+        versionCode = 21
+        versionName = "2.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -6,6 +6,7 @@ import android.app.LocaleManager
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
@@ -29,6 +30,7 @@ import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -197,6 +199,12 @@ class MainActivity : AppCompatActivity() {
         editor = ScreenNewVideoBinding.bind(findViewById(R.id.newVideoScreen))
         settingsScreen = ScreenSettingsBinding.bind(findViewById(R.id.settingsScreen))
         playerScreen = ScreenPlayerBinding.bind(findViewById(R.id.playerScreen))
+        val lightSystemBars = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
+            Configuration.UI_MODE_NIGHT_YES
+        WindowInsetsControllerCompat(window, binding.root).apply {
+            isAppearanceLightStatusBars = lightSystemBars
+            isAppearanceLightNavigationBars = lightSystemBars
+        }
         timelineSourceStore.recoverInterruptedImport()?.let { uri ->
             releaseUriAccess(uri)
             interruptedTimelineRecovered = true
@@ -204,7 +212,13 @@ class MainActivity : AppCompatActivity() {
         }
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
             val bars: Insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(0, bars.top, 0, bars.bottom)
+            view.setPadding(0, bars.top, 0, 0)
+            binding.bottomNavigation.setPadding(
+                binding.bottomNavigation.paddingLeft,
+                binding.bottomNavigation.paddingTop,
+                binding.bottomNavigation.paddingRight,
+                bars.bottom,
+            )
             WindowInsetsCompat.CONSUMED
         }
 

--- a/app/src/main/res/layout/item_video.xml
+++ b/app/src/main/res/layout/item_video.xml
@@ -18,7 +18,7 @@
             android:id="@+id/videoThumbnail"
             android:layout_width="88dp"
             android:layout_height="88dp"
-            android:background="#E7E0E2"
+            android:background="@color/thumbnail_surface"
             android:contentDescription="@string/video_thumbnail"
             android:padding="18dp"
             android:scaleType="centerCrop"
@@ -80,4 +80,3 @@
         </LinearLayout>
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>
-

--- a/app/src/main/res/layout/screen_settings.xml
+++ b/app/src/main/res/layout/screen_settings.xml
@@ -33,7 +33,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="24dp" android:text="@string/about_and_privacy" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
-        <TextView android:id="@+id/versionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:gravity="center_horizontal" android:textAppearance="?attr/textAppearanceBodyMedium" tools:text="Version 2.2.1 (20)" />
+        <TextView android:id="@+id/versionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:gravity="center_horizontal" android:textAppearance="?attr/textAppearanceBodyMedium" tools:text="Version 2.2.2 (21)" />
         <TextView android:id="@+id/privacyText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:text="@string/privacy_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
         <com.google.android.material.button.MaterialButton android:id="@+id/privacyPolicyButton" style="@style/Widget.Material3.Button.TextButton" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center_horizontal" android:maxLines="1" android:text="@string/privacy_policy" />
         <com.google.android.material.button.MaterialButton android:id="@+id/checkUpdatesButton" style="@style/Widget.Material3.Button.TextButton" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center_horizontal" android:maxLines="1" android:text="@string/check_for_updates" />

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,10 @@
+<resources>
+    <color name="interactive">#FFB1C8</color>
+    <color name="on_interactive">#65002A</color>
+    <color name="surface">#1B1115</color>
+    <color name="surface_container">#281B20</color>
+    <color name="on_surface">#F1DEE4</color>
+    <color name="on_surface_variant">#D9C1C9</color>
+    <color name="outline">#A58A93</color>
+    <color name="thumbnail_surface">#3A3034</color>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,5 +1,5 @@
 <resources>
-    <style name="Theme.TimelineVisualizer" parent="Theme.Material3.Light.NoActionBar">
+    <style name="Theme.TimelineVisualizer" parent="Theme.Material3.Dark.NoActionBar">
         <item name="colorPrimary">@color/interactive</item>
         <item name="colorOnPrimary">@color/on_interactive</item>
         <item name="colorSurface">@color/surface</item>
@@ -8,7 +8,7 @@
         <item name="colorOnSurfaceVariant">@color/on_surface_variant</item>
         <item name="colorOutline">@color/outline</item>
         <item name="android:colorAccent">@color/interactive</item>
-        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightStatusBar">false</item>
         <item name="android:statusBarColor">@color/surface</item>
         <item name="android:navigationBarColor">@color/surface_container</item>
         <item name="android:windowBackground">@color/surface</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,5 +5,8 @@
     <color name="surface">#FFF8FA</color>
     <color name="surface_container">#F7EEF1</color>
     <color name="on_surface">#24191D</color>
+    <color name="on_surface_variant">#574147</color>
+    <color name="outline">#8A7078</color>
+    <color name="thumbnail_surface">#E7E0E2</color>
     <color name="map_surface">#EEE8EA</color>
 </resources>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.google.android.material.button.MaterialButton
 import androidx.test.core.app.ApplicationProvider
 import dev.mahlernim.timelinevisualizer.videos.VideoRecord
@@ -605,8 +606,8 @@ class MainActivityTest {
         measureActivity(activity)
 
         val navigation = activity.findViewById<ViewGroup>(R.id.bottomNavigation)
-        assertEquals(bottomInset, root.paddingBottom)
-        assertEquals(0, navigation.paddingBottom)
+        assertEquals(0, root.paddingBottom)
+        assertEquals(bottomInset, navigation.paddingBottom)
         assertNavigationItemsInsideBounds(navigation)
     }
 
@@ -645,10 +646,37 @@ class MainActivityTest {
         measureActivity(activity)
 
         val navigation = activity.findViewById<ViewGroup>(R.id.bottomNavigation)
-        assertEquals(bottomInset, root.paddingBottom)
-        assertEquals(0, navigation.paddingBottom)
-        assertTrue(navigation.measuredHeight >= (80 * density).toInt())
+        assertEquals(topInset, root.paddingTop)
+        assertEquals(0, root.paddingBottom)
+        assertEquals(bottomInset, navigation.paddingBottom)
+        assertTrue(navigation.measuredHeight >= (80 * density).toInt() + bottomInset)
         assertNavigationItemsInsideBounds(navigation)
+    }
+
+    @Test
+    @Config(sdk = [35], qualifiers = "notnight")
+    fun systemLightModeUsesLightThemeAndSystemBars() {
+        val activity = launchActivity()
+
+        assertEquals(activity.getColor(R.color.surface), resolvedColor(activity, com.google.android.material.R.attr.colorSurface))
+        assertEquals(activity.getColor(R.color.surface_container), resolvedColor(activity, com.google.android.material.R.attr.colorSurfaceContainer))
+        assertEquals(true, resolvedBoolean(activity, android.R.attr.windowLightStatusBar))
+        assertEquals(true, WindowInsetsControllerCompat(activity.window, activity.window.decorView).isAppearanceLightNavigationBars)
+        assertEquals(activity.getColor(R.color.surface), resolvedColor(activity, android.R.attr.statusBarColor))
+        assertEquals(activity.getColor(R.color.surface_container), resolvedColor(activity, android.R.attr.navigationBarColor))
+    }
+
+    @Test
+    @Config(sdk = [35], qualifiers = "night")
+    fun systemDarkModeUsesDarkThemeAndSystemBars() {
+        val activity = launchActivity()
+
+        assertEquals(activity.getColor(R.color.surface), resolvedColor(activity, com.google.android.material.R.attr.colorSurface))
+        assertEquals(activity.getColor(R.color.surface_container), resolvedColor(activity, com.google.android.material.R.attr.colorSurfaceContainer))
+        assertEquals(false, resolvedBoolean(activity, android.R.attr.windowLightStatusBar))
+        assertEquals(false, WindowInsetsControllerCompat(activity.window, activity.window.decorView).isAppearanceLightNavigationBars)
+        assertEquals(activity.getColor(R.color.surface), resolvedColor(activity, android.R.attr.statusBarColor))
+        assertEquals(activity.getColor(R.color.surface_container), resolvedColor(activity, android.R.attr.navigationBarColor))
     }
 
     @Test
@@ -773,8 +801,20 @@ class MainActivityTest {
             val label = item.findViewById<TextView>(com.google.android.material.R.id.navigation_bar_item_large_label_view)
             assertTrue(icon.top >= 0 && icon.bottom <= item.height)
             assertTrue(label.height > 0 && label.top >= 0 && label.bottom <= item.height)
-            assertTrue(item.top >= 0 && item.bottom <= navigation.height)
+            assertTrue(item.top >= 0 && item.bottom <= navigation.height - navigation.paddingBottom)
         }
+    }
+
+    private fun resolvedBoolean(activity: MainActivity, attribute: Int): Boolean {
+        val value = TypedValue()
+        assertTrue(activity.theme.resolveAttribute(attribute, value, true))
+        return value.data != 0
+    }
+
+    private fun resolvedColor(activity: MainActivity, attribute: Int): Int {
+        val value = TypedValue()
+        assertTrue(activity.theme.resolveAttribute(attribute, value, true))
+        return value.data
     }
 
     private fun waitUntil(condition: () -> Boolean) {

--- a/docs/release-notes-v2.2.2.md
+++ b/docs/release-notes-v2.2.2.md
@@ -1,0 +1,59 @@
+# Timeline Visualizer 2.2.2
+
+The app interface now follows the Android system setting and switches automatically
+between light and dark colors. Road maps and exported videos keep their existing
+appearance. The bottom-navigation background now extends behind the Android gesture
+indicator or navigation-button area without clipping its icons or labels.
+
+## 한국어
+
+앱 화면이 Android 시스템 설정에 따라 밝은 테마와 어두운 테마 사이에서 자동으로
+전환됩니다. 기존 도로 지도와 내보낸 영상의 모양은 그대로 유지됩니다. 하단 탐색 배경은
+아이콘이나 라벨을 자르지 않고 Android 제스처 표시줄 또는 탐색 버튼 영역까지 이어집니다.
+
+## 日本語
+
+アプリ画面が Android のシステム設定に従い、ライトテーマとダークテーマを自動的に
+切り替えるようになりました。道路地図と書き出した動画の表示は変わりません。下部ナビ
+ゲーションの背景は、アイコンやラベルを切らずにジェスチャー表示またはナビゲーション
+ボタン領域まで広がります。
+
+## 简体中文
+
+应用界面现在会跟随 Android 系统设置，在浅色和深色主题之间自动切换。道路地图和导出
+视频的外观保持不变。底部导航背景会延伸到 Android 手势指示条或导航按钮区域，同时不会
+裁切图标或标签。
+
+## 繁體中文
+
+應用程式介面現在會跟隨 Android 系統設定，在淺色和深色主題之間自動切換。道路地圖和
+匯出影片的外觀維持不變。底部導覽背景會延伸到 Android 手勢指示列或導覽按鈕區域，同時
+不會裁切圖示或標籤。
+
+## Español
+
+La interfaz ahora sigue la configuración del sistema Android y cambia automáticamente
+entre los temas claro y oscuro. Los mapas de carreteras y los vídeos exportados conservan
+su aspecto. El fondo de navegación inferior se extiende tras el área de gestos o botones
+sin recortar los iconos ni las etiquetas.
+
+## Français
+
+L'interface suit maintenant le réglage du système Android et bascule automatiquement
+entre les thèmes clair et sombre. Les cartes routières et les vidéos exportées conservent
+leur apparence. L'arrière-plan de navigation inférieur s'étend derrière la zone des gestes
+ou des boutons sans couper les icônes ni les libellés.
+
+## Deutsch
+
+Die App-Oberfläche folgt jetzt der Android-Systemeinstellung und wechselt automatisch
+zwischen hellem und dunklem Design. Straßenkarten und exportierte Videos behalten ihr
+bisheriges Aussehen. Der Hintergrund der unteren Navigation reicht bis in den Gesten-
+oder Schaltflächenbereich, ohne Symbole oder Beschriftungen abzuschneiden.
+
+## Português (Brasil)
+
+A interface agora segue a configuração do sistema Android e alterna automaticamente
+entre os temas claro e escuro. Os mapas rodoviários e os vídeos exportados mantêm a
+aparência atual. O fundo da navegação inferior se estende pela área de gestos ou botões
+sem cortar os ícones nem os rótulos.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.1` and version code `20`
+- Version name `2.2.2` and version code `21`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- follow the Android system light or dark setting for the app interface
- keep Road map tiles and exported video appearance unchanged
- extend the bottom-navigation surface behind the system navigation area without double-applying the inset
- prepare Android version name 2.2.2 and version code 21

Targets #78 and #79. The issues will be closed after the public release is independently verified.

## Validation

- `./gradlew test lint assembleGithubDebug assemblePlayDebug assembleGithubDebugAndroidTest --stacktrace`
- 26 Python tests passed
- 6 API 36 device tests passed on an isolated emulator
- API 36 light and dark Create and Settings screens visually checked
- gesture indicator background is continuous in both themes
- `git diff --check` passed