### PR TITLE
Keep video export progress visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.2.4
+
+- Keep video-generation progress visible above bottom navigation while scrolling or switching app tabs.
+- Show the current generation phase, percentage, estimated remaining time when available, and Cancel in one persistent tray.
+- Change the tray to Watch and Share when a video is ready, or Retry when generation fails.
+- Keep the preview playback scrubber separate from generation progress.
+- Announce major generation phase and result changes without announcing every percentage update.
+- Preserve the existing export service, background notifications, saved export recovery, and cancellation behavior.
+- Translate the new Retry action in all nine supported app languages.
+- Set Android version code 23 and version name 2.2.4.
+
 ## 2.2.3
 
 - Recognize raw location records that may accompany or replace processed Timeline visits and trips.

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,7 @@ MP4 の作成には H.264 エンコードに対応した Safari 16.4 以降が�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.2.2.apk` をダウンロードします。
+1. **Assets** にある `TimelineVisualizer-v2.2.4.apk` をダウンロードします。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,7 +32,7 @@ MP4를 만들려면 H.264 인코딩을 지원하는 Safari 16.4 이상이 필요
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.2.2.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 `TimelineVisualizer-v2.2.4.apk`를 휴대전화로 다운로드합니다.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use Safari's Share menu and choose **Add to Home Screen**.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.2.2.apk` on your phone.
+1. Under **Assets**, download `TimelineVisualizer-v2.2.4.apk` on your phone.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22
-        versionName = "2.2.3"
+        versionCode = 23
+        versionName = "2.2.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -158,6 +158,7 @@ class MainActivity : AppCompatActivity() {
     private var rememberedTimelineLoaded = false
     private var interruptedTimelineRecovered = false
     private var lastRenderedExportStatus = VideoExportStatus.IDLE
+    private var lastAnnouncedExportPhase: ExportPhase? = null
     private var videoPlayer: ExoPlayer? = null
     private var playerUri: Uri? = null
     private var playerPositionMs = 0L
@@ -241,7 +242,10 @@ class MainActivity : AppCompatActivity() {
             }
             true
         }
