### PR TITLE
Dismiss completed export tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.6
+
+- Add a Done action to dismiss the persistent Video ready tray.
+- Clear only the completed export status when the tray is dismissed.
+- Keep the generated video available in My videos after dismissal.
+- Prevent the dismissed completion tray from returning after the app restarts.
+- Set Android version code 25 and version name 2.2.6.
+
 ## 2.2.5
 
 - Add Automatic, Kilometers, and Miles distance-unit choices.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 24
-        versionName = "2.2.5"
+        versionCode = 25
+        versionName = "2.2.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -253,6 +253,9 @@ class MainActivity : AppCompatActivity() {
         binding.exportTrayRetryButton.setOnClickListener { retryVideoExport() }
         binding.exportTrayWatchButton.setOnClickListener { lastVideoUri?.let(::watchVideo) }
         binding.exportTrayShareButton.setOnClickListener { lastVideoUri?.let(::shareVideo) }
+        binding.exportTrayDismissButton.setOnClickListener {
+            VideoExportCoordinator.clear(applicationContext)
+        }
         editor.doneButton.setOnClickListener {
             VideoExportCoordinator.clear(applicationContext)
             editor.videoReadyGroup.visibility = View.GONE
@@ -1557,6 +1560,7 @@ class MainActivity : AppCompatActivity() {
         binding.exportTrayCancelButton.visibility = View.VISIBLE
         binding.exportTrayWatchButton.visibility = View.GONE
         binding.exportTrayShareButton.visibility = View.GONE
+        binding.exportTrayDismissButton.visibility = View.GONE
         binding.exportTrayRetryButton.visibility = View.GONE
     }
 
@@ -1567,6 +1571,7 @@ class MainActivity : AppCompatActivity() {
         binding.exportTrayRetryButton.visibility = View.GONE
         binding.exportTrayWatchButton.visibility = if (lastVideoUri != null) View.VISIBLE else View.GONE
         binding.exportTrayShareButton.visibility = if (lastVideoUri != null) View.VISIBLE else View.GONE
+        binding.exportTrayDismissButton.visibility = View.VISIBLE
         binding.exportTrayStatusText.setText(R.string.video_ready)
         if (lastRenderedExportStatus != VideoExportStatus.COMPLETE) {
             announceExportStatus(getString(R.string.video_ready))
@@ -1580,6 +1585,7 @@ class MainActivity : AppCompatActivity() {
         binding.exportTrayCancelButton.visibility = View.GONE
         binding.exportTrayWatchButton.visibility = View.GONE
         binding.exportTrayShareButton.visibility = View.GONE
+        binding.exportTrayDismissButton.visibility = View.GONE
         binding.exportTrayRetryButton.visibility = View.VISIBLE
         binding.exportTrayRetryButton.isEnabled = true
         binding.exportTrayStatusText.text = message ?: getString(R.string.video_export_failed)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -67,6 +67,7 @@
                 android:max="1000" />
 
             <LinearLayout
+                android:id="@+id/exportTrayActions"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="end|center_vertical"
@@ -88,6 +89,15 @@
                     android:layout_height="wrap_content"
                     android:maxLines="1"
                     android:text="@string/share"
+                    android:visibility="gone" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/exportTrayDismissButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:text="@string/done"
                     android:visibility="gone" />
 
                 <com.google.android.material.button.MaterialButton

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -609,7 +609,69 @@ class MainActivityTest {
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportTrayWatchButton).visibility)
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportTrayShareButton).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportTrayDismissButton).visibility)
         assertEquals(View.GONE, activity.findViewById<View>(R.id.exportTrayProgress).visibility)
