### PR TITLE
Prepare Timeline Visualizer 2.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.7
+
+- Prepare every map tile used by every video frame and the final overview before encoding begins.
+- Load missing map tiles with four bounded workers and retry transient failures once.
+- Stop with a localized connection message instead of silently creating a video with missing map areas.
+- Use unique atomic cache writes and preserve export cancellation during tile preparation.
+- Set Android version code 26 and version name 2.2.7.
+
 ## 2.2.6
 
 - Add a Done action to dismiss the persistent Video ready tray.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 25
-        versionName = "2.2.6"
+        versionCode = 26
+        versionName = "2.2.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/docs/release-notes-v2.2.7.md
+++ b/docs/release-notes-v2.2.7.md
@@ -1,0 +1,55 @@
+# Timeline Visualizer 2.2.7
+
+Video export now waits until the complete map is ready. Missing map tiles load in
+parallel for faster preparation, and the app asks you to check your connection instead
+of creating a video with blank map areas when the map cannot be loaded completely.
+
+## 한국어
+
+이제 지도가 완전히 준비된 후 영상 내보내기가 시작됩니다. 누락된 지도 타일을 동시에 불러와
+준비 시간이 단축되며, 지도를 완전히 불러올 수 없으면 빈 지도 영역이 있는 영상을 만드는 대신
+연결을 확인하라는 안내가 표시됩니다.
+
+## 日本語
+
+地図の準備がすべて完了してから動画の書き出しを開始するようになりました。不足している地図
+タイルを並行して読み込むため準備が速くなり、地図を完全に読み込めない場合は空白の地図を含む
+動画を作成せず、接続を確認するよう案内します。
+
+## 简体中文
+
+现在会在地图完全准备好后再开始导出视频。缺失的地图图块会并行加载，从而加快准备速度。
+如果无法完整加载地图，应用会提示您检查网络连接，而不会创建含有空白地图区域的视频。
+
+## 繁體中文
+
+現在會在地圖完整準備好後才開始匯出影片。缺少的地圖圖磚會平行載入，以加快準備速度。
+如果無法完整載入地圖，應用程式會提示您檢查網路連線，而不會建立含有空白地圖區域的影片。
+
+## Español
+
+La exportación de vídeo ahora espera hasta que el mapa esté completamente listo. Los
+mosaicos que faltan se cargan en paralelo para acelerar la preparación. Si el mapa no
+puede cargarse por completo, la aplicación pide comprobar la conexión en lugar de crear
+un vídeo con zonas del mapa en blanco.
+
+## Français
+
+L’exportation de la vidéo attend désormais que la carte soit entièrement prête. Les
+tuiles manquantes sont chargées en parallèle pour accélérer la préparation. Si la carte
+ne peut pas être chargée complètement, l’application demande de vérifier la connexion
+au lieu de créer une vidéo comportant des zones de carte vides.
+
+## Deutsch
+
+Der Videoexport beginnt jetzt erst, wenn die Karte vollständig vorbereitet ist. Fehlende
+Kacheln werden parallel geladen, um die Vorbereitung zu beschleunigen. Kann die Karte
+nicht vollständig geladen werden, bittet die App darum, die Verbindung zu prüfen, statt
+ein Video mit leeren Kartenbereichen zu erstellen.
+
+## Português (Brasil)
+
+A exportação de vídeo agora espera até que o mapa esteja totalmente pronto. Os blocos
+ausentes são carregados em paralelo para acelerar a preparação. Se não for possível
+carregar o mapa por completo, o app pede para verificar a conexão em vez de criar um
+vídeo com áreas do mapa em branco.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.6` and version code `25`
+- Version name `2.2.7` and version code `26`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- set Android version name to 2.2.7 and version code to 26
- document the complete and parallel map-tile preparation fix
- add localized v2.2.7 GitHub release notes
- update the Play submission checklist

## Validation

- `python -m pytest -q`, 26 passed
- release workflow YAML parsed successfully
- `./gradlew.bat test lint assembleGithubDebug assemblePlayDebug --stacktrace`
- 360 Android unit tests passed across GitHub and Play flavors
- `git diff --check`

Release follow-up for #52 and PR #117.