-        home.homeCancelExportButton.setOnClickListener { VideoExportService.cancel(applicationContext) }
+        binding.exportTrayCancelButton.setOnClickListener { VideoExportService.cancel(applicationContext) }
+        binding.exportTrayRetryButton.setOnClickListener { retryVideoExport() }
+        binding.exportTrayWatchButton.setOnClickListener { lastVideoUri?.let(::watchVideo) }
+        binding.exportTrayShareButton.setOnClickListener { lastVideoUri?.let(::shareVideo) }
         editor.doneButton.setOnClickListener {
             VideoExportCoordinator.clear(applicationContext)
             editor.videoReadyGroup.visibility = View.GONE
@@ -253,7 +257,6 @@ class MainActivity : AppCompatActivity() {
         editor.restoreTimelineHelpLink.setOnClickListener { openRestoreGuide() }
         editor.playButton.setOnClickListener { togglePreview() }
         editor.exportButton.setOnClickListener { chooseExportDestination() }
-        editor.cancelExportButton.setOnClickListener { VideoExportService.cancel(applicationContext) }
         editor.shareButton.setOnClickListener { lastVideoUri?.let(::shareVideo) }
         editor.saveOverviewButton.setOnClickListener { lastVideoUri?.let(::chooseOverviewDestination) }
         editor.shareOverviewButton.setOnClickListener { lastVideoUri?.let(::shareOverviewImage) }
@@ -1419,7 +1422,6 @@ class MainActivity : AppCompatActivity() {
         )
         VideoExportCoordinator.publish(applicationContext, snapshot)
         runCatching { VideoExportService.start(applicationContext) }.onFailure {
-            VideoExportRequestStore(applicationContext).clear()
             generatedMedia.discard(uri)
             VideoExportCoordinator.publish(
                 applicationContext,
@@ -1442,11 +1444,14 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun renderVideoExport(snapshot: VideoExportSnapshot) {
-        home.homeExportGroup.visibility = if (snapshot.status == VideoExportStatus.RUNNING) View.VISIBLE else View.GONE
         when (snapshot.status) {
-            VideoExportStatus.IDLE -> setExporting(false)
+            VideoExportStatus.IDLE -> {
+                setExporting(false)
+                hideExportTray()
+            }
             VideoExportStatus.RUNNING -> {
                 setExporting(true)
+                showRunningExportTray()
                 snapshot.progress?.let { showExportProgress(it, snapshot.startedAtMillis) }
             }
             VideoExportStatus.COMPLETE -> {
@@ -1461,23 +1466,68 @@ class MainActivity : AppCompatActivity() {
                     editor.shareOverviewButton.isEnabled = hasOverview
                 }
                 editor.statusText.text = getString(R.string.video_saved)
+                showCompletedExportTray()
                 if (lastRenderedExportStatus != VideoExportStatus.COMPLETE) renderVideos()
             }
             VideoExportStatus.CANCELLED -> {
                 setExporting(false)
+                hideExportTray()
                 editor.statusText.text = getString(R.string.video_creation_cancelled)
             }
             VideoExportStatus.FAILED -> {
                 setExporting(false)
                 editor.statusText.setText(R.string.video_export_failed)
+                showFailedExportTray(snapshot.errorMessage)
             }
         }
         lastRenderedExportStatus = snapshot.status
     }
 
+    private fun showRunningExportTray() {
+        binding.exportStatusTray.visibility = View.VISIBLE
+        binding.exportTrayProgress.visibility = View.VISIBLE
+        binding.exportTrayCancelButton.visibility = View.VISIBLE
+        binding.exportTrayWatchButton.visibility = View.GONE
+        binding.exportTrayShareButton.visibility = View.GONE
+        binding.exportTrayRetryButton.visibility = View.GONE
+    }
+
+    private fun showCompletedExportTray() {
+        binding.exportStatusTray.visibility = View.VISIBLE
+        binding.exportTrayProgress.visibility = View.GONE
+        binding.exportTrayCancelButton.visibility = View.GONE
+        binding.exportTrayRetryButton.visibility = View.GONE
+        binding.exportTrayWatchButton.visibility = if (lastVideoUri != null) View.VISIBLE else View.GONE
+        binding.exportTrayShareButton.visibility = if (lastVideoUri != null) View.VISIBLE else View.GONE
+        binding.exportTrayStatusText.setText(R.string.video_ready)
+        if (lastRenderedExportStatus != VideoExportStatus.COMPLETE) {
+            announceExportStatus(getString(R.string.video_ready))
+        }
+        lastAnnouncedExportPhase = null
+    }
+
+    private fun showFailedExportTray(message: String?) {
+        binding.exportStatusTray.visibility = View.VISIBLE
+        binding.exportTrayProgress.visibility = View.GONE
+        binding.exportTrayCancelButton.visibility = View.GONE
+        binding.exportTrayWatchButton.visibility = View.GONE
+        binding.exportTrayShareButton.visibility = View.GONE
+        binding.exportTrayRetryButton.visibility = View.VISIBLE
+        binding.exportTrayRetryButton.isEnabled = true
+        binding.exportTrayStatusText.text = message ?: getString(R.string.video_export_failed)
+        if (lastRenderedExportStatus != VideoExportStatus.FAILED) {
+            announceExportStatus(binding.exportTrayStatusText.text)
+        }
+        lastAnnouncedExportPhase = null
+    }
+
+    private fun hideExportTray() {
+        binding.exportStatusTray.visibility = View.GONE
+        lastAnnouncedExportPhase = null
+    }
+
     private fun showExportProgress(progress: ExportProgress, startedAtMillis: Long) {
-        editor.exportProgress.progress = (progress.fraction * 1000).toInt()
-        home.homeExportProgress.progress = (progress.fraction * 1000).toInt()
+        binding.exportTrayProgress.progress = (progress.fraction * 1000).toInt()
         if (progress.phase == ExportPhase.COMPLETE) return
         val base = when (progress.phase) {
             ExportPhase.PREPARING_MAP -> getString(
@@ -1503,7 +1553,55 @@ class MainActivity : AppCompatActivity() {
             getString(R.string.progress_with_eta, base, formatRemainingTime(remaining))
         } else base
         editor.statusText.text = status
-        home.homeExportStatusText.text = status
+        binding.exportTrayStatusText.text = status
+        if (lastAnnouncedExportPhase != progress.phase) {
+            announceExportStatus(base)
+            lastAnnouncedExportPhase = progress.phase
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun announceExportStatus(status: CharSequence) {
+        binding.exportTrayStatusText.announceForAccessibility(status)
+    }
+
+    private fun retryVideoExport() {
+        binding.exportTrayRetryButton.isEnabled = false
+        lifecycleScope.launch {
+            val request = withContext(Dispatchers.IO) {
+                VideoExportRequestStore(applicationContext).load()
+            }
+            retryVideoExport(request)
+        }
+    }
+
+    private fun retryVideoExport(request: VideoExportRequest?) {
+        if (request == null) {
+            VideoExportCoordinator.clear(applicationContext)
+            showNewVideo(loadRemembered = true)
+            Snackbar.make(binding.root, R.string.video_request_unavailable, Snackbar.LENGTH_LONG).show()
+            return
+        }
+        binding.exportTrayRetryButton.isEnabled = true
+        pendingExport = request.copy(outputUri = "")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val retryRequest = pendingExport ?: return
+            pendingExport = null
+            runCatching { generatedMedia.createVideoDestination(retryRequest.title, retryRequest.journey.period) }
+                .onSuccess { uri -> uri?.let { startVideoExport(it, retryRequest) } }
+                .onFailure {
+                    VideoExportCoordinator.publish(
+                        applicationContext,
+                        VideoExportSnapshot(
+                            status = VideoExportStatus.FAILED,
+                            title = retryRequest.title,
+                            errorMessage = getString(R.string.video_request_unavailable),
+                        ),
+                    )
+                }
+        } else {
+            createVideo.launch("${generatedMedia.fileBaseName(request.title, request.journey.period)}.mp4")
+        }
     }
 
     private fun formatRemainingTime(seconds: Int): String = if (seconds < 90) {
@@ -1516,8 +1614,6 @@ class MainActivity : AppCompatActivity() {
     private fun setExporting(exporting: Boolean) {
         exportingVideo = exporting
         val canCreate = journey?.let(::canCreateVideo) == true && editor.timelineView.isCameraReady
-        editor.exportProgress.visibility = if (exporting) View.VISIBLE else View.GONE
-        editor.cancelExportButton.visibility = if (exporting) View.VISIBLE else View.GONE
         home.deleteAllVideosButton.isEnabled = !exporting
         editor.importButton.isEnabled = !exporting && editor.loadingGroup.visibility != View.VISIBLE
         editor.playButton.isEnabled = !exporting && canCreate

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
@@ -167,7 +167,6 @@ class VideoExportService : Service() {
         } catch (error: Throwable) {
             Log.e(TAG, "Video export failed", error)
             GeneratedMediaRepository(applicationContext).discard(uri)
-            requestStore.clear()
             finishWithFailure(request, failureMessage(error), startId)
             return
         } finally {
@@ -205,7 +204,7 @@ class VideoExportService : Service() {
     }
 
     private fun finishWithFailure(request: VideoExportRequest?, message: String, startId: Int) {
-        requestStore.clear()
+        if (request == null) requestStore.clear()
         publish(
             VideoExportSnapshot(
                 status = VideoExportStatus.FAILED,

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,6 +30,87 @@
             android:visibility="gone" />
     </FrameLayout>
 
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/exportStatusTray"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="8dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="@color/surface_container"
+        app:cardCornerRadius="18dp"
+        app:strokeWidth="0dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingTop="14dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="8dp">
+
+            <TextView
+                android:id="@+id/exportTrayStatusText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/creating_video"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textStyle="bold" />
+
+            <com.google.android.material.progressindicator.LinearProgressIndicator
+                android:id="@+id/exportTrayProgress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:max="1000" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end|center_vertical"
+                android:orientation="horizontal">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/exportTrayWatchButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:text="@string/watch"
+                    android:visibility="gone" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/exportTrayShareButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:text="@string/share"
+                    android:visibility="gone" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/exportTrayRetryButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:text="@string/retry"
+                    android:visibility="gone" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/exportTrayCancelButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:text="@string/cancel"
+                    android:visibility="gone" />
+            </LinearLayout>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/screen_new_video.xml
+++ b/app/src/main/res/layout/screen_new_video.xml
@@ -251,9 +251,6 @@
                 <com.google.android.material.button.MaterialButton android:id="@+id/exportButton" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:maxLines="1" android:text="@string/create_video" />
             </LinearLayout>
 
-            <com.google.android.material.button.MaterialButton android:id="@+id/cancelExportButton" style="@style/Widget.Material3.Button.OutlinedButton" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:maxLines="1" android:text="@string/cancel" android:visibility="gone" />
-            <com.google.android.material.progressindicator.LinearProgressIndicator android:id="@+id/exportProgress" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:max="1000" android:visibility="gone" />
-
             <LinearLayout android:id="@+id/videoReadyGroup" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="16dp" android:orientation="vertical" android:visibility="gone">
                 <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="@string/video_saved" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
                 <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:orientation="horizontal">

--- a/app/src/main/res/layout/screen_videos.xml
+++ b/app/src/main/res/layout/screen_videos.xml
@@ -38,47 +38,6 @@
             android:maxLines="1"
             android:text="@string/add_videos" />
 
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/homeExportGroup"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:visibility="gone"
-            app:cardBackgroundColor="@color/surface_container"
-            app:cardCornerRadius="16dp"
-            app:strokeWidth="0dp">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="16dp">
-
-                <TextView
-                    android:id="@+id/homeExportStatusText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/creating_video"
-                    android:textAppearance="?attr/textAppearanceBodyMedium" />
-
-                <com.google.android.material.progressindicator.LinearProgressIndicator
-                    android:id="@+id/homeExportProgress"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:max="1000" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/homeCancelExportButton"
-                    style="@style/Widget.Material3.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="end"
-                    android:maxLines="1"
-                    android:text="@string/cancel" />
-            </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
-
         <TextView
             android:id="@+id/emptyVideosText"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -56,6 +56,7 @@
     <string name="cancel_video_creation">Videoerstellung abbrechen</string>
     <string name="video_creation_cancelled">Videoerstellung abgebrochen</string>
     <string name="cancel">Stornieren</string>
+    <string name="retry">Erneut versuchen</string>
     <string name="not_now">Nicht jetzt</string>
     <string name="background_video_title">Erstellen Sie im Hintergrund weiter</string>
     <string name="background_video_message">Erlauben Sie Benachrichtigungen, um den Videofortschritt nach dem Verlassen der App zu sehen und eine Benachrichtigung zu erhalten, wenn Ihr Video fertig ist. Die Videoerstellung wird auch dann fortgesetzt, wenn Benachrichtigungen nicht zulässig sind.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -57,6 +57,7 @@
     <string name="cancel_video_creation">Cancelar la creación de vídeo</string>
     <string name="video_creation_cancelled">Creación de vídeo cancelada</string>
     <string name="cancel">Cancelar</string>
+    <string name="retry">Reintentar</string>
     <string name="not_now">Ahora no</string>
     <string name="background_video_title">Continuar creando en segundo plano.</string>
     <string name="background_video_message">Permita que las notificaciones vean el progreso del video después de salir de la aplicación y reciba una alerta cuando su video esté listo. La creación de videos continúa incluso si no se permiten notificaciones.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -57,6 +57,7 @@
     <string name="cancel_video_creation">Annuler la création vidéo</string>
     <string name="video_creation_cancelled">Création vidéo annulée</string>
     <string name="cancel">Annuler</string>
+    <string name="retry">Réessayer</string>
     <string name="not_now">Pas maintenant</string>
     <string name="background_video_title">Continuer à créer en arrière-plan</string>
     <string name="background_video_message">Autorisez les notifications à voir la progression de la vidéo après avoir quitté l\'application et recevez une alerte lorsque votre vidéo est prête. La création vidéo continue même si les notifications ne sont pas autorisées.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -54,6 +54,7 @@
     <string name="cancel_video_creation">動画作成をキャンセル</string>
     <string name="video_creation_cancelled">動画作成をキャンセルしました</string>
     <string name="cancel">キャンセル</string>
+    <string name="retry">再試行</string>
     <string name="not_now">後で</string>
     <string name="background_video_title">バックグラウンドで作成を続ける</string>
     <string name="background_video_message">アプリを閉じた後も進行状況を確認し、完成時に通知を受け取るには通知を許可してください。通知を許可しなくても動画作成は続きます。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -54,6 +54,7 @@
     <string name="cancel_video_creation">영상 만들기 취소</string>
     <string name="video_creation_cancelled">영상 만들기를 취소했습니다</string>
     <string name="cancel">취소</string>
+    <string name="retry">다시 시도</string>
     <string name="not_now">나중에</string>
     <string name="background_video_title">백그라운드에서 영상 계속 만들기</string>
     <string name="background_video_message">앱을 나간 뒤에도 영상 진행률을 확인하고 완성 알림을 받으려면 알림을 허용하세요. 알림을 허용하지 않아도 영상 만들기는 계속됩니다.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -57,6 +57,7 @@
     <string name="cancel_video_creation">Cancelar a criação do vídeo</string>
     <string name="video_creation_cancelled">Criação de vídeo cancelada</string>
     <string name="cancel">Cancelar</string>
+    <string name="retry">Tentar novamente</string>
     <string name="not_now">Agora não</string>
     <string name="background_video_title">Continue criando em segundo plano</string>
     <string name="background_video_message">Permita notificações para ver o progresso do vídeo depois de sair do aplicativo e receba um alerta quando seu vídeo estiver pronto. A criação do vídeo continua mesmo que as notificações não sejam permitidas.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -55,6 +55,7 @@
     <string name="cancel_video_creation">取消视频创建</string>
     <string name="video_creation_cancelled">视频创作已取消</string>
     <string name="cancel">取消</string>
+    <string name="retry">重试</string>
     <string name="not_now">现在不要</string>
     <string name="background_video_title">继续在后台创建</string>
     <string name="background_video_message">允许通知在离开应用程序后查看视频进度，并在视频准备就绪时收到提醒。即使不允许通知，视频创建也会继续。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -55,6 +55,7 @@
     <string name="cancel_video_creation">取消影片創建</string>
     <string name="video_creation_cancelled">影片創作已取消</string>
     <string name="cancel">取消</string>
+    <string name="retry">重試</string>
     <string name="not_now">現在不要</string>
     <string name="background_video_title">繼續在背景創建</string>
     <string name="background_video_message">允許通知在離開應用程式後查看視訊進度，並在視訊準備就緒時收到提醒。即使不允許通知，視訊建立也會繼續。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="cancel_video_creation">Cancel video creation</string>
     <string name="video_creation_cancelled">Video creation cancelled</string>
     <string name="cancel">Cancel</string>
+    <string name="retry">Retry</string>
     <string name="not_now">Not now</string>
     <string name="background_video_title">Continue creating in the background</string>
     <string name="background_video_message">Allow notifications to see video progress after leaving the app and get an alert when your video is ready. Video creation continues even if notifications are not allowed.</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.AutoCompleteTextView
+import android.widget.SeekBar
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.graphics.Insets
@@ -18,11 +19,14 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.progressindicator.LinearProgressIndicator
 import androidx.test.core.app.ApplicationProvider
 import dev.mahlernim.timelinevisualizer.videos.VideoRecord
 import dev.mahlernim.timelinevisualizer.videos.VideoStore
 import dev.mahlernim.timelinevisualizer.data.TimelineSourceStore
 import dev.mahlernim.timelinevisualizer.export.VideoExportCoordinator
+import dev.mahlernim.timelinevisualizer.export.ExportPhase
+import dev.mahlernim.timelinevisualizer.export.ExportProgress
 import dev.mahlernim.timelinevisualizer.export.VideoExportSnapshot
 import dev.mahlernim.timelinevisualizer.export.VideoExportStateStore
 import dev.mahlernim.timelinevisualizer.export.VideoExportStatus
@@ -502,7 +506,71 @@ class MainActivityTest {
         shadowOf(Looper.getMainLooper()).idle()
 
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
-        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.homeExportGroup).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportTrayCancelButton).visibility)
+    }
+
+    @Test
+    fun generationProgressTrayIsIndependentFromPreviewPlaybackControl() {
+        val activity = launchActivity()
+        val playback = activity.findViewById<SeekBar>(R.id.timelineSeek)
+        playback.progress = 375
+
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.RUNNING,
+                progress = ExportProgress(0.42f, ExportPhase.CREATING_VIDEO, 42, 100),
+                startedAtMillis = System.currentTimeMillis(),
+            ),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(375, playback.progress)
+        assertEquals(420, activity.findViewById<LinearProgressIndicator>(R.id.exportTrayProgress).progress)
+    }
+
+    @Test
+    fun generationProgressTrayLivesOutsideScrollableScreens() {
+        val activity = launchActivity()
+        val root = activity.findViewById<ViewGroup>(R.id.exportStatusTray).parent as ViewGroup
+        val tray = activity.findViewById<View>(R.id.exportStatusTray)
+        val bottomNavigation = activity.findViewById<View>(R.id.bottomNavigation)
+
+        assertTrue(root.indexOfChild(tray) < root.indexOfChild(bottomNavigation))
+    }
+
+    @Test
+    fun completedExportTrayOffersWatchAndShare() {
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.COMPLETE,
+                outputUri = "content://example/generated-video",
+                title = "Trip",
+            ),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportTrayWatchButton).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportTrayShareButton).visibility)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportTrayProgress).visibility)
+    }
+
+    @Test
+    fun failedExportTrayOffersRetry() {
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(status = VideoExportStatus.FAILED, errorMessage = "Could not create video"),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportTrayRetryButton).visibility)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportTrayProgress).visibility)
     }
 
     @Test
