### PR TITLE
Add automatic distance units for v2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.5
+
+- Add Automatic, Kilometers, and Miles distance-unit choices.
+- Resolve Automatic from the device region and show the resolved unit directly in Settings.
+- Apply the selected unit consistently to selected-period summaries, previews, and exported videos.
+- Restore Automatic together with the other video defaults.
+- Preserve kilometers internally for route processing and convert only user-facing distances.
+- Translate the new distance-unit setting in all nine supported app languages.
+- Set Android version code 24 and version name 2.2.5.
+
 ## 2.2.4
 
 - Keep video-generation progress visible above bottom navigation while scrolling or switching app tabs.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 23
-        versionName = "2.2.4"
+        versionCode = 24
+        versionName = "2.2.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -7,6 +7,7 @@ import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
+import android.content.res.Resources
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
@@ -78,10 +79,13 @@ import dev.mahlernim.timelinevisualizer.model.VideoDuration
 import dev.mahlernim.timelinevisualizer.render.TimelineAnimation
 import dev.mahlernim.timelinevisualizer.render.RenderText
 import dev.mahlernim.timelinevisualizer.render.CameraSettings
+import dev.mahlernim.timelinevisualizer.render.DistanceUnit
+import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
 import dev.mahlernim.timelinevisualizer.render.CameraMovement
 import dev.mahlernim.timelinevisualizer.render.LongTripCompression
 import dev.mahlernim.timelinevisualizer.render.VideoQuality
 import dev.mahlernim.timelinevisualizer.ui.CameraSettingsPreferences
+import dev.mahlernim.timelinevisualizer.ui.DistanceUnitPreferences
 import dev.mahlernim.timelinevisualizer.ui.AppLanguage
 import dev.mahlernim.timelinevisualizer.ui.LocationFilterPreferences
 import dev.mahlernim.timelinevisualizer.ui.SelectionArrayAdapter