+    }
+
+    @Test
+    fun completedExportTrayCanBeDismissedWithoutRemovingSavedVideo() {
+        store.upsert(
+            VideoRecord(
+                uri = "content://example/generated-video",
+                title = "Trip",
+                fileName = "trip.mp4",
+                createdAtMillis = 1L,
+                durationSeconds = 30,
+            ),
+        )
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.COMPLETE,
+                outputUri = "content://example/generated-video",
+                title = "Trip",
+            ),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        activity.findViewById<View>(R.id.exportTrayDismissButton).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertEquals(listOf("content://example/generated-video"), store.list().map { it.uri })
+
+        activity.recreate()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(listOf("content://example/generated-video"), store.list().map { it.uri })
+    }
+
+    @Test
+    @Config(sdk = [35], qualifiers = "de-w360dp-h640dp-xxhdpi")
+    fun completedExportTrayActionsFitCompactWidth() {
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.COMPLETE,
+                outputUri = "content://example/generated-video",
+                title = "Trip",
+            ),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+        measureActivity(activity)
+
+        val actions = activity.findViewById<ViewGroup>(R.id.exportTrayActions)
+        assertSingleLineButtons(actions)
+        repeat(actions.childCount) { index ->
+            val child = actions.getChildAt(index)
+            if (child.visibility == View.VISIBLE) {
+                assertTrue("Tray action exceeds compact width", child.right <= actions.width)
+            }
+        }
     }
 
     @Test

--- a/docs/release-notes-v2.2.6.md
+++ b/docs/release-notes-v2.2.6.md
@@ -1,0 +1,51 @@
+# Timeline Visualizer 2.2.6
+
+The Video ready tray can now be dismissed with Done. Dismissing it clears the completed
+export status so the tray does not return when the app restarts. The generated video
+remains available in My videos.
+
+## 한국어
+
+이제 완료를 눌러 동영상 준비 완료 창을 닫을 수 있습니다. 창을 닫으면 완료된 내보내기 상태가
+지워져 앱을 다시 시작해도 창이 나타나지 않습니다. 생성된 동영상은 내 동영상에 그대로
+보관됩니다.
+
+## 日本語
+
+動画の準備完了トレイを「完了」で閉じられるようになりました。閉じると完了した書き出し
+状態が消去され、アプリを再起動してもトレイは再表示されません。作成した動画は「マイ動画」
+に引き続き保存されます。
+
+## 简体中文
+
+现在可以点击“完毕”关闭“视频已就绪”托盘。关闭后，已完成的导出状态会被清除，因此重新
+启动应用时托盘不会再次出现。生成的视频仍会保留在“我的视频”中。
+
+## 繁體中文
+
+現在可以點選「完畢」關閉「影片已就緒」托盤。關閉後，已完成的匯出狀態會被清除，因此重新
+啟動應用程式時托盤不會再次出現。產生的影片仍會保留在「我的影片」中。
+
+## Español
+
+La bandeja Vídeo listo ahora se puede cerrar con Hecho. Al cerrarla se elimina el estado
+de exportación completada para que no vuelva a aparecer al reiniciar la aplicación. El
+vídeo generado permanece disponible en Mis vídeos.
+
+## Français
+
+Le volet Vidéo prête peut maintenant être fermé avec Fait. Sa fermeture efface l'état
+d'exportation terminé afin qu'il ne réapparaisse pas au redémarrage de l'application. La
+vidéo générée reste disponible dans Mes vidéos.
+
+## Deutsch
+
+Die Anzeige Video bereit kann jetzt mit Erledigt geschlossen werden. Dadurch wird nur der
+abgeschlossene Exportstatus gelöscht, sodass die Anzeige nach einem Neustart nicht erneut
+erscheint. Das erstellte Video bleibt unter Meine Videos verfügbar.
+
+## Português (Brasil)
+
+Agora é possível fechar a bandeja Vídeo pronto com Feito. Ao fechá-la, o estado da
+exportação concluída é limpo para que a bandeja não volte após reiniciar o aplicativo. O
+vídeo gerado continua disponível em Meus vídeos.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.5` and version code `24`
+- Version name `2.2.6` and version code `25`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- add a Done action to the completed Video ready tray
- clear only the transient completed export state when dismissed
- keep the generated video in My videos and prevent the tray from returning after restart
- prepare v2.2.6 with version code 25

## Validation

- `./gradlew.bat test lint assembleGithubDebug assemblePlayDebug --stacktrace`
- focused completion dismissal and relaunch regression tests
- compact 360 dp completed-tray layout test with the longest German action label
- `python -m pytest -q`, 26 passed
- `corepack pnpm test -- --run`, 39 passed
- `corepack pnpm run build`
- `git diff --check`

Addresses #98. The issue should be closed after the v2.2.6 public release artifacts are verified.