@@ -542,7 +610,7 @@ class MainActivityTest {
         activity.onBackPressedDispatcher.onBackPressed()
 
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
-        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.homeExportGroup).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
         assertEquals(VideoExportStatus.RUNNING, VideoExportStateStore(context).load().status)
     }
 

--- a/docs/release-notes-v2.2.4.md
+++ b/docs/release-notes-v2.2.4.md
@@ -1,0 +1,64 @@
+# Timeline Visualizer 2.2.4
+
+Video creation progress now stays visible above bottom navigation while you scroll or
+switch tabs. The persistent tray shows the current phase, percentage, estimated time
+remaining when available, and Cancel. When the video is ready it offers Watch and Share,
+and a failed export offers Retry. The preview playback scrubber remains a separate control.
+
+## 한국어
+
+이제 화면을 스크롤하거나 탭을 바꿔도 영상 생성 진행 상황이 하단 탐색 메뉴 위에 계속
+표시됩니다. 고정 진행 창에서 현재 단계, 진행률, 가능한 경우 예상 남은 시간과 취소 버튼을
+확인할 수 있습니다. 영상이 완성되면 보기와 공유 버튼이, 생성에 실패하면 다시 시도 버튼이
+표시됩니다. 미리보기 재생 위치 조절 막대는 별도의 컨트롤로 유지됩니다.
+
+## 日本語
+
+画面をスクロールしたりタブを切り替えたりしても、動画作成の進捗が下部ナビゲーションの
+上に表示され続けるようになりました。固定トレイには現在の段階、進捗率、利用できる場合
+は推定残り時間、キャンセルが表示されます。動画の準備が完了すると見ると共有、失敗時は
+再試行が表示されます。プレビューの再生位置スライダーは別の操作のままです。
+
+## 简体中文
+
+滚动页面或切换标签页时，视频生成进度现在会持续显示在底部导航栏上方。固定状态栏会显示
+当前阶段、完成百分比、可用时的预计剩余时间以及取消操作。视频完成后会显示观看和分享，
+失败时会显示重试。预览播放位置滑块仍是独立控件。
+
+## 繁體中文
+
+捲動畫面或切換分頁時，影片產生進度現在會持續顯示在底部導覽列上方。固定狀態列會顯示
+目前階段、完成百分比、可用時的預估剩餘時間以及取消操作。影片完成後會顯示觀看和分享，
+失敗時會顯示重試。預覽播放位置滑桿仍是獨立控制項。
+
+## Español
+
+El progreso de creación del vídeo ahora permanece visible sobre la navegación inferior
+al desplazarse o cambiar de pestaña. La bandeja muestra la fase actual, el porcentaje,
+el tiempo restante estimado cuando está disponible y Cancelar. Al terminar ofrece Ver y
+Compartir, y si falla ofrece Reintentar. El control de reproducción de la vista previa
+sigue siendo independiente.
+
+## Français
+
+La progression de la création vidéo reste maintenant visible au-dessus de la navigation
+inférieure pendant le défilement ou le changement d'onglet. Le panneau affiche l'étape,
+le pourcentage, le temps restant estimé lorsqu'il est disponible et Annuler. Une fois la
+vidéo prête, il propose Regarder et Partager. En cas d'échec, il propose Réessayer. Le
+curseur de lecture de l'aperçu reste une commande distincte.
+
+## Deutsch
+
+Der Fortschritt der Videoerstellung bleibt nun beim Scrollen oder Wechseln zwischen Tabs
+oberhalb der unteren Navigation sichtbar. Die Leiste zeigt die aktuelle Phase, den
+Prozentsatz, sofern verfügbar die geschätzte Restzeit und Abbrechen. Nach Abschluss stehen
+Ansehen und Teilen bereit, bei einem Fehler Erneut versuchen. Der Wiedergaberegler der
+Vorschau bleibt eine separate Steuerung.
+
+## Português (Brasil)
+
+O progresso da criação do vídeo agora permanece visível acima da navegação inferior ao
+rolar a tela ou trocar de aba. A bandeja mostra a etapa atual, a porcentagem, o tempo
+restante estimado quando disponível e Cancelar. Ao concluir, oferece Assistir e
+Compartilhar. Em caso de falha, oferece Tentar novamente. O controle de reprodução da
+prévia continua separado.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.3` and version code `22`
+- Version name `2.2.4` and version code `23`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- replace the scroll-dependent export indicators with one persistent status tray above bottom navigation
- keep preview playback seeking separate from video-generation progress
- show phase, percentage, ETA, and Cancel while running
- show Watch and Share when complete, and Retry after failure
- preserve pending export data after failure so Retry can create a fresh destination
- localize Retry in all nine supported app languages
- bump Android to version 2.2.4, code 23

## Validation

- `./gradlew test lint assembleGithubDebug assemblePlayDebug`
- 103 Android tasks passed
- `python -m pytest -q`, 26 passed
- `pnpm test -- --run`, 39 passed
- `pnpm run build`
- compact 360 dp visual render checked for tray visibility and bottom-navigation separation

Closes #90