@@ -123,6 +127,7 @@ class MainActivity : AppCompatActivity() {
     private var rawSignalsEnabled = false
     private var rawOnlyImport = false
     private var journey: Journey? = null
+    private var selectedIgnoredCount = 0
     private var animation: ValueAnimator? = null
     private var pendingExport: VideoExportRequest? = null
     private var lastVideoUri: Uri? = null
@@ -145,9 +150,11 @@ class MainActivity : AppCompatActivity() {
     private val generatedMedia by lazy { GeneratedMediaRepository(applicationContext) }
     private val timelineSourceStore by lazy { TimelineSourceStore(applicationContext) }
     private val cameraSettingsPreferences by lazy { CameraSettingsPreferences(applicationContext) }
+    private val distanceUnitPreferences by lazy { DistanceUnitPreferences(applicationContext) }
     private val locationFilterPreferences by lazy { LocationFilterPreferences(applicationContext) }
     private val videoEncoderProfiles by lazy { VideoEncoderSupport.deviceProfiles() }
     private var cameraSettings = CameraSettings.DEFAULT
+    private var distanceUnitPreference = DistanceUnitPreference.AUTOMATIC
     private var videoFormatSupported = true
     private var locationFilterMode = LocationFilterMode.CONSERVATIVE
     private var routeDurationSeconds = VideoDuration.DEFAULT_SECONDS
@@ -307,6 +314,7 @@ class MainActivity : AppCompatActivity() {
         } + getString(R.string.custom_duration)
         editor.durationDropdown.setAdapter(SelectionArrayAdapter(this, durations))
         applyDuration(VideoDuration.DEFAULT_SECONDS)
+        configureDistanceUnitSelection()
         editor.timelineView.renderText = currentRenderText()
         editor.durationDropdown.setOnItemClickListener { _, _, position, _ ->
             if (position == VideoDuration.presets.size) {
@@ -461,6 +469,9 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         if (::settingsScreen.isInitialized) updateLanguageSelectionLabel()
+        if (::settingsScreen.isInitialized && distanceUnitPreference == DistanceUnitPreference.AUTOMATIC) {
+            applyDistanceUnitPreference(distanceUnitPreference, save = false)
+        }
     }
 
     override fun onStop() {
@@ -797,6 +808,7 @@ class MainActivity : AppCompatActivity() {
     private fun applySelectedJourney(selected: Journey, ignoredCount: Int) {
         animation?.cancel()
         journey = selected
+        selectedIgnoredCount = ignoredCount
         editor.timelineView.journey = selected
         editor.timelineSeek.progress = 0
         showProgress(0f)
@@ -807,13 +819,15 @@ class MainActivity : AppCompatActivity() {
 
     internal fun selectedPeriodSummary(selected: Journey, ignoredCount: Int = 0): String {
         val number = NumberFormat.getNumberInstance().apply { maximumFractionDigits = 0 }
+        val unit = resolvedDistanceUnit()
         if (selected.points.isEmpty()) return withOutlierSummary(getString(R.string.selected_period_empty), ignoredCount)
         if (selected.points.size == 1) return withOutlierSummary(getString(R.string.selected_period_one_point), ignoredCount)
         if (rawSignalsEnabled) {
             return getString(
                 R.string.raw_location_summary,
                 number.format(selected.points.size),
-                number.format(selected.totalDistanceKm),
+                number.format(unit.fromKilometers(selected.totalDistanceKm)),
+                unit.symbol,
                 number.format(rawSignalProcessing?.rejectedCount ?: ignoredCount),
             )
         }
@@ -856,7 +870,8 @@ class MainActivity : AppCompatActivity() {
             getString(
                 R.string.selected_period_summary,
                 number.format(selected.points.size),
-                number.format(selected.totalDistanceKm),
+                number.format(unit.fromKilometers(selected.totalDistanceKm)),
+                unit.symbol,
                 period,
             ),
             ignoredCount,
@@ -1137,6 +1152,7 @@ class MainActivity : AppCompatActivity() {
             updateAdvancedSettings(cameraSettings.copy(videoQuality = VideoQuality.values()[position]))
         }
         settingsScreen.resetAdvancedSettingsButton.setOnClickListener {
+            applyDistanceUnitPreference(DistanceUnitPreference.AUTOMATIC)
             applyAdvancedSettings(cameraSettingsPreferences.reset())
             Snackbar.make(binding.root, R.string.advanced_defaults_restored, Snackbar.LENGTH_SHORT).show()
         }
@@ -1162,6 +1178,58 @@ class MainActivity : AppCompatActivity() {
         locationFilterMode = locationFilterPreferences.load()
         updateLocationFilterLabel()
     }
+
+    private fun configureDistanceUnitSelection() {
+        distanceUnitPreference = distanceUnitPreferences.load()
+        val dropdown = settingsScreen.distanceUnitDropdown
+        dropdown.setAdapter(SelectionArrayAdapter(this, distanceUnitLabels()))
+        makeDropdownOpenReliably(dropdown)
+        updateDistanceUnitLabel()
+        dropdown.setOnItemClickListener { _, _, position, _ ->
+            applyDistanceUnitPreference(DistanceUnitPreference.entries[position])
+        }
+    }
+
+    private fun applyDistanceUnitPreference(preference: DistanceUnitPreference, save: Boolean = true) {
+        distanceUnitPreference = preference
+        if (save) distanceUnitPreferences.save(preference)
+        updateDistanceUnitLabel()
+        editor.timelineView.renderText = currentRenderText()
+        journey?.let { editor.periodSummaryText.text = selectedPeriodSummary(it, selectedIgnoredCount) }
+        showProgress(editor.timelineSeek.progress / 1000f)
+    }
+
+    private fun updateDistanceUnitLabel() {
+        val dropdown = settingsScreen.distanceUnitDropdown
+        val labels = distanceUnitLabels()
+        dropdown.setAdapter(SelectionArrayAdapter(this, labels))
+        dropdown.setText(labels[distanceUnitPreference.ordinal], false)
+    }
+
+    private fun distanceUnitLabels(): List<String> {
+        val automatic = getString(
+            R.string.distance_unit_automatic_resolved,
+            getString(R.string.distance_unit_automatic),
+            distanceUnitName(DistanceUnit.automatic(systemLocale())),
+        )
+        return listOf(
+            automatic,
+            getString(R.string.distance_unit_kilometers),
+            getString(R.string.distance_unit_miles),
+        )
+    }
+
+    private fun distanceUnitName(unit: DistanceUnit): String = getString(
+        when (unit) {
+            DistanceUnit.KILOMETERS -> R.string.distance_unit_kilometers
+            DistanceUnit.MILES -> R.string.distance_unit_miles
+        },
+    )
+
+    private fun resolvedDistanceUnit(): DistanceUnit = distanceUnitPreference.resolve(systemLocale())
+
+    private fun systemLocale(): Locale =
+        Resources.getSystem().configuration.locales[0] ?: Locale.getDefault(Locale.Category.FORMAT)
 
     private fun configureLanguageSelection() {
         val labels = listOf(
@@ -2086,12 +2154,14 @@ class MainActivity : AppCompatActivity() {
 
     private fun currentRenderText(): RenderText {
         val locale = resources.configuration.locales[0] ?: Locale.getDefault()
+        val distanceUnit = resolvedDistanceUnit()
         return RenderText(
             localeTag = locale.toLanguageTag(),
             fallbackTitle = getString(R.string.default_title),
             datePattern = getString(R.string.render_date_pattern),
-            distanceUnit = getString(R.string.distance_unit),
+            distanceUnit = distanceUnit.symbol,
             attribution = getString(R.string.map_attribution),
+            distanceScale = distanceUnit.kilometersMultiplier,
         )
     }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequest.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequest.kt
@@ -45,6 +45,7 @@ class VideoExportRequestStore(context: Context) {
             output.writeUTF(request.renderText.datePattern)
             output.writeUTF(request.renderText.distanceUnit)
             output.writeUTF(request.renderText.attribution)
+            output.writeDouble(request.renderText.distanceScale)
             output.writeUTF(request.cameraSettings.cameraMovement.name)
             output.writeUTF(request.cameraSettings.longTripCompression.name)
             output.writeUTF(request.cameraSettings.videoQuality.name)
@@ -85,12 +86,19 @@ class VideoExportRequestStore(context: Context) {
                 } else {
                     endYear = input.readInt()
                     endMonth = input.readInt()
+                    val localeTag = input.readUTF()
+                    val fallbackTitle = input.readUTF()
+                    val datePattern = input.readUTF()
+                    val distanceUnit = input.readUTF()
+                    val attribution = input.readUTF()
+                    val distanceScale = if (version >= 5) input.readDouble() else 1.0
                     renderText = RenderText(
-                        localeTag = input.readUTF(),
-                        fallbackTitle = input.readUTF(),
-                        datePattern = input.readUTF(),
-                        distanceUnit = input.readUTF(),
-                        attribution = input.readUTF(),
+                        localeTag = localeTag,
+                        fallbackTitle = fallbackTitle,
+                        datePattern = datePattern,
+                        distanceUnit = distanceUnit,
+                        attribution = attribution,
+                        distanceScale = distanceScale,
                     )
                     cameraSettings = if (version >= 4) {
                         CameraSettings(
@@ -142,7 +150,7 @@ class VideoExportRequestStore(context: Context) {
     }
 
     companion object {
-        private const val CURRENT_FILE_VERSION = 4
+        private const val CURRENT_FILE_VERSION = 5
         private const val MAX_POINT_COUNT = 2_000_000
         private const val REQUEST_FILE = "pending-video-export.bin"
         private const val TEMPORARY_FILE = "pending-video-export.tmp"

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/DistanceUnit.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/DistanceUnit.kt
@@ -1,0 +1,49 @@
+package dev.mahlernim.timelinevisualizer.render
+
+import android.icu.util.LocaleData
+import android.icu.util.ULocale
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.util.Locale
+
+enum class DistanceUnit(
+    val symbol: String,
+    val kilometersMultiplier: Double,
+) {
+    KILOMETERS("km", 1.0),
+    MILES("mi", 0.621371192237334),
+    ;
+
+    fun fromKilometers(kilometers: Double): Double = kilometers * kilometersMultiplier
+
+    companion object {
+        fun automatic(locale: Locale): DistanceUnit =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) automaticFromIcu(locale) else automaticFallback(locale)
+
+        @RequiresApi(Build.VERSION_CODES.P)
+        private fun automaticFromIcu(locale: Locale): DistanceUnit = when (
+            LocaleData.getMeasurementSystem(ULocale.forLocale(locale))
+        ) {
+            LocaleData.MeasurementSystem.US, LocaleData.MeasurementSystem.UK -> MILES
+            else -> KILOMETERS
+        }
+
+        private fun automaticFallback(locale: Locale): DistanceUnit =
+            if (locale.country.uppercase(Locale.ROOT) in MILE_REGIONS) MILES else KILOMETERS
+
+        private val MILE_REGIONS = setOf("GB", "LR", "MM", "US")
+    }
+}
+
+enum class DistanceUnitPreference {
+    AUTOMATIC,
+    KILOMETERS,
+    MILES,
+    ;
+
+    fun resolve(systemLocale: Locale): DistanceUnit = when (this) {
+        AUTOMATIC -> DistanceUnit.automatic(systemLocale)
+        KILOMETERS -> DistanceUnit.KILOMETERS
+        MILES -> DistanceUnit.MILES
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/RenderText.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/RenderText.kt
@@ -1,6 +1,7 @@
 package dev.mahlernim.timelinevisualizer.render
 
 import java.time.format.DateTimeFormatter
+import java.text.NumberFormat
 import java.util.Locale
 
 data class RenderText(
@@ -9,6 +10,7 @@ data class RenderText(
     val datePattern: String,
     val distanceUnit: String,
     val attribution: String,
+    val distanceScale: Double = 1.0,
 ) {
     val locale: Locale get() = Locale.forLanguageTag(localeTag).takeUnless { it.language.isBlank() } ?: Locale.ENGLISH
 
@@ -18,6 +20,11 @@ data class RenderText(
     val dateFormatter: DateTimeFormatter by lazy(LazyThreadSafetyMode.PUBLICATION) {
         runCatching { DateTimeFormatter.ofPattern(datePattern, locale) }
             .getOrElse { DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN, locale) }
+    }
+
+    fun formatDistance(kilometers: Double): String {
+        val number = NumberFormat.getNumberInstance(locale).apply { maximumFractionDigits = 0 }
+        return "${number.format(kilometers * distanceScale)} $distanceUnit"
     }
 
     companion object {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -14,7 +14,6 @@ import dev.mahlernim.timelinevisualizer.model.MutableRenderSampleLocation
 import dev.mahlernim.timelinevisualizer.model.WebMercator
 import dev.mahlernim.timelinevisualizer.model.WorldPoint
 import java.time.ZoneId
-import java.text.NumberFormat
 import java.util.Locale
 import kotlin.math.floor
 import kotlin.math.ln
@@ -733,10 +732,8 @@ class TimelinePainter {
         }
         canvas.drawText(fittedTitle, card.centerX(), 72f * scale, titlePaint)
         val date = renderText.dateFormatter.format(position.point.instant.atZone(ZoneId.systemDefault()))
-        val distance = position.distanceKm
-        val number = NumberFormat.getNumberInstance(renderText.locale).apply { maximumFractionDigits = 0 }
         canvas.drawText(
-            "$date  ·  ${number.format(distance)} ${renderText.distanceUnit}",
+            "$date  ·  ${renderText.formatDistance(position.distanceKm)}",
             card.centerX(),
             108f * scale,
             bodyPaint,

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferences.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferences.kt
@@ -1,0 +1,28 @@
+package dev.mahlernim.timelinevisualizer.ui
+
+import android.content.Context
+import androidx.core.content.edit
+import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
+
+class DistanceUnitPreferences(context: Context) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    fun load(): DistanceUnitPreference = runCatching {
+        enumValueOf<DistanceUnitPreference>(
+            preferences.getString(KEY_DISTANCE_UNIT, null) ?: return DistanceUnitPreference.AUTOMATIC,
+        )
+    }.getOrDefault(DistanceUnitPreference.AUTOMATIC)
+
+    fun save(preference: DistanceUnitPreference) {
+        preferences.edit { putString(KEY_DISTANCE_UNIT, preference.name) }
+    }
+
+    internal fun clear() {
+        preferences.edit { clear() }
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME = "distance-unit-settings"
+        const val KEY_DISTANCE_UNIT = "distance-unit"
+    }
+}

--- a/app/src/main/res/layout/screen_settings.xml
+++ b/app/src/main/res/layout/screen_settings.xml
@@ -8,7 +8,11 @@
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="22dp" android:text="@string/video_defaults" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="4dp" android:layout_marginBottom="10dp" android:text="@string/video_defaults_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="@string/camera_movement">
+        <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="@string/distance_unit_setting">
+            <AutoCompleteTextView android:id="@+id/distanceUnitDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:hint="@string/camera_movement">
             <AutoCompleteTextView android:id="@+id/cameraMovementDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
         </com.google.android.material.textfield.TextInputLayout>
         <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:hint="@string/long_trip_compression">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -66,7 +66,6 @@
     <string name="video_creation_notification_channel">Videoerstellung</string>
     <string name="video_creation_notification_channel_description">Fortschritts- und Abschlusswarnungen für timeline-Videos</string>
     <string name="no_video_player">Für die Wiedergabe dieses Videos ist keine App verfügbar</string>
-    <string name="journey_summary">%1$s Punkte · %2$s km · %3$s</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>
     <string name="preparing_map_progress">Karte vorbereiten · %1$d/%2$d</string>
@@ -126,7 +125,6 @@
     <string name="project_on_github">Projekt auf GitHub</string>
     <string name="update_page_unavailable">Die Update-Seite konnte nicht geöffnet werden</string>
     <string name="web_page_unavailable">Die Webseite konnte nicht geöffnet werden</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline-Video</string>
     <string name="default_video_filename">Timeline Video.mp4</string>
@@ -152,7 +150,7 @@
     <string name="no_videos">Von Ihnen erstellte oder hinzugefügte Videos werden hier angezeigt.</string>
     <string name="show_all_videos">Alle anzeigen (%1$d)</string>
     <string name="show_fewer_videos">Weniger anzeigen</string>
-    <string name="selected_period_summary">%1$s Punkte · über %2$s km · %3$s</string>
+    <string name="selected_period_summary">%1$s Punkte · über %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">Keine Standortpunkte in diesem Zeitraum</string>
     <string name="selected_period_one_point">1 Standortpunkt · Wählen Sie einen größeren Zeitraum</string>
     <string name="selected_period_no_movement">%1$s Punkte · keine Bewegung erkannt</string>
@@ -203,7 +201,7 @@
     <string name="raw_accuracy_limit">Genauigkeitsgrenze (Meter)</string>
     <string name="raw_accuracy_helper">Ungenauere Standorte werden ausgeschlossen. Leer lassen, um alle verwendbaren Standorte einzubeziehen.</string>
     <string name="raw_accuracy_invalid">Null oder eine positive Zahl eingeben oder das Feld leer lassen.</string>
-    <string name="raw_location_summary">%1$s Standorte · geschätzt %2$s km · %3$s ausgeschlossen</string>
+    <string name="raw_location_summary">%1$s Standorte · geschätzt %2$s %3$s · %4$s ausgeschlossen</string>
     <string name="raw_only_title">Nur unverarbeitete Standortdaten gefunden</string>
     <string name="raw_only_message">Diese Datei enthält unverarbeitete Standortdaten, aber keine verarbeiteten Besuche oder Wege. Du kannst fortfahren, aber die Route kann ungenau oder unvollständig sein und die Entfernung ist nur eine Schätzung.\n\nÖffne für bessere Ergebnisse Google Maps, prüfe deine Zeitachse oder stelle sie wieder her und vergewissere dich, dass Besuche und Wege angezeigt werden. Exportiere die Zeitachse danach erneut und lade die neue Datei in dieser App.</string>
     <string name="open_google_maps">Google Maps öffnen</string>
@@ -220,6 +218,11 @@
     <string name="settings_summary">Legen Sie die Standardeinstellungen für Vorschauen und neue Videos fest.</string>
     <string name="video_defaults">Videostandards</string>
     <string name="video_defaults_summary">Änderungen gelten für die Vorschau und das nächste von Ihnen erstellte Video.</string>
+    <string name="distance_unit_setting">Entfernungseinheit</string>
+    <string name="distance_unit_automatic">Automatisch</string>
+    <string name="distance_unit_kilometers">Kilometer</string>
+    <string name="distance_unit_miles">Meilen</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">Timeline-Verarbeitung</string>
     <string name="location_filter">GPS-Ausreißerfilter</string>
     <string name="location_filter_summary">Die vorsichtige Filterung ignoriert nur kurze, unmögliche Hin- und Rückwege. Ihre Timeline-Datei wird nicht verändert.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -67,7 +67,6 @@
     <string name="video_creation_notification_channel">Creación de vídeos</string>
     <string name="video_creation_notification_channel_description">Alertas de progreso y finalización de videos timeline</string>
     <string name="no_video_player">No hay ninguna aplicación disponible para reproducir este vídeo.</string>
-    <string name="journey_summary">Puntos %1$s · %2$s km · %3$s</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>
     <string name="preparing_map_progress">Preparando mapa · %1$d/%2$d</string>
@@ -130,7 +129,6 @@
     <string name="project_on_github">Proyecto en GitHub</string>
     <string name="update_page_unavailable">No se pudo abrir la página de actualización</string>
     <string name="web_page_unavailable">No se pudo abrir la página web</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Vídeo Timeline</string>
     <string name="default_video_filename">Vídeo Timeline.mp4</string>
@@ -156,7 +154,7 @@
     <string name="no_videos">Los vídeos que crees o agregues aparecerán aquí.</string>
     <string name="show_all_videos">Mostrar todo (%1$d)</string>
     <string name="show_fewer_videos">Mostrar menos</string>
-    <string name="selected_period_summary">Puntos %1$s · sobre %2$s km · %3$s</string>
+    <string name="selected_period_summary">Puntos %1$s · sobre %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">No hay puntos de ubicación en este período.</string>
     <string name="selected_period_one_point">1 punto de ubicación · elige un período más amplio</string>
     <string name="selected_period_no_movement">Puntos %1$s · no se detecta movimiento</string>
@@ -207,7 +205,7 @@
     <string name="raw_accuracy_limit">Límite de precisión (metros)</string>
     <string name="raw_accuracy_helper">Se excluyen las ubicaciones menos precisas. Déjalo vacío para incluir todas las ubicaciones utilizables.</string>
     <string name="raw_accuracy_invalid">Introduce cero o un número positivo, o deja el campo vacío.</string>
-    <string name="raw_location_summary">%1$s ubicaciones · %2$s km estimados · %3$s excluidas</string>
+    <string name="raw_location_summary">%1$s ubicaciones · %2$s %3$s estimados · %4$s excluidas</string>
     <string name="raw_only_title">Solo se encontraron datos de ubicación sin procesar</string>
     <string name="raw_only_message">Este archivo contiene datos de ubicación sin procesar, pero no visitas ni trayectos procesados. Puedes continuar, pero la ruta puede ser imprecisa o estar incompleta, y la distancia será solo una estimación.\n\nPara obtener mejores resultados, abre Google Maps, confirma o restaura tu cronología y comprueba que aparezcan tus visitas y trayectos. Después, vuelve a exportar la cronología y carga el archivo nuevo en esta aplicación.</string>
     <string name="open_google_maps">Abrir Google Maps</string>
@@ -224,6 +222,11 @@
     <string name="settings_summary">Establezca los valores predeterminados utilizados para vistas previas y videos nuevos.</string>
     <string name="video_defaults">Valores predeterminados de vídeo</string>
     <string name="video_defaults_summary">Los cambios se aplican a la vista previa y al siguiente vídeo que cree.</string>
+    <string name="distance_unit_setting">Unidad de distancia</string>
+    <string name="distance_unit_automatic">Automático</string>
+    <string name="distance_unit_kilometers">Kilómetros</string>
+    <string name="distance_unit_miles">Millas</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">Procesamiento de Timeline</string>
     <string name="location_filter">Filtro de valores GPS atípicos</string>
     <string name="location_filter_summary">El filtro conservador solo ignora viajes de ida y vuelta breves e imposibles. El archivo de Timeline no se modifica.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -67,7 +67,6 @@
     <string name="video_creation_notification_channel">Création vidéo</string>
     <string name="video_creation_notification_channel_description">Alertes de progression et d\'achèvement pour les vidéos timeline</string>
     <string name="no_video_player">Aucune application n\'est disponible pour lire cette vidéo</string>
-    <string name="journey_summary">Points %1$s · %2$s km · %3$s</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>
     <string name="preparing_map_progress">Préparation de la carte · %1$d/%2$d</string>
@@ -130,7 +129,6 @@
     <string name="project_on_github">Projet sur GitHub</string>
     <string name="update_page_unavailable">Impossible d\'ouvrir la page de mise à jour</string>
     <string name="web_page_unavailable">Impossible d\'ouvrir la page Web</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Vidéo Timeline</string>
     <string name="default_video_filename">Vidéo Timeline.mp4</string>
@@ -156,7 +154,7 @@
     <string name="no_videos">Les vidéos que vous créez ou ajoutez apparaîtront ici.</string>
     <string name="show_all_videos">Afficher tout (%1$d)</string>
     <string name="show_fewer_videos">Afficher moins</string>
-    <string name="selected_period_summary">Points %1$s · à propos de %2$s km · %3$s</string>
+    <string name="selected_period_summary">Points %1$s · environ %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">Aucun point de localisation pendant cette période</string>
     <string name="selected_period_one_point">1 point de localisation · choisissez une période plus large</string>
     <string name="selected_period_no_movement">Points %1$s · aucun mouvement détecté</string>
@@ -207,7 +205,7 @@
     <string name="raw_accuracy_limit">Limite de précision (mètres)</string>
     <string name="raw_accuracy_helper">Les positions moins précises sont exclues. Laissez vide pour inclure toutes les positions utilisables.</string>
     <string name="raw_accuracy_invalid">Saisissez zéro ou un nombre positif, ou laissez ce champ vide.</string>
-    <string name="raw_location_summary">%1$s positions · %2$s km estimés · %3$s exclues</string>
+    <string name="raw_location_summary">%1$s positions · %2$s %3$s estimés · %4$s exclues</string>
     <string name="raw_only_title">Seules des données de localisation brutes ont été trouvées</string>
     <string name="raw_only_message">Ce fichier contient des données de localisation brutes, mais aucune visite ni aucun trajet traité. Vous pouvez continuer, mais l’itinéraire peut être imprécis ou incomplet, et la distance ne sera qu’une estimation.\n\nPour de meilleurs résultats, ouvrez Google Maps, vérifiez ou restaurez votre chronologie, puis assurez-vous que vos visites et trajets apparaissent. Exportez ensuite de nouveau votre chronologie et chargez le nouveau fichier dans cette application.</string>
     <string name="open_google_maps">Ouvrir Google Maps</string>
@@ -224,6 +222,11 @@
     <string name="settings_summary">Définissez les valeurs par défaut utilisées pour les aperçus et les nouvelles vidéos.</string>
     <string name="video_defaults">Paramètres vidéo par défaut</string>
     <string name="video_defaults_summary">Les modifications s\'appliquent à l\'aperçu et à la prochaine vidéo que vous créez.</string>
+    <string name="distance_unit_setting">Unité de distance</string>
+    <string name="distance_unit_automatic">Automatique</string>
+    <string name="distance_unit_kilometers">Kilomètres</string>
+    <string name="distance_unit_miles">Miles</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">Traitement de la Timeline</string>
     <string name="location_filter">Filtrage des valeurs GPS aberrantes</string>
     <string name="location_filter_summary">Le filtrage prudent ignore uniquement les courts allers-retours impossibles. Votre fichier Timeline n\'est jamais modifié.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -64,7 +64,6 @@
     <string name="video_creation_notification_channel">動画作成</string>
     <string name="video_creation_notification_channel_description">タイムライン動画の進行状況と完了通知</string>
     <string name="no_video_player">この動画を再生できるアプリがありません</string>
-    <string name="journey_summary">位置 %1$s件 · %2$s km · %3$s</string>
     <string name="period_same_year">%3$d年%1$s～%2$s</string>
     <string name="period_cross_year">%2$d年%1$s～%4$d年%3$s</string>
     <string name="preparing_map_progress">地図を準備中 · %1$d/%2$d</string>
@@ -122,7 +121,6 @@
     <string name="update_page_unavailable">更新ページを開けませんでした</string>
     <string name="web_page_unavailable">ウェブページを開けませんでした</string>
     <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy年M月</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap  © CARTO</string>
     <string name="timeline_video">タイムライン動画</string>
     <string name="default_video_filename">タイムライン動画.mp4</string>
@@ -148,7 +146,7 @@
     <string name="no_videos">作成または追加した動画がここに表示されます。</string>
     <string name="show_all_videos">すべて表示（%1$d）</string>
     <string name="show_fewer_videos">表示を減らす</string>
-    <string name="selected_period_summary">位置 %1$s件 · 約%2$s km · %3$s</string>
+    <string name="selected_period_summary">位置 %1$s件 · 約%2$s %3$s · %4$s</string>
     <string name="selected_period_empty">この期間に位置情報はありません</string>
     <string name="selected_period_one_point">位置 1件 · 期間を広げてください</string>
     <string name="selected_period_no_movement">位置 %1$s件 · 移動はありません</string>
@@ -199,7 +197,7 @@
     <string name="raw_accuracy_limit">精度の上限（メートル）</string>
     <string name="raw_accuracy_helper">精度の低い位置は除外されます。使用可能な位置をすべて含める場合は空欄にしてください。</string>
     <string name="raw_accuracy_invalid">0以上の数値を入力するか、空欄にしてください。</string>
-    <string name="raw_location_summary">位置 %1$s件 · 推定 %2$s km · %3$s件除外</string>
+    <string name="raw_location_summary">位置 %1$s件 · 推定 %2$s %3$s · %4$s件除外</string>
     <string name="raw_only_title">未処理の位置情報のみが見つかりました</string>
     <string name="raw_only_message">このファイルには未処理の位置情報のみが含まれ、処理済みの訪問や移動はありません。続行できますが、経路が不正確または不完全になり、距離は推定値になります。\n\nより正確な結果を得るには、Google マップを開いてタイムラインを確認または復元し、訪問や移動が表示されることを確認してください。その後、タイムラインを再度エクスポートし、新しいファイルをこのアプリで読み込んでください。</string>
     <string name="open_google_maps">Google マップを開く</string>
@@ -216,6 +214,11 @@
     <string name="settings_summary">プレビューと新しい動画に使用する初期値を設定します。</string>
     <string name="video_defaults">動画の初期設定</string>
     <string name="video_defaults_summary">変更はプレビューと次に作成する動画に適用されます。</string>
+    <string name="distance_unit_setting">距離の単位</string>
+    <string name="distance_unit_automatic">自動</string>
+    <string name="distance_unit_kilometers">キロメートル</string>
+    <string name="distance_unit_miles">マイル</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">タイムライン処理</string>
     <string name="location_filter">GPS外れ値フィルター</string>
     <string name="location_filter_summary">慎重なフィルターで、短時間では不可能な往復移動だけを無視します。タイムライン ファイルは変更されません。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -64,7 +64,6 @@
     <string name="video_creation_notification_channel">영상 만들기</string>
     <string name="video_creation_notification_channel_description">타임라인 영상의 진행률과 완성 알림</string>
     <string name="no_video_player">이 영상을 재생할 앱이 없습니다</string>
-    <string name="journey_summary">위치 %1$s개 · %2$s km · %3$s</string>
     <string name="period_same_year">%3$d년 %1$s–%2$s</string>
     <string name="period_cross_year">%2$d년 %1$s–%4$d년 %3$s</string>
     <string name="preparing_map_progress">지도 준비 중 · 타일 %1$d/%2$d</string>
@@ -122,7 +121,6 @@
     <string name="update_page_unavailable">업데이트 페이지를 열 수 없습니다</string>
     <string name="web_page_unavailable">웹페이지를 열 수 없습니다</string>
     <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy년 M월</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap  © CARTO</string>
     <string name="timeline_video">타임라인 영상</string>
     <string name="default_video_filename">타임라인 영상.mp4</string>
@@ -148,7 +146,7 @@
     <string name="no_videos">직접 만들거나 추가한 영상이 여기에 표시됩니다.</string>
     <string name="show_all_videos">전체 보기 (%1$d)</string>
     <string name="show_fewer_videos">간단히 보기</string>
-    <string name="selected_period_summary">위치 %1$s개 · 약 %2$s km · %3$s</string>
+    <string name="selected_period_summary">위치 %1$s개 · 약 %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">이 기간에는 위치 정보가 없습니다</string>
     <string name="selected_period_one_point">위치 1개 · 기간을 넓혀 주세요</string>
     <string name="selected_period_no_movement">위치 %1$s개 · 이동 없음</string>
@@ -199,7 +197,7 @@
     <string name="raw_accuracy_limit">정확도 한도(미터)</string>
     <string name="raw_accuracy_helper">정확도가 낮은 위치는 제외됩니다. 사용 가능한 모든 위치를 포함하려면 비워 두세요.</string>
     <string name="raw_accuracy_invalid">0 이상의 숫자를 입력하거나 비워 두세요.</string>
-    <string name="raw_location_summary">위치 %1$s개 · 추정 거리 %2$s km · %3$s개 제외</string>
+    <string name="raw_location_summary">위치 %1$s개 · 추정 거리 %2$s %3$s · %4$s개 제외</string>
     <string name="raw_only_title">원시 위치 데이터만 발견됨</string>
     <string name="raw_only_message">이 파일에는 처리된 방문 및 이동 기록 없이 원시 위치 정보만 포함되어 있습니다. 계속할 수 있지만 경로가 부정확하거나 일부 누락될 수 있으며, 이동 거리는 추정값으로 표시됩니다.\n\n더 정확한 결과를 얻으려면 Google 지도에서 타임라인을 확인하거나 복원하고, 방문 및 이동 기록이 표시되는지 확인하세요. 그런 다음 타임라인을 다시 내보낸 후 이 앱에서 불러오세요.</string>
     <string name="open_google_maps">Google 지도 열기</string>
@@ -216,6 +214,11 @@
     <string name="settings_summary">미리보기와 새 동영상에 사용할 기본값을 설정합니다.</string>
     <string name="video_defaults">동영상 기본값</string>
     <string name="video_defaults_summary">변경 사항은 미리보기와 다음에 만드는 동영상에 적용됩니다.</string>
+    <string name="distance_unit_setting">거리 단위</string>
+    <string name="distance_unit_automatic">자동</string>
+    <string name="distance_unit_kilometers">킬로미터</string>
+    <string name="distance_unit_miles">마일</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">타임라인 처리</string>
     <string name="location_filter">GPS 이상치 필터링</string>
     <string name="location_filter_summary">보수적 필터링은 짧고 불가능한 왕복 이동만 무시합니다. 타임라인 파일은 변경되지 않습니다.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,7 +67,6 @@
     <string name="video_creation_notification_channel">Criação de vídeo</string>
     <string name="video_creation_notification_channel_description">Alertas de progresso e conclusão para vídeos timeline</string>
     <string name="no_video_player">Nenhum aplicativo está disponível para reproduzir este vídeo</string>
-    <string name="journey_summary">Pontos %1$s · %2$s km · %3$s</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>
     <string name="preparing_map_progress">Preparando mapa · %1$d/%2$d</string>
@@ -130,7 +129,6 @@
     <string name="project_on_github">Projeto em GitHub</string>
     <string name="update_page_unavailable">Não foi possível abrir a página de atualização</string>
     <string name="web_page_unavailable">Não foi possível abrir a página da web</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap</string>
     <string name="timeline_video">Vídeo Timeline</string>
     <string name="default_video_filename">Vídeo Timeline.mp4</string>
@@ -156,7 +154,7 @@
     <string name="no_videos">Os vídeos que você criar ou adicionar aparecerão aqui.</string>
     <string name="show_all_videos">Mostrar tudo (%1$d)</string>
     <string name="show_fewer_videos">Mostrar menos</string>
-    <string name="selected_period_summary">Pontos %1$s · sobre %2$s km · %3$s</string>
+    <string name="selected_period_summary">Pontos %1$s · cerca de %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">Nenhum ponto de localização neste período</string>
     <string name="selected_period_one_point">1 ponto de localização · escolha um período mais amplo</string>
     <string name="selected_period_no_movement">Pontos %1$s · nenhum movimento detectado</string>
@@ -207,7 +205,7 @@
     <string name="raw_accuracy_limit">Limite de precisão (metros)</string>
     <string name="raw_accuracy_helper">Locais menos precisos são excluídos. Deixe em branco para incluir todos os locais utilizáveis.</string>
     <string name="raw_accuracy_invalid">Digite zero ou um número positivo, ou deixe em branco.</string>
-    <string name="raw_location_summary">%1$s locais · %2$s km estimados · %3$s excluídos</string>
+    <string name="raw_location_summary">%1$s locais · %2$s %3$s estimados · %4$s excluídos</string>
     <string name="raw_only_title">Apenas dados de localização brutos encontrados</string>
     <string name="raw_only_message">Este arquivo contém dados de localização brutos, mas não contém visitas ou trajetos processados. Você pode continuar, mas a rota pode ficar imprecisa ou incompleta, e a distância será apenas uma estimativa.\n\nPara obter resultados melhores, abra o Google Maps, confirme ou restaure sua Linha do tempo e verifique se as visitas e os trajetos aparecem. Depois, exporte a Linha do tempo novamente e carregue o novo arquivo neste app.</string>
     <string name="open_google_maps">Abrir o Google Maps</string>
@@ -224,6 +222,11 @@
     <string name="settings_summary">Defina os padrões usados ​​para visualizações e novos vídeos.</string>
     <string name="video_defaults">Padrões de vídeo</string>
     <string name="video_defaults_summary">As alterações se aplicam à visualização e ao próximo vídeo que você criar.</string>
+    <string name="distance_unit_setting">Unidade de distância</string>
+    <string name="distance_unit_automatic">Automático</string>
+    <string name="distance_unit_kilometers">Quilômetros</string>
+    <string name="distance_unit_miles">Milhas</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">Processamento da Timeline</string>
     <string name="location_filter">Filtro de valores GPS atípicos</string>
     <string name="location_filter_summary">O filtro conservador ignora apenas viagens curtas de ida e volta impossíveis. O arquivo da Timeline nunca é alterado.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -65,7 +65,6 @@
     <string name="video_creation_notification_channel">视频创作</string>
     <string name="video_creation_notification_channel_description">timeline 视频的进度和完成提醒</string>
     <string name="no_video_player">没有可用的应用程序来播放该视频</string>
-    <string name="journey_summary">%1$s 分 · %2$s km · %3$s</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>
     <string name="preparing_map_progress">准备地图·%1$d/%2$d</string>
@@ -123,7 +122,6 @@
     <string name="update_page_unavailable">无法打开更新页面</string>
     <string name="web_page_unavailable">无法打开网页</string>
     <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy年M月</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline视频</string>
     <string name="default_video_filename">Timeline 视频.mp4</string>
@@ -149,7 +147,7 @@
     <string name="no_videos">您创建或添加的视频将显示在此处。</string>
     <string name="show_all_videos">显示全部 (%1$d)</string>
     <string name="show_fewer_videos">显示较少</string>
-    <string name="selected_period_summary">%1$s 积分 · 关于 %2$s km · %3$s</string>
+    <string name="selected_period_summary">%1$s 个点 · 约 %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">此期间没有位置点</string>
     <string name="selected_period_one_point">1个位置点·选择范围更广</string>
     <string name="selected_period_no_movement">%1$s 点 · 未检测到移动</string>
@@ -200,7 +198,7 @@
     <string name="raw_accuracy_limit">精度上限（米）</string>
     <string name="raw_accuracy_helper">精度较低的位置会被排除。留空可包含所有可用位置。</string>
     <string name="raw_accuracy_invalid">请输入零或正数，或者留空。</string>
-    <string name="raw_location_summary">%1$s 个位置 · 估算 %2$s 公里 · 已排除 %3$s 个</string>
+    <string name="raw_location_summary">%1$s 个位置 · 估算 %2$s %3$s · 已排除 %4$s 个</string>
     <string name="raw_only_title">仅发现原始位置数据</string>
     <string name="raw_only_message">此文件包含原始位置数据，但没有经过处理的到访记录或行程。你可以继续，但路线可能不准确或不完整，距离也只是估算值。\n\n为了获得更好的结果，请打开 Google 地图，确认或恢复你的时间轴，并确保其中显示到访记录和行程。然后再次导出时间轴，并在此应用中加载新文件。</string>
     <string name="open_google_maps">打开 Google 地图</string>
@@ -217,6 +215,11 @@
     <string name="settings_summary">设置用于预览和新视频的默认值。</string>
     <string name="video_defaults">视频默认值</string>
     <string name="video_defaults_summary">更改适用于预览和您创建的下一个视频。</string>
+    <string name="distance_unit_setting">距离单位</string>
+    <string name="distance_unit_automatic">自动</string>
+    <string name="distance_unit_kilometers">公里</string>
+    <string name="distance_unit_miles">英里</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">时间轴处理</string>
     <string name="location_filter">GPS异常点过滤</string>
     <string name="location_filter_summary">保守过滤仅忽略短时间内不可能的往返移动。不会更改您的时间轴文件。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -65,7 +65,6 @@
     <string name="video_creation_notification_channel">影片創作</string>
     <string name="video_creation_notification_channel_description">timeline 影片的進度和完成提醒</string>
     <string name="no_video_player">沒有可用的應用程式來播放該視頻</string>
-    <string name="journey_summary">%1$s 分 · %2$s km · %3$s</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>
     <string name="preparing_map_progress">準備地圖·%1$d/%2$d</string>
@@ -123,7 +122,6 @@
     <string name="update_page_unavailable">無法開啟更新頁面</string>
     <string name="web_page_unavailable">無法開啟網頁</string>
     <string name="render_date_pattern" tools:ignore="ExtraTranslation">yyyy年M月</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap © CARTO</string>
     <string name="timeline_video">Timeline視頻</string>
     <string name="default_video_filename">Timeline 影片.mp4</string>
@@ -149,7 +147,7 @@
     <string name="no_videos">您建立或新增的影片將顯示在此。</string>
     <string name="show_all_videos">顯示全部 (%1$d)</string>
     <string name="show_fewer_videos">顯示較少</string>
-    <string name="selected_period_summary">%1$s 積分 · 關於 %2$s km · %3$s</string>
+    <string name="selected_period_summary">%1$s 個點 · 約 %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">此期間沒有位置點</string>
     <string name="selected_period_one_point">1個位置點·選擇範圍更廣</string>
     <string name="selected_period_no_movement">%1$s 點 · 未偵測到移動</string>
@@ -200,7 +198,7 @@
     <string name="raw_accuracy_limit">精確度上限（公尺）</string>
     <string name="raw_accuracy_helper">精確度較低的位置會被排除。留空可包含所有可用位置。</string>
     <string name="raw_accuracy_invalid">請輸入零或正數，或將此欄留空。</string>
-    <string name="raw_location_summary">%1$s 個位置 · 估算 %2$s 公里 · 已排除 %3$s 個</string>
+    <string name="raw_location_summary">%1$s 個位置 · 估算 %2$s %3$s · 已排除 %4$s 個</string>
     <string name="raw_only_title">僅找到原始位置資料</string>
     <string name="raw_only_message">此檔案包含原始位置資料，但沒有已處理的造訪記錄或行程。你可以繼續，但路線可能不準確或不完整，距離也只是估算值。\n\n若要獲得更好的結果，請開啟 Google 地圖，確認或還原時間軸，並確定其中顯示造訪記錄和行程。然後再次匯出時間軸，並在此應用程式中載入新檔案。</string>
     <string name="open_google_maps">開啟 Google 地圖</string>
@@ -217,6 +215,11 @@
     <string name="settings_summary">設定用於預覽和新影片的預設值。</string>
     <string name="video_defaults">影片預設值</string>
     <string name="video_defaults_summary">更改適用於預覽和您創建的下一個影片。</string>
+    <string name="distance_unit_setting">距離單位</string>
+    <string name="distance_unit_automatic">自動</string>
+    <string name="distance_unit_kilometers">公里</string>
+    <string name="distance_unit_miles">英里</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">時間軸處理</string>
     <string name="location_filter">GPS異常點篩選</string>
     <string name="location_filter_summary">保守篩選只會忽略短時間內不可能的往返移動，不會變更您的時間軸檔案。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,6 @@
     <string name="video_creation_notification_channel">Video creation</string>
     <string name="video_creation_notification_channel_description">Progress and completion alerts for timeline videos</string>
     <string name="no_video_player">No app is available to play this video</string>
-    <string name="journey_summary">%1$s points · %2$s km · %3$s</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>
     <string name="preparing_map_progress">Preparing map · %1$d/%2$d</string>
@@ -132,7 +131,6 @@
          date shape (ja, ko, zh) carry a hand-maintained override in their strings.xml,
          changed only through code review, with tools:ignore="ExtraTranslation". -->
     <string name="render_date_pattern" translatable="false">MMMM yyyy</string>
-    <string name="distance_unit">km</string>
     <string name="map_attribution">© OpenStreetMap  © CARTO</string>
     <string name="timeline_video">Timeline video</string>
     <string name="default_video_filename">Timeline video.mp4</string>
@@ -158,7 +156,7 @@
     <string name="no_videos">Videos you create or add will appear here.</string>
     <string name="show_all_videos">Show all (%1$d)</string>
     <string name="show_fewer_videos">Show fewer</string>
-    <string name="selected_period_summary">%1$s points · about %2$s km · %3$s</string>
+    <string name="selected_period_summary">%1$s points · about %2$s %3$s · %4$s</string>
     <string name="selected_period_empty">No location points in this period</string>
     <string name="selected_period_one_point">1 location point · choose a wider period</string>
     <string name="selected_period_no_movement">%1$s points · no movement detected</string>
@@ -209,7 +207,7 @@
     <string name="raw_accuracy_limit">Accuracy limit (meters)</string>
     <string name="raw_accuracy_helper">Less accurate locations are excluded. Leave blank to include every usable location.</string>
     <string name="raw_accuracy_invalid">Enter zero or a positive number, or leave this blank.</string>
-    <string name="raw_location_summary">%1$s locations · estimated %2$s km · %3$s ignored</string>
+    <string name="raw_location_summary">%1$s locations · estimated %2$s %3$s · %4$s ignored</string>
     <string name="raw_only_title">Only raw location data found</string>
     <string name="raw_only_message">This file contains raw location data but no processed visits or trips. You can continue, but the route may be noisy or incomplete, and its distance will only be an estimate.\n\nFor better results, open Google Maps, confirm or restore your Timeline, and make sure your visits and trips appear. Then export your Timeline again and load the new file in this app.</string>
     <string name="open_google_maps">Open Google Maps</string>
@@ -226,6 +224,11 @@
     <string name="settings_summary">Set the defaults used for previews and new videos.</string>
     <string name="video_defaults">Video defaults</string>
     <string name="video_defaults_summary">Changes apply to the preview and the next video you create.</string>
+    <string name="distance_unit_setting">Distance unit</string>
+    <string name="distance_unit_automatic">Automatic</string>
+    <string name="distance_unit_kilometers">Kilometers</string>
+    <string name="distance_unit_miles">Miles</string>
+    <string name="distance_unit_automatic_resolved">%1$s · %2$s</string>
     <string name="timeline_processing">Timeline processing</string>
     <string name="location_filter">GPS outlier filtering</string>
     <string name="location_filter_summary">Conservative filtering ignores only short, impossible round trips. Your Timeline file is never changed.</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -34,7 +34,10 @@ import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
 import dev.mahlernim.timelinevisualizer.render.VideoQuality
+import dev.mahlernim.timelinevisualizer.render.DistanceUnit
+import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
 import dev.mahlernim.timelinevisualizer.ui.CameraSettingsPreferences
+import dev.mahlernim.timelinevisualizer.ui.DistanceUnitPreferences
 import dev.mahlernim.timelinevisualizer.ui.TimelineView
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -68,6 +71,7 @@ class MainActivityTest {
         context.getSharedPreferences("display", Context.MODE_PRIVATE).edit().clear().commit()
         context.getSharedPreferences("camera-settings", Context.MODE_PRIVATE).edit().clear().commit()
         context.getSharedPreferences("timeline-filter-settings", Context.MODE_PRIVATE).edit().clear().commit()
+        context.getSharedPreferences("distance-unit-settings", Context.MODE_PRIVATE).edit().clear().commit()
         timelineSourceStore.clearForTest()
     }
 
@@ -303,6 +307,24 @@ class MainActivityTest {
             activity.getString(R.string.format_square_480),
             activity.findViewById<AutoCompleteTextView>(R.id.videoQualityDropdown).text.toString(),
         )
+        val automaticDistance = DistanceUnit.automatic(
+            android.content.res.Resources.getSystem().configuration.locales[0],
+        )
+        val automaticDistanceName = activity.getString(
+            if (automaticDistance == DistanceUnit.MILES) {
+                R.string.distance_unit_miles
+            } else {
+                R.string.distance_unit_kilometers
+            },
+        )
+        assertEquals(
+            activity.getString(
+                R.string.distance_unit_automatic_resolved,
+                activity.getString(R.string.distance_unit_automatic),
+                automaticDistanceName,
+            ),
+            activity.findViewById<AutoCompleteTextView>(R.id.distanceUnitDropdown).text.toString(),
+        )
         assertEquals(
             activity.getString(R.string.location_filter_conservative),
             activity.findViewById<AutoCompleteTextView>(R.id.locationFilterDropdown).text.toString(),
@@ -316,6 +338,37 @@ class MainActivityTest {
             activity.getString(R.string.app_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE),
             activity.findViewById<TextView>(R.id.versionText).text.toString(),
         )
+    }
+
+    @Test
+    fun milesOverrideUpdatesSettingsSummaryAndPreviewRendering() {
+        val activity = launchActivity()
+        activity.findViewById<View>(R.id.navigationSettings).performClick()
+        val dropdown = activity.findViewById<AutoCompleteTextView>(R.id.distanceUnitDropdown)
+
+        dropdown.onItemClickListener?.onItemClick(null, null, DistanceUnitPreference.MILES.ordinal, 0L)
+
+        assertEquals(activity.getString(R.string.distance_unit_miles), dropdown.text.toString())
+        assertEquals(DistanceUnitPreference.MILES, DistanceUnitPreferences(activity).load())
+        assertEquals("mi", activity.findViewById<TimelineView>(R.id.timelineView).renderText.distanceUnit)
+        assertEquals(
+            DistanceUnit.MILES.kilometersMultiplier,
+            activity.findViewById<TimelineView>(R.id.timelineView).renderText.distanceScale,
+            0.0,
+        )
+        val journey = Journey.from(
+            listOf(
+                GeoPoint(Instant.parse("2026-01-01T00:00:00Z"), 37.5, 127.0),
+                GeoPoint(Instant.parse("2026-02-01T00:00:00Z"), 35.1, 129.0),
+            ),
+            2026,
+        )
+        assertTrue(activity.selectedPeriodSummary(journey).contains(" mi "))
+
+        activity.findViewById<View>(R.id.resetAdvancedSettingsButton).performClick()
+
+        assertEquals(DistanceUnitPreference.AUTOMATIC, DistanceUnitPreferences(activity).load())
+        assertTrue(dropdown.text.toString().startsWith(activity.getString(R.string.distance_unit_automatic)))
     }
 
     @Test

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequestStoreTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequestStoreTest.kt
@@ -45,7 +45,14 @@ class VideoExportRequestStoreTest {
             ),
             title = "2026 Mina's Timeline",
             durationSeconds = 60,
-            renderText = RenderText("ja", "マイタイムライン", "yyyy年M月", "km", "attribution"),
+            renderText = RenderText(
+                "ja",
+                "マイタイムライン",
+                "yyyy年M月",
+                "mi",
+                "attribution",
+                distanceScale = 0.621371192237334,
+            ),
             cameraSettings = CameraSettings(
                 CameraMovement.FIXED,
                 LongTripCompression.STRONG,
@@ -121,6 +128,39 @@ class VideoExportRequestStoreTest {
         assertEquals(RenderText.ENGLISH, restored.renderText)
         assertEquals(CameraSettings.DEFAULT, restored.cameraSettings)
         assertEquals(1, restored.journey.points.size)
+    }
+
+    @Test
+    fun readsVersionFourPendingExportsAsKilometers() {
+        val requestFile = File(context.filesDir, "pending-video-export.bin")
+        DataOutputStream(requestFile.outputStream().buffered()).use { output ->
+            output.writeInt(4)
+            output.writeUTF("content://documents/version-four.mp4")
+            output.writeUTF("Version four")
+            output.writeInt(30)
+            output.writeInt(2026)
+            output.writeInt(1)
+            output.writeInt(2026)
+            output.writeInt(12)
+            output.writeUTF("en-US")
+            output.writeUTF("My Timeline")
+            output.writeUTF("MMMM yyyy")
+            output.writeUTF("km")
+            output.writeUTF("attribution")
+            output.writeUTF(CameraMovement.STEADY.name)
+            output.writeUTF(LongTripCompression.BALANCED.name)
+            output.writeUTF(VideoQuality.STANDARD.name)
+            output.writeInt(1)
+            output.writeLong(Instant.parse("2026-06-01T00:00:00Z").toEpochMilli())
+            output.writeDouble(35.0)
+            output.writeDouble(139.0)
+        }
+
+        val restored = store.load()!!
+
+        assertEquals("km", restored.renderText.distanceUnit)
+        assertEquals(1.0, restored.renderText.distanceScale, 0.0)
+        assertEquals(CameraSettings.DEFAULT, restored.cameraSettings)
     }
 
     @Test

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/DistanceUnitTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/DistanceUnitTest.kt
@@ -1,0 +1,38 @@
+package dev.mahlernim.timelinevisualizer.render
+
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class DistanceUnitTest {
+    @Test
+    fun automaticUsesMilesForUnitedStatesAndUnitedKingdom() {
+        assertEquals(DistanceUnit.MILES, DistanceUnit.automatic(Locale.US))
+        assertEquals(DistanceUnit.MILES, DistanceUnit.automatic(Locale.UK))
+    }
+
+    @Test
+    fun automaticUsesKilometersForMetricRegions() {
+        assertEquals(DistanceUnit.KILOMETERS, DistanceUnit.automatic(Locale.KOREA))
+        assertEquals(DistanceUnit.KILOMETERS, DistanceUnit.automatic(Locale.JAPAN))
+    }
+
+    @Test
+    @Config(sdk = [27])
+    fun androidEightFallbackUsesTheSameCommonRegionConventions() {
+        assertEquals(DistanceUnit.MILES, DistanceUnit.automatic(Locale.US))
+        assertEquals(DistanceUnit.MILES, DistanceUnit.automatic(Locale.UK))
+        assertEquals(DistanceUnit.KILOMETERS, DistanceUnit.automatic(Locale.GERMANY))
+    }
+
+    @Test
+    fun milesConvertFromKilometersOnlyForDisplay() {
+        assertEquals(62.1371192237334, DistanceUnit.MILES.fromKilometers(100.0), 1e-12)
+        assertEquals(100.0, DistanceUnit.KILOMETERS.fromKilometers(100.0), 0.0)
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/RenderTextTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/RenderTextTest.kt
@@ -34,4 +34,14 @@ class RenderTextTest {
         val text = RenderText.ENGLISH.copy(localeTag = "ja", datePattern = "yyyy年M月")
         assertEquals("2025年8月", text.dateFormatter.format(august2025))
     }
+
+    @Test
+    fun distanceScaleChangesTheValueAndUnitTogether() {
+        val text = RenderText.ENGLISH.copy(
+            distanceUnit = "mi",
+            distanceScale = DistanceUnit.MILES.kilometersMultiplier,
+        )
+
+        assertEquals("62 mi", text.formatDistance(100.0))
+    }
 }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
@@ -42,7 +42,7 @@ class TimelinePainterTest {
                 localeTag = tag,
                 fallbackTitle = localized.getString(R.string.default_title),
                 datePattern = localized.getString(R.string.render_date_pattern),
-                distanceUnit = localized.getString(R.string.distance_unit),
+                distanceUnit = DistanceUnit.KILOMETERS.symbol,
                 attribution = localized.getString(R.string.map_attribution),
             )
             val bitmap = Bitmap.createBitmap(SIZE, SIZE, Bitmap.Config.ARGB_8888)

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferencesTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferencesTest.kt
@@ -1,0 +1,45 @@
+package dev.mahlernim.timelinevisualizer.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class DistanceUnitPreferencesTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val preferences = DistanceUnitPreferences(context)
+
+    @Before
+    fun reset() = preferences.clear()
+
+    @After
+    fun tearDown() = preferences.clear()
+
+    @Test
+    fun automaticIsTheDefault() {
+        assertEquals(DistanceUnitPreference.AUTOMATIC, preferences.load())
+    }
+
+    @Test
+    fun savesAndRestoresAnExplicitOverride() {
+        preferences.save(DistanceUnitPreference.MILES)
+
+        assertEquals(DistanceUnitPreference.MILES, DistanceUnitPreferences(context).load())
+    }
+
+    @Test
+    fun invalidStoredValuesFallBackToAutomatic() {
+        context.getSharedPreferences("distance-unit-settings", Context.MODE_PRIVATE)
+            .edit().putString("distance-unit", "NAUTICAL_MILES").commit()
+
+        assertEquals(DistanceUnitPreference.AUTOMATIC, preferences.load())
+    }
+}

--- a/docs/release-notes-v2.2.5.md
+++ b/docs/release-notes-v2.2.5.md
@@ -1,0 +1,51 @@
+# Timeline Visualizer 2.2.5
+
+Distance units can now be Automatic, Kilometers, or Miles. Automatic follows the device
+region and shows the resolved unit in Settings. The selected unit is applied consistently
+to journey summaries, previews, and exported videos.
+
+## 한국어
+
+이제 거리 단위를 자동, 킬로미터 또는 마일로 선택할 수 있습니다. 자동은 기기 지역을 따르며
+설정에 실제 적용되는 단위를 표시합니다. 선택한 단위는 여정 요약, 미리보기와 내보낸 영상에
+일관되게 적용됩니다.
+
+## 日本語
+
+距離の単位を自動、キロメートル、マイルから選べるようになりました。自動は端末の地域に
+従い、実際に使用される単位を設定画面に表示します。選択した単位は旅程の概要、
+プレビュー、書き出した動画に一貫して適用されます。
+
+## 简体中文
+
+现在可以将距离单位设为自动、公里或英里。自动选项会跟随设备地区，并在设置中显示实际
+采用的单位。所选单位会一致应用于行程摘要、预览和导出的视频。
+
+## 繁體中文
+
+現在可以將距離單位設為自動、公里或英里。自動選項會跟隨裝置地區，並在設定中顯示實際
+採用的單位。所選單位會一致套用於行程摘要、預覽和匯出的影片。
+
+## Español
+
+Ahora puede elegir Automático, Kilómetros o Millas como unidad de distancia. Automático
+sigue la región del dispositivo y muestra la unidad aplicada en Ajustes. La unidad elegida
+se aplica de forma coherente a los resúmenes, las vistas previas y los vídeos exportados.
+
+## Français
+
+Vous pouvez maintenant choisir Automatique, Kilomètres ou Miles comme unité de distance.
+Le mode Automatique suit la région de l'appareil et affiche l'unité appliquée dans les
+paramètres. L'unité choisie est utilisée dans les résumés, aperçus et vidéos exportées.
+
+## Deutsch
+
+Als Entfernungseinheit stehen jetzt Automatisch, Kilometer und Meilen zur Auswahl.
+Automatisch folgt der Geräteeinstellung für die Region und zeigt die verwendete Einheit
+in den Einstellungen an. Die Auswahl gilt für Zusammenfassungen, Vorschauen und Exporte.
+
+## Português (Brasil)
+
+Agora é possível escolher Automático, Quilômetros ou Milhas como unidade de distância.
+Automático segue a região do dispositivo e mostra a unidade aplicada nas Configurações.
+A unidade escolhida é usada nos resumos, nas prévias e nos vídeos exportados.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.4` and version code `23`
+- Version name `2.2.5` and version code `24`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- add Automatic, Kilometers, and Miles distance choices
- show the unit resolved by Automatic directly in Settings
- convert selected-period summaries, previews, and exported videos consistently
- preserve Android 8 compatibility and pending v2.2.4 exports
- translate the setting and v2.2.5 release notes in all nine supported languages

## Validation

- full Android unit tests
- Android lint
- GitHub debug APK build
- 26 Python tests
- API 35 emulator layout and persistence check at 411 dp width
- packaged APK reports version 2.2.5 and code 24

Implements #91