### PR TITLE
Make APK installation instructions version-independent

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,8 @@ MP4 の作成には H.264 エンコードに対応した Safari 16.4 以降が�
 [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
 次の手順でインストールします。
 
-1. **Assets** にある `TimelineVisualizer-v2.2.4.apk` をダウンロードします。
+1. **Assets** にある最新の `TimelineVisualizer-*.apk` ファイルをダウンロードします。
+   `.sha256` チェックサムファイルはダウンロードしないでください。
 2. ダウンロードしたファイルを開きます。
 3. インストールがブロックされた場合は、ブラウザまたはファイル管理アプリに
    **不明なアプリのインストール**を一時的に許可します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,7 +32,8 @@ MP4를 만들려면 H.264 인코딩을 지원하는 Safari 16.4 이상이 필요
 아직 Google Play에는 등록되지 않았습니다. 이 저장소의
 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
 
-1. **Assets**에서 `TimelineVisualizer-v2.2.4.apk`를 휴대전화로 다운로드합니다.
+1. **Assets**에서 최신 `TimelineVisualizer-*.apk` 파일을 휴대전화로 다운로드합니다.
+   `.sha256` 체크섬 파일은 다운로드하지 마세요.
 2. 다운로드한 파일을 엽니다.
 3. 설치가 차단되면 **설정**을 누르고, 사용한 브라우저 또는 파일 앱의
    **출처를 알 수 없는 앱 설치**를 허용한 뒤 다시 설치합니다.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ use Safari's Share menu and choose **Add to Home Screen**.
 The app is not yet on Google Play. Install it from this repository's
 [latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
 
-1. Under **Assets**, download `TimelineVisualizer-v2.2.4.apk` on your phone.
+1. Under **Assets**, download the latest `TimelineVisualizer-*.apk` file on your
+   phone. Do not download the `.sha256` checksum file.
 2. Open the downloaded file.
 3. If Android blocks the installation, select **Settings**, allow your browser or
    file manager to **Install unknown apps**, then return and try again.


### PR DESCRIPTION
## Summary

- remove fixed APK version numbers from installation instructions
- direct users to the latest APK asset
- distinguish the APK from its checksum file
- keep English, Korean, and Japanese instructions aligned

## Verification

- `git diff --check`
- confirmed the remote comparison contains only the three README files