### PR TITLE
Fix Arctic return route direction in the web app

### DIFF
--- a/web/src/camera.test.ts
+++ b/web/src/camera.test.ts
@@ -7,7 +7,7 @@ import {
   overviewViewport,
   worldPositionAtProgress,
 } from './camera';
-import { cumulativeDistances, project, unwrapWorldPoints } from './geo';
+import { cumulativeDistances, project, unwrapJourneyPoints, unwrapWorldPoints } from './geo';
 import { requiredTiles } from './renderer';
 import type { CameraMovement, GeoPoint } from './types';
 
@@ -19,7 +19,7 @@ function journey(points: Array<[number, number]>) {
   }));
   const cumulativeDistanceKm = cumulativeDistances(geoPoints);
   return {
-    worldPoints: unwrapWorldPoints(geoPoints.map((point) => project(point.latitude, point.longitude))),
+    worldPoints: unwrapJourneyPoints(geoPoints),
     cumulativeDistanceKm,
     totalDistanceKm: cumulativeDistanceKm.at(-1) ?? 0,
   };
@@ -79,6 +79,27 @@ describe('camera track', () => {
       expect(tile.x).toBeGreaterThanOrEqual(0);
       expect(tile.x).toBeLessThan(count);
     });
+  });
+
+  it('moves back west on the return leg of an Arctic round trip', () => {
+    const arcticRoundTrip = journey([
+      [37, 127],
+      [70, 170],
+      [82, -170],
+      [38, -122],
+      [70, -60],
+      [82, 20],
+      [70, 100],
+      [37, 127],
+    ]);
+    const track = buildCameraTrack(arcticRoundTrip, 480, 'dynamic');
+    const turnProgress = arcticRoundTrip.cumulativeDistanceKm[3] / arcticRoundTrip.totalDistanceKm;
+    const [startX] = center(cameraViewportAt(track, 0));
+    const [turnX] = center(cameraViewportAt(track, turnProgress));
+    const [endX] = center(cameraViewportAt(track, 1));
+
+    expect(turnX).toBeGreaterThan(startX);
+    expect(endX).toBeLessThan(turnX);
   });
 
   it('smooths changing spans and stabilizes integer tile zoom', () => {

--- a/web/src/geo.test.ts
+++ b/web/src/geo.test.ts
@@ -3,6 +3,7 @@ import {
   cumulativeDistances,
   overviewRouteSegments,
   project,
+  unwrapJourneyPoints,
   unwrapWorldPoints,
   viewportFor,
 } from './geo';
@@ -16,6 +17,42 @@ describe('geography helpers', () => {
     const points = unwrapWorldPoints([project(0, 179), project(0, -179)]);
     expect(Math.abs(points[1].x - points[0].x)).toBeLessThan(0.01);
     expect(viewportFor(points, 480).maxX - viewportFor(points, 480).minX).toBeLessThan(0.02);
+  });
+
+  it('returns west after an eastbound Arctic round trip', () => {
+    const points = [
+      { instant: new Date(0), latitude: 37, longitude: 127 },
+      { instant: new Date(1), latitude: 70, longitude: 170 },
+      { instant: new Date(2), latitude: 82, longitude: -170 },
+      { instant: new Date(3), latitude: 38, longitude: -122 },
+      { instant: new Date(4), latitude: 70, longitude: -60 },
+      { instant: new Date(5), latitude: 82, longitude: 20 },
+      { instant: new Date(6), latitude: 70, longitude: 100 },
+      { instant: new Date(7), latitude: 37, longitude: 127 },
+    ];
+
+    const route = unwrapJourneyPoints(points);
+
+    expect(route[3].x).toBeGreaterThan(route[0].x);
+    expect(route[7].x).toBeLessThan(route[3].x);
+    expect(route[7].x).toBeCloseTo(route[0].x);
+    expect(Math.max(...route.map((point) => point.x)) - Math.min(...route.map((point) => point.x)))
+      .toBeLessThan(0.5);
+  });
+
+  it('does not collapse ordinary low-latitude date-line travel', () => {
+    const points = [
+      { instant: new Date(0), latitude: 10, longitude: 170 },
+      { instant: new Date(1), latitude: 10, longitude: -170 },
+      { instant: new Date(2), latitude: 10, longitude: -140 },
+    ];
+
+    const route = unwrapJourneyPoints(points);
+
+    expect(route.map((point) => point.x)).toEqual(unwrapWorldPoints(
+      points.map((point) => project(point.latitude, point.longitude)),
+    ).map((point) => point.x));
+    expect(route[2].x).toBeGreaterThan(route[0].x);
   });
 
   it('collapses accumulated world copies for the ending overview', () => {

--- a/web/src/geo.ts
+++ b/web/src/geo.ts
@@ -26,6 +26,87 @@ function wrapNear(value: number, reference: number): number {
   return value - Math.floor(value - reference + 0.5);
 }
 
+const POLAR_CORE_LATITUDE = 70;
+const POLAR_CORRIDOR_LATITUDE = 50;
+
+function greatCircleReferenceX(start: GeoPoint, end: GeoPoint, fraction: number): number {
+  const toVector = (point: GeoPoint): [number, number, number] => {
+    const latitude = (point.latitude * Math.PI) / 180;
+    const longitude = (point.longitude * Math.PI) / 180;
+    const latitudeRadius = Math.cos(latitude);
+    return [
+      latitudeRadius * Math.cos(longitude),
+      latitudeRadius * Math.sin(longitude),
+      Math.sin(latitude),
+    ];
+  };
+  const from = toVector(start);
+  const to = toVector(end);
+  const dot = Math.max(-1, Math.min(1, from[0] * to[0] + from[1] * to[1] + from[2] * to[2]));
+  const angle = Math.acos(dot);
+  const sinAngle = Math.sin(angle);
+  if (sinAngle < 1e-9) {
+    return project(
+      start.latitude + (end.latitude - start.latitude) * fraction,
+      start.longitude + (end.longitude - start.longitude) * fraction,
+    ).x;
+  }
+  const fromWeight = Math.sin((1 - fraction) * angle) / sinAngle;
+  const toWeight = Math.sin(fraction * angle) / sinAngle;
+  const x = from[0] * fromWeight + to[0] * toWeight;
+  const y = from[1] * fromWeight + to[1] * toWeight;
+  return (Math.atan2(y, x) / Math.PI + 1) / 2;
+}
+
+/**
+ * Keeps polar flight corridors on the world-copy branch selected by their
+ * stable endpoints. Longitude changes rapidly near a pole, so greedily
+ * unwrapping every polar point can invent a complete extra turn around the map.
+ */
+export function unwrapJourneyPoints(points: GeoPoint[]): WorldPoint[] {
+  const projected = points.map((point) => project(point.latitude, point.longitude));
+  const output = unwrapWorldPoints(projected);
+  let coreIndex = 1;
+  while (coreIndex < points.length - 1) {
+    if (Math.abs(points[coreIndex].latitude) < POLAR_CORE_LATITUDE) {
+      coreIndex += 1;
+      continue;
+    }
+
+    let corridorStart = coreIndex;
+    while (
+      corridorStart > 1
+      && Math.abs(points[corridorStart - 1].latitude) >= POLAR_CORRIDOR_LATITUDE
+    ) corridorStart -= 1;
+    let corridorEnd = coreIndex;
+    while (
+      corridorEnd < points.length - 2
+      && Math.abs(points[corridorEnd + 1].latitude) >= POLAR_CORRIDOR_LATITUDE
+    ) corridorEnd += 1;
+
+    const startAnchor = corridorStart - 1;
+    const endAnchor = corridorEnd + 1;
+    const startX = output[startAnchor].x;
+    const intendedEndX = wrapNear(projected[endAnchor].x, startX);
+    const branchCorrection = intendedEndX - output[endAnchor].x;
+    if (Math.abs(branchCorrection) >= 0.5) {
+      for (let index = corridorStart; index < endAnchor; index += 1) {
+        const fraction = (index - startAnchor) / (endAnchor - startAnchor);
+        const expectedX = startX + (intendedEndX - startX) * fraction;
+        output[index].x = wrapNear(
+          greatCircleReferenceX(points[startAnchor], points[endAnchor], fraction),
+          expectedX,
+        );
+      }
+      for (let index = endAnchor; index < output.length; index += 1) {
+        output[index].x += branchCorrection;
+      }
+    }
+    coreIndex = corridorEnd + 1;
+  }
+  return output;
+}
+
 export function overviewRouteSegments(points: WorldPoint[]): WorldPoint[][] {
   if (points.length === 0) return [];
   const referenceX = points.at(-1)?.x ?? 0.5;

--- a/web/src/renderer.ts
+++ b/web/src/renderer.ts
@@ -6,7 +6,7 @@ import {
   overviewViewport,
   worldPositionAtProgress,
 } from './camera';
-import { cumulativeDistances, overviewRouteSegments, project, unwrapWorldPoints } from './geo';
+import { cumulativeDistances, overviewRouteSegments, unwrapJourneyPoints } from './geo';
 import type {
   CameraMovement,
   GeoPoint,
@@ -150,7 +150,7 @@ export async function prepareJourney(
   onProgress?: (completed: number, total: number) => void,
 ): Promise<PreparedJourney> {
   if (points.length < 2) throw new Error('Select a period containing at least two location points.');
-  const worldPoints = unwrapWorldPoints(points.map((point) => project(point.latitude, point.longitude)));
+  const worldPoints = unwrapJourneyPoints(points);
   const distances = cumulativeDistances(points);
   const journey = {
     points,


### PR DESCRIPTION
## Summary

- detect bounded polar flight corridors that accumulate an artificial world turn
- anchor corrected corridors to stable lower-latitude endpoints using a great-circle longitude reference
- use the corrected route for the moving web camera while leaving ordinary Date Line travel unchanged

## Scope

Web app only. Android behavior and Android releases are intentionally unchanged.

## Validation

- `pnpm test` with 42 passing tests
- `pnpm build`
- `python -m pytest` with 26 passing tests
- new route-coordinate and camera-direction regressions for an Arctic round trip

Closes #109