### PR TITLE
Require complete map tiles before video export

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TileRepository.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/TileRepository.kt
@@ -5,11 +5,15 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.LruCache
 import dev.mahlernim.timelinevisualizer.render.TileId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 class TileRepository(context: Context) {
     private val cacheDirectory = File(context.cacheDir, "carto-tiles").apply { mkdirs() }
@@ -29,25 +33,34 @@ class TileRepository(context: Context) {
         cached(id)?.let { return@withContext it }
         val key = id.key()
         val target = File(cacheDirectory, "$key.png")
-        val temp = File(cacheDirectory, "$key.tmp")
-        val connection = URL("https://a.basemaps.cartocdn.com/light_all/${id.zoom}/${id.x}/${id.y}.png")
-            .openConnection() as HttpURLConnection
+        val temp = File.createTempFile("$key-", ".tmp", cacheDirectory)
+        var connection: HttpURLConnection? = null
         try {
+            connection = URL("https://a.basemaps.cartocdn.com/light_all/${id.zoom}/${id.x}/${id.y}.png")
+                .openConnection() as HttpURLConnection
             connection.connectTimeout = 10_000
             connection.readTimeout = 15_000
             connection.setRequestProperty("User-Agent", "TimelineVisualizer-Android/1.0")
             if (connection.responseCode !in 200..299) return@withContext null
             connection.inputStream.use { input -> temp.outputStream().use(input::copyTo) }
-            if (!temp.renameTo(target)) {
-                temp.copyTo(target, overwrite = true)
-                temp.delete()
+            try {
+                Files.move(
+                    temp.toPath(),
+                    target.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(temp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
             }
             BitmapFactory.decodeFile(target.absolutePath)?.also { memory.put(key, it) }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
         } catch (_: Exception) {
-            temp.delete()
             null
         } finally {
-            connection.disconnect()
+            temp.delete()
+            connection?.disconnect()
         }
     }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/MapTilePreparer.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/MapTilePreparer.kt
@@ -1,0 +1,100 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import dev.mahlernim.timelinevisualizer.render.TileId
+import java.io.IOException
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class MapTilePreparationException(
+    val missingTiles: List<TileId>,
+    val totalTiles: Int,
+) : IOException("Could not prepare ${missingTiles.size} of $totalTiles map tiles")
+
+internal class MapTilePreparer(
+    private val parallelism: Int = DEFAULT_PARALLELISM,
+    private val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+    private val retryDelayMillis: Long = DEFAULT_RETRY_DELAY_MILLIS,
+    private val isReady: (TileId) -> Boolean,
+    private val load: suspend (TileId) -> Unit,
+    private val pause: suspend (Long) -> Unit = { delay(it) },
+) {
+    init {
+        require(parallelism > 0)
+        require(maxAttempts > 0)
+        require(retryDelayMillis >= 0)
+    }
+
+    suspend fun prepare(
+        requiredTiles: Collection<TileId>,
+        onReady: (completed: Int, total: Int) -> Unit,
+    ) = coroutineScope {
+        val tiles = requiredTiles.distinct()
+        if (tiles.isEmpty()) return@coroutineScope
+
+        val nextIndex = AtomicInteger(0)
+        val readyCount = AtomicInteger(0)
+        val missing = ConcurrentLinkedQueue<TileId>()
+        val cancellation = AtomicReference<CancellationException?>()
+        val progressMutex = Mutex()
+        val workers = List(minOf(parallelism, tiles.size)) {
+            async {
+                while (true) {
+                    if (cancellation.get() != null) break
+                    val index = nextIndex.getAndIncrement()
+                    if (index >= tiles.size) break
+                    val tile = tiles[index]
+                    try {
+                        if (loadUntilReady(tile)) {
+                            progressMutex.withLock {
+                                onReady(readyCount.incrementAndGet(), tiles.size)
+                            }
+                        } else {
+                            missing.add(tile)
+                        }
+                    } catch (cancelled: CancellationException) {
+                        cancellation.compareAndSet(null, cancelled)
+                        break
+                    }
+                }
+            }
+        }
+        workers.awaitAll()
+        cancellation.get()?.let { throw it }
+
+        if (missing.isNotEmpty()) {
+            throw MapTilePreparationException(missing.toList(), tiles.size)
+        }
+    }
+
+    private suspend fun loadUntilReady(tile: TileId): Boolean {
+        if (isReady(tile)) return true
+        repeat(maxAttempts) { attempt ->
+            try {
+                load(tile)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (_: Exception) {
+                // A failed attempt is retried below and reported if the cache remains incomplete.
+            }
+            if (isReady(tile)) return true
+            if (attempt < maxAttempts - 1 && retryDelayMillis > 0) {
+                pause(retryDelayMillis * (attempt + 1))
+            }
+        }
+        return false
+    }
+
+    companion object {
+        private const val DEFAULT_PARALLELISM = 4
+        private const val DEFAULT_MAX_ATTEMPTS = 2
+        private const val DEFAULT_RETRY_DELAY_MILLIS = 250L
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -12,6 +12,7 @@ import dev.mahlernim.timelinevisualizer.data.TileRepository
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.render.TimelineAnimation
 import dev.mahlernim.timelinevisualizer.render.CameraSettings
+import dev.mahlernim.timelinevisualizer.render.TileId
 import dev.mahlernim.timelinevisualizer.render.TimelineFrame
 import dev.mahlernim.timelinevisualizer.render.TimelinePainter
 import dev.mahlernim.timelinevisualizer.render.RenderText
@@ -20,8 +21,6 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.nio.ByteBuffer
 import kotlin.coroutines.coroutineContext
-import kotlin.math.ceil
-import kotlin.math.max
 
 enum class ExportPhase { PREPARING_MAP, CREATING_VIDEO, FINISHING_VIDEO, COMPLETE }
 
@@ -57,49 +56,39 @@ class Mp4Exporter(
         val overviewWidth = overviewWidth(videoFormat)
         val overviewHeight = overviewHeight(videoFormat)
         val painter = TimelinePainter()
+        val journeyFrameCount = durationSeconds * fps
+        val outroFrameCount = (TimelineAnimation.OUTRO_SECONDS * fps).toInt()
+        val frameCount = journeyFrameCount + outroFrameCount
 
-        val sampleCount = max(durationSeconds * 2, ceil(journey.totalDistanceKm / 250.0).toInt())
-            .coerceIn(20, durationSeconds * 8)
-        val requiredTiles = buildSet {
-            for (sample in 0..sampleCount) {
-                val progress = sample.toFloat() / sampleCount
-                addAll(
-                    painter.requiredTiles(painter.viewport(journey, progress, width, height, cameraSettings))
-                        .map { it.id },
-                )
-            }
-            for (sample in 0..OUTRO_TILE_SAMPLES) {
-                val outroProgress = sample.toFloat() / OUTRO_TILE_SAMPLES
-                val frame = TimelineFrame(1f, outroProgress)
-                addAll(
-                    painter.requiredTiles(painter.viewport(journey, frame, width, height, cameraSettings))
-                        .map { it.id },
-                )
-            }
-            addAll(
-                painter.requiredTiles(
-                    painter.viewport(
-                        journey,
-                        TimelineFrame(1f, 1f),
-                        overviewWidth,
-                        overviewHeight,
-                        cameraSettings,
-                    ),
-                ).map { it.id },
-            )
-        }
+        val requiredTiles = requiredTilesForExport(
+            painter,
+            journey,
+            width,
+            height,
+            journeyFrameCount,
+            outroFrameCount,
+            fps,
+            overviewWidth,
+            overviewHeight,
+            cameraSettings,
+        )
         onProgress(ExportProgress(0f, ExportPhase.PREPARING_MAP, 0, requiredTiles.size))
-        requiredTiles.forEachIndexed { index, tile ->
-            coroutineContext.ensureActive()
-            tileRepository.load(tile)
+        MapTilePreparer(
+            isReady = { tileRepository.cached(it) != null },
+            load = { tileRepository.load(it) },
+        ).prepare(requiredTiles) { completed, total ->
             onProgress(
                 ExportProgress(
-                    (index + 1f) / requiredTiles.size.coerceAtLeast(1) * PREPARING_PROGRESS_WEIGHT,
+                    completed.toFloat() / total.coerceAtLeast(1) * PREPARING_PROGRESS_WEIGHT,
                     ExportPhase.PREPARING_MAP,
-                    index + 1,
-                    requiredTiles.size,
+                    completed,
+                    total,
                 ),
             )
+        }
+        val preparedTile = { tile: TileId ->
+            tileRepository.cached(tile)
+                ?: throw MapTilePreparationException(listOf(tile), requiredTiles.size)
         }
 
         val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, width, height).apply {
@@ -150,22 +139,9 @@ class Mp4Exporter(
         try {
             codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
             codec.start()
-            val journeyFrameCount = durationSeconds * fps
-            val outroFrameCount = (TimelineAnimation.OUTRO_SECONDS * fps).toInt()
-            val frameCount = journeyFrameCount + outroFrameCount
             for (frame in 0 until frameCount) {
                 coroutineContext.ensureActive()
-                val animationFrame = if (frame < journeyFrameCount) {
-                    val progress = if (journeyFrameCount == 1) 1f else frame.toFloat() / (journeyFrameCount - 1)
-                    TimelineFrame(progress, 0f)
-                } else {
-                    val outroFrame = frame - journeyFrameCount
-                    val outroElapsed = outroFrame.toFloat() / fps
-                    TimelineFrame(
-                        1f,
-                        (outroElapsed / TimelineAnimation.OUTRO_TRANSITION_SECONDS).coerceIn(0f, 1f),
-                    )
-                }
+                val animationFrame = animationFrame(frame, journeyFrameCount, fps)
                 var inputIndex: Int
                 do {
                     inputIndex = codec.dequeueInputBuffer(10_000)
@@ -183,7 +159,7 @@ class Mp4Exporter(
                     title,
                     renderText,
                     cameraSettings,
-                    tiles = tileRepository::cached,
+                    tiles = preparedTile,
                 )
                 bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
                 argbToYuv420(pixels, yuv, width, height, encoder.colorFormat)
@@ -241,7 +217,7 @@ class Mp4Exporter(
                 title,
                 renderText,
                 cameraSettings,
-                tiles = tileRepository::cached,
+                tiles = preparedTile,
             )
             onProgress(ExportProgress(1f, ExportPhase.COMPLETE, 1, 1))
             overview
@@ -287,7 +263,6 @@ class Mp4Exporter(
     }
 
     companion object {
-        private const val OUTRO_TILE_SAMPLES = 12
         const val OVERVIEW_MAX_EDGE = 1080
         private const val PREPARING_PROGRESS_WEIGHT = 0.10f
         private const val JOURNEY_PROGRESS_WEIGHT = 0.80f
@@ -305,6 +280,56 @@ class Mp4Exporter(
                 OVERVIEW_MAX_EDGE
             } else {
                 (OVERVIEW_MAX_EDGE / format.aspectRatio).toInt().coerceAtLeast(1).toEven()
+            }
+
+        internal fun requiredTilesForExport(
+            painter: TimelinePainter,
+            journey: Journey,
+            width: Int,
+            height: Int,
+            journeyFrameCount: Int,
+            outroFrameCount: Int,
+            fps: Int,
+            overviewWidth: Int,
+            overviewHeight: Int,
+            cameraSettings: CameraSettings,
+        ) = buildSet {
+            for (frame in 0 until journeyFrameCount + outroFrameCount) {
+                addAll(
+                    painter.requiredTiles(
+                        painter.viewport(
+                            journey,
+                            animationFrame(frame, journeyFrameCount, fps),
+                            width,
+                            height,
+                            cameraSettings,
+                        ),
+                    ).map { it.id },
+                )
+            }
+            addAll(
+                painter.requiredTiles(
+                    painter.viewport(
+                        journey,
+                        TimelineFrame(1f, 1f),
+                        overviewWidth,
+                        overviewHeight,
+                        cameraSettings,
+                    ),
+                ).map { it.id },
+            )
+        }
+
+        internal fun animationFrame(frame: Int, journeyFrameCount: Int, fps: Int): TimelineFrame =
+            if (frame < journeyFrameCount) {
+                val progress = if (journeyFrameCount == 1) 1f else frame.toFloat() / (journeyFrameCount - 1)
+                TimelineFrame(progress, 0f)
+            } else {
+                val outroElapsed = (frame - journeyFrameCount).toFloat() / fps
+                TimelineFrame(
+                    1f,
+                    (outroElapsed / TimelineAnimation.OUTRO_TRANSITION_SECONDS).coerceIn(0f, 1f),
+                )
             }
 
         private fun Int.toEven(): Int = if (this % 2 == 0) this else this + 1

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
@@ -177,6 +177,7 @@ class VideoExportService : Service() {
 
     private fun failureMessage(error: Throwable): String = when (error) {
         is UnsupportedVideoFormatException -> error.reason.describe(this, error.format)
+        is MapTilePreparationException -> getString(R.string.map_tiles_unavailable)
         else -> getString(R.string.video_export_failed)
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -30,6 +30,7 @@
     <string name="remembered_timeline_unavailable">Der bisher verwendete Timeline ist nicht mehr verfügbar.</string>
     <string name="choose_timeline_again">Wählen Sie erneut die Datei Timeline.json.</string>
     <string name="video_export_failed">Video konnte nicht erstellt werden</string>
+    <string name="map_tiles_unavailable">Die Karte konnte nicht vollständig geladen werden. Prüfe deine Verbindung und versuche es erneut.</string>
     <string name="location_settings_unavailable">Standorteinstellungen sind auf diesem Telefon nicht verfügbar</string>
     <string name="traveler">Reisender</string>
     <string name="tagline">Verwandeln Sie Ihre Timeline-Datei in ein animiertes Reisevideo.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -30,6 +30,7 @@
     <string name="remembered_timeline_unavailable">El modelo Timeline usado anteriormente ya no está disponible.</string>
     <string name="choose_timeline_again">Elija el archivo Timeline.json nuevamente.</string>
     <string name="video_export_failed">No se pudo crear el vídeo</string>
+    <string name="map_tiles_unavailable">No se pudo cargar el mapa por completo. Comprueba tu conexión e inténtalo de nuevo.</string>
     <string name="location_settings_unavailable">La configuración de ubicación no está disponible en este teléfono</string>
     <string name="traveler">Viajero</string>
     <string name="tagline">Convierta su archivo Timeline en un vídeo de viaje animado.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -30,6 +30,7 @@
     <string name="remembered_timeline_unavailable">Le Timeline précédemment utilisé n’est plus disponible.</string>
     <string name="choose_timeline_again">Choisissez à nouveau le fichier Timeline.json.</string>
     <string name="video_export_failed">Impossible de créer une vidéo</string>
+    <string name="map_tiles_unavailable">La carte n’a pas pu être chargée complètement. Vérifiez votre connexion et réessayez.</string>
     <string name="location_settings_unavailable">Les paramètres de localisation ne sont pas disponibles sur ce téléphone</string>
     <string name="traveler">Voyageur</string>
     <string name="tagline">Transformez votre fichier Timeline en vidéo de voyage animée.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -29,6 +29,7 @@
     <string name="remembered_timeline_unavailable">前回使用したタイムラインを開けなくなりました。</string>
     <string name="choose_timeline_again">Timeline.jsonをもう一度選択してください。</string>
     <string name="video_export_failed">動画を作成できませんでした</string>
+    <string name="map_tiles_unavailable">地図を完全に読み込めませんでした。接続を確認して、もう一度お試しください。</string>
     <string name="location_settings_unavailable">この端末では位置情報の設定を開けません</string>
     <string name="traveler">旅行者</string>
     <string name="tagline">タイムライン ファイルから旅のアニメーション動画を作成します。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -29,6 +29,7 @@
     <string name="remembered_timeline_unavailable">이전에 사용한 타임라인 파일을 더 이상 열 수 없습니다.</string>
     <string name="choose_timeline_again">Timeline.json 파일을 다시 선택해 주세요.</string>
     <string name="video_export_failed">영상을 만들지 못했습니다</string>
+    <string name="map_tiles_unavailable">지도를 완전히 불러오지 못했습니다. 연결을 확인한 후 다시 시도해 주세요.</string>
     <string name="location_settings_unavailable">이 휴대전화에서 위치 설정을 열 수 없습니다</string>
     <string name="traveler">여행자</string>
     <string name="tagline">타임라인 파일을 움직이는 여행 영상으로 만드세요.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -30,6 +30,7 @@
     <string name="remembered_timeline_unavailable">O Timeline usado anteriormente não está mais disponível.</string>
     <string name="choose_timeline_again">Escolha o arquivo Timeline.json novamente.</string>
     <string name="video_export_failed">Não foi possível criar o vídeo</string>
+    <string name="map_tiles_unavailable">Não foi possível carregar o mapa por completo. Verifique sua conexão e tente novamente.</string>
     <string name="location_settings_unavailable">As configurações de localização não estão disponíveis neste telefone</string>
     <string name="traveler">Viajante</string>
     <string name="tagline">Transforme seu arquivo Timeline em um vídeo animado de viagem.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -30,6 +30,7 @@
     <string name="remembered_timeline_unavailable">之前使用的Timeline不再可用。</string>
     <string name="choose_timeline_again">再次选择 Timeline.json 文件。</string>
     <string name="video_export_failed">无法创建视频</string>
+    <string name="map_tiles_unavailable">地图未能完全加载。请检查网络连接后重试。</string>
     <string name="location_settings_unavailable">此手机上无法使用位置设置</string>
     <string name="traveler">游客</string>
     <string name="tagline">将您的 Timeline 文件变成动画旅行视频。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -30,6 +30,7 @@
     <string name="remembered_timeline_unavailable">之前使用的時間軸已不再可用。</string>
     <string name="choose_timeline_again">請再次選擇「時間軸.json」檔案。</string>
     <string name="video_export_failed">無法建立影片</string>
+    <string name="map_tiles_unavailable">地圖未能完整載入。請檢查網路連線後再試一次。</string>
     <string name="location_settings_unavailable">無法開啟這支手機的位置設定</string>
     <string name="traveler">遊客</string>
     <string name="tagline">將您的時間軸紀錄檔案變成旅遊影片。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="remembered_timeline_unavailable">The previously used Timeline is no longer available.</string>
     <string name="choose_timeline_again">Choose the Timeline.json file again.</string>
     <string name="video_export_failed">Could not create video</string>
+    <string name="map_tiles_unavailable">The map could not be completely loaded. Check your connection and try again.</string>
     <string name="location_settings_unavailable">Location settings are unavailable on this phone</string>
     <string name="traveler">Traveler</string>
     <string name="tagline">Turn your Timeline file into an animated travel video.</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/MapTilePreparerTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/MapTilePreparerTest.kt
@@ -1,0 +1,133 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import dev.mahlernim.timelinevisualizer.render.TileId
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class MapTilePreparerTest {
+    @Test
+    fun cachedTilesCompleteWithoutAnotherLoad() = runBlocking {
+        val tiles = tiles(3)
+        val ready = tiles.toSet()
+        var loadCalls = 0
+        val progress = mutableListOf<Int>()
+
+        MapTilePreparer(
+            isReady = ready::contains,
+            load = { loadCalls++ },
+            pause = {},
+        ).prepare(tiles) { completed, _ -> progress += completed }
+
+        assertEquals(0, loadCalls)
+        assertEquals(listOf(1, 2, 3), progress.sorted())
+    }
+
+    @Test
+    fun transientFailuresAreRetriedUntilTheTileIsCached() = runBlocking {
+        val tile = TileId(4, 14, 6)
+        val ready = mutableSetOf<TileId>()
+        var attempts = 0
+
+        MapTilePreparer(
+            maxAttempts = 2,
+            retryDelayMillis = 1,
+            isReady = ready::contains,
+            load = {
+                attempts++
+                if (attempts == 2) ready += it
+            },
+            pause = {},
+        ).prepare(listOf(tile)) { _, _ -> }
+
+        assertEquals(2, attempts)
+        assertTrue(tile in ready)
+    }
+
+    @Test
+    fun incompleteCacheFailsBeforeEncodingCanStart() = runBlocking {
+        val tiles = tiles(3)
+        val ready = ConcurrentHashMap.newKeySet<TileId>()
+        ready += tiles.first()
+        val attempts = ConcurrentHashMap<TileId, AtomicInteger>()
+
+        val error = try {
+            MapTilePreparer(
+                parallelism = 2,
+                maxAttempts = 2,
+                retryDelayMillis = 0,
+                isReady = ready::contains,
+                load = { tile -> attempts.computeIfAbsent(tile) { AtomicInteger() }.incrementAndGet() },
+                pause = {},
+            ).prepare(tiles) { _, _ -> }
+            fail("Expected incomplete tile preparation to fail")
+            null
+        } catch (error: MapTilePreparationException) {
+            error
+        }
+
+        assertEquals(tiles.drop(1).toSet(), error!!.missingTiles.toSet())
+        assertEquals(tiles.size, error.totalTiles)
+        tiles.drop(1).forEach { assertEquals(2, attempts[it]?.get()) }
+    }
+
+    @Test
+    fun downloadsUseBoundedParallelism() = runBlocking {
+        val tiles = tiles(12)
+        val ready = ConcurrentHashMap.newKeySet<TileId>()
+        val active = AtomicInteger()
+        val maximumActive = AtomicInteger()
+
+        MapTilePreparer(
+            parallelism = 4,
+            maxAttempts = 1,
+            isReady = ready::contains,
+            load = { tile ->
+                val current = active.incrementAndGet()
+                maximumActive.updateAndGet { maximum -> maxOf(maximum, current) }
+                try {
+                    delay(10)
+                    ready += tile
+                } finally {
+                    active.decrementAndGet()
+                }
+            },
+            pause = {},
+        ).prepare(tiles) { _, _ -> }
+
+        assertEquals(tiles.toSet(), ready)
+        assertTrue("Expected concurrent downloads", maximumActive.get() > 1)
+        assertTrue("Exceeded worker limit", maximumActive.get() <= 4)
+    }
+
+    @Test
+    fun cancellationIsNeverRetriedOrConvertedToAMissingTile() = runBlocking {
+        val cancellation = CancellationException("cancel export")
+        var attempts = 0
+
+        try {
+            MapTilePreparer(
+                maxAttempts = 2,
+                isReady = { false },
+                load = {
+                    attempts++
+                    throw cancellation
+                },
+                pause = {},
+            ).prepare(listOf(TileId(4, 14, 6))) { _, _ -> }
+            fail("Expected cancellation")
+        } catch (actual: CancellationException) {
+            assertEquals(cancellation.message, actual.message)
+        }
+
+        assertEquals(1, attempts)
+    }
+
+    private fun tiles(count: Int): List<TileId> = List(count) { index -> TileId(5, index, index) }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/Mp4ExporterTileCoverageTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/Mp4ExporterTileCoverageTest.kt
@@ -1,0 +1,88 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import dev.mahlernim.timelinevisualizer.model.GeoPoint
+import dev.mahlernim.timelinevisualizer.model.Journey
+import dev.mahlernim.timelinevisualizer.render.CameraSettings
+import dev.mahlernim.timelinevisualizer.render.TimelineFrame
+import dev.mahlernim.timelinevisualizer.render.TimelinePainter
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class Mp4ExporterTileCoverageTest {
+    @Test
+    fun preparationIncludesEveryVideoFrameAndTheOverview() {
+        val journey = Journey.from(
+            listOf(
+                point(37.55, 126.95),
+                point(35.68, 139.76),
+                point(34.69, 135.50),
+            ),
+            2025,
+        )
+        val painter = TimelinePainter()
+        val journeyFrames = 9
+        val outroFrames = 4
+        val fps = 3
+        val settings = CameraSettings.DEFAULT
+        val expected = buildSet {
+            for (frame in 0 until journeyFrames + outroFrames) {
+                addAll(
+                    painter.requiredTiles(
+                        painter.viewport(
+                            journey,
+                            Mp4Exporter.animationFrame(frame, journeyFrames, fps),
+                            VIDEO_WIDTH,
+                            VIDEO_HEIGHT,
+                            settings,
+                        ),
+                    ).map { it.id },
+                )
+            }
+            addAll(
+                painter.requiredTiles(
+                    painter.viewport(
+                        journey,
+                        TimelineFrame(1f, 1f),
+                        OVERVIEW_WIDTH,
+                        OVERVIEW_HEIGHT,
+                        settings,
+                    ),
+                ).map { it.id },
+            )
+        }
+
+        val actual = Mp4Exporter.requiredTilesForExport(
+            painter,
+            journey,
+            VIDEO_WIDTH,
+            VIDEO_HEIGHT,
+            journeyFrames,
+            outroFrames,
+            fps,
+            OVERVIEW_WIDTH,
+            OVERVIEW_HEIGHT,
+            settings,
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    private fun point(latitude: Double, longitude: Double) = GeoPoint(
+        Instant.parse("2025-06-01T00:00:00Z"),
+        latitude,
+        longitude,
+    )
+
+    companion object {
+        private const val VIDEO_WIDTH = 480
+        private const val VIDEO_HEIGHT = 480
+        private const val OVERVIEW_WIDTH = 1080
+        private const val OVERVIEW_HEIGHT = 1080
+    }
+}


### PR DESCRIPTION
## Summary

- require every map tile used by every video frame and the overview before encoding begins
- load missing tiles with four bounded workers and one retry
- abort with a localized connection message instead of silently rendering blank map areas
- use unique atomic cache writes and preserve export cancellation

## Validation

- reporter-tested Android build successfully exports the map
- `testGithubDebugUnitTest` with 180 tests and no failures
- `lintGithubDebug`
- `assembleGithubDebug`

Fixes #52