### PR TITLE
Acknowledge completed exports in v2.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.8
+
+- Clear the completed Video ready tray after watching or sharing the matching video.
+- Clear the tray when the user intentionally opens or reopens My videos.
+- Keep unacknowledged completions visible across automatic app startup and screen restoration.
+- Preserve every generated video when its transient completion state is cleared.
+- Set Android version code 27 and version name 2.2.8.
+
 ## 2.2.7
 
 - Prepare every map tile used by every video frame and the final overview before encoding begins.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 26
-        versionName = "2.2.7"
+        versionCode = 27
+        versionName = "2.2.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -242,12 +242,15 @@ class MainActivity : AppCompatActivity() {
         binding.bottomNavigation.setOnItemSelectedListener { item ->
             if (syncingBottomNavigation) return@setOnItemSelectedListener true
             when (item.itemId) {
-                R.id.navigationVideos -> showVideos()
+                R.id.navigationVideos -> showVideos(acknowledgeCompletion = true)
                 R.id.navigationCreate -> showNewVideo(loadRemembered = true)
                 R.id.navigationSettings -> showSettings()
                 else -> return@setOnItemSelectedListener false
             }
             true
+        }
+        binding.bottomNavigation.setOnItemReselectedListener { item ->
+            if (item.itemId == R.id.navigationVideos) acknowledgeCompletedExport()
         }
         binding.exportTrayCancelButton.setOnClickListener { VideoExportService.cancel(applicationContext) }
         binding.exportTrayRetryButton.setOnClickListener { retryVideoExport() }
@@ -282,14 +285,14 @@ class MainActivity : AppCompatActivity() {
         settingsScreen.githubProjectButton.setOnClickListener { openWebPage(PROJECT_URL, R.string.web_page_unavailable) }
         settingsScreen.checkUpdatesButton.setOnClickListener { openUpdates() }
         settingsScreen.versionText.text = installedVersionLabel()
-        playerScreen.playerBackButton.setOnClickListener { showVideos() }
+        playerScreen.playerBackButton.setOnClickListener { showVideos(acknowledgeCompletion = true) }
         playerScreen.playerShareButton.setOnClickListener { playerUri?.let(::shareVideo) }
         playerScreen.playerMoreButton.setOnClickListener {
             playerUri?.let { uri -> videoStore.list().firstOrNull { it.uri == uri.toString() }?.let(::showVideoActions) }
         }
         playerScreen.playerExternalButton.setOnClickListener { playerUri?.let(::openExternalVideoPlayer) }
         onBackPressedDispatcher.addCallback(this) {
-            if (currentScreen == Screen.VIDEOS) finish() else showVideos()
+            if (currentScreen == Screen.VIDEOS) finish() else showVideos(acknowledgeCompletion = true)
         }
         editor.timelineSeek.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
@@ -344,7 +347,7 @@ class MainActivity : AppCompatActivity() {
         playerPlayWhenReady = savedInstanceState?.getBoolean(STATE_PLAYER_PLAYING) ?: true
         val incoming = intent?.data
         if (intent?.action == ACTION_WATCH_VIDEO && incoming != null) {
-            showVideoPlayer(incoming, resetPosition = savedInstanceState == null)
+            if (savedInstanceState == null) watchVideo(incoming) else showVideoPlayer(incoming, resetPosition = false)
         } else if (incoming != null) {
             showNewVideo(loadRemembered = false)
             requestTimelineImport(incoming)
@@ -382,14 +385,15 @@ class MainActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         intent.data?.let { uri ->
-            if (intent.action == ACTION_WATCH_VIDEO) showVideoPlayer(uri) else {
+            if (intent.action == ACTION_WATCH_VIDEO) watchVideo(uri) else {
                 showNewVideo(loadRemembered = false)
                 requestTimelineImport(uri)
             }
         }
     }
 
-    private fun showVideos() {
+    private fun showVideos(acknowledgeCompletion: Boolean = false) {
+        if (acknowledgeCompletion) acknowledgeCompletedExport()
         releaseVideoPlayer()
         currentScreen = Screen.VIDEOS
         home.root.visibility = View.VISIBLE
@@ -2047,6 +2051,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun watchVideo(uri: Uri) {
         showVideoPlayer(uri)
+        acknowledgeCompletedExport(uri)
     }
 
     private fun openExternalVideoPlayer(uri: Uri) {
@@ -2066,6 +2071,17 @@ class MainActivity : AppCompatActivity() {
             clipData = ClipData.newRawUri(getString(R.string.timeline_video), uri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }, getString(R.string.share_travel_video)))
+        acknowledgeCompletedExport(uri)
+    }
+
+    private fun acknowledgeCompletedExport(uri: Uri? = null) {
+        val snapshot = VideoExportCoordinator.state.value
+        if (
+            snapshot.status == VideoExportStatus.COMPLETE &&
+            (uri == null || snapshot.outputUri == uri.toString())
+        ) {
+            VideoExportCoordinator.clear(applicationContext)
+        }
     }
 
     private fun chooseVideoCopyDestination(source: Uri) {

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -650,6 +650,118 @@ class MainActivityTest {
     }
 
     @Test
+    fun watchingCompletedExportAcknowledgesTrayWithoutRemovingSavedVideo() {
+        val uri = "content://example/generated-video"
+        store.upsert(
+            VideoRecord(
+                uri = uri,
+                title = "Trip",
+                fileName = "trip.mp4",
+                createdAtMillis = 1L,
+                durationSeconds = 30,
+            ),
+        )
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(status = VideoExportStatus.COMPLETE, outputUri = uri, title = "Trip"),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        activity.findViewById<View>(R.id.exportTrayWatchButton).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.playerScreen).visibility)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertEquals(listOf(uri), store.list().map { it.uri })
+    }
+
+    @Test
+    fun sharingCompletedExportAcknowledgesTrayWithoutRemovingSavedVideo() {
+        val uri = "content://example/generated-video"
+        store.upsert(
+            VideoRecord(
+                uri = uri,
+                title = "Trip",
+                fileName = "trip.mp4",
+                createdAtMillis = 1L,
+                durationSeconds = 30,
+            ),
+        )
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(status = VideoExportStatus.COMPLETE, outputUri = uri, title = "Trip"),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        activity.findViewById<View>(R.id.exportTrayShareButton).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(Intent.ACTION_CHOOSER, shadowOf(activity).nextStartedActivity.action)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertEquals(listOf(uri), store.list().map { it.uri })
+    }
+
+    @Test
+    fun userNavigationToVideosAcknowledgesCompletionButSettingsDoesNot() {
+        val activity = launchActivity()
+        val completed = VideoExportSnapshot(
+            status = VideoExportStatus.COMPLETE,
+            outputUri = "content://example/generated-video",
+            title = "Trip",
+        )
+        VideoExportCoordinator.publish(context, completed)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        activity.findViewById<View>(R.id.navigationSettings).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(VideoExportStatus.COMPLETE, VideoExportStateStore(context).load().status)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+
+        activity.findViewById<View>(R.id.navigationVideos).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+
+        VideoExportCoordinator.publish(context, completed)
+        shadowOf(Looper.getMainLooper()).idle()
+        activity.findViewById<View>(R.id.navigationVideos).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+    }
+
+    @Test
+    fun automaticVideosLaunchDoesNotAcknowledgeRestoredCompletion() {
+        val uri = "content://example/generated-video"
+        store.upsert(
+            VideoRecord(
+                uri = uri,
+                title = "Trip",
+                fileName = "trip.mp4",
+                createdAtMillis = 1L,
+                durationSeconds = 30,
+            ),
+        )
+        VideoExportStateStore(context).save(
+            VideoExportSnapshot(status = VideoExportStatus.COMPLETE, outputUri = uri, title = "Trip"),
+        )
+
+        val activity = launchActivity()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.videosScreen).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.exportStatusTray).visibility)
+        assertEquals(VideoExportStatus.COMPLETE, VideoExportStateStore(context).load().status)
+    }
+
+    @Test
     @Config(sdk = [35], qualifiers = "de-w360dp-h640dp-xxhdpi")
     fun completedExportTrayActionsFitCompactWidth() {
         val activity = launchActivity()

--- a/docs/release-notes-v2.2.8.md
+++ b/docs/release-notes-v2.2.8.md
@@ -1,0 +1,46 @@
+# Timeline Visualizer 2.2.8
+
+The Video ready tray now closes after you watch or share the completed video, or open
+My videos. The generated video remains safely available in My videos.
+
+## 한국어
+
+이제 완성된 영상을 보거나 공유하거나 내 동영상을 열면 동영상 준비 완료 창이 닫힙니다.
+생성된 영상은 내 동영상에 안전하게 보관됩니다.
+
+## 日本語
+
+完成した動画を見たり共有したり、「マイ動画」を開いたりすると、動画の準備完了トレイが
+閉じるようになりました。作成した動画は引き続き「マイ動画」に安全に保存されます。
+
+## 简体中文
+
+现在，观看或分享已完成的视频，或者打开“我的视频”后，“视频已就绪”托盘会自动关闭。
+生成的视频仍会安全地保留在“我的视频”中。
+
+## 繁體中文
+
+現在，觀看或分享已完成的影片，或開啟「我的影片」後，「影片已就緒」托盤會自動關閉。
+產生的影片仍會安全地保留在「我的影片」中。
+
+## Español
+
+El panel Vídeo listo ahora se cierra después de ver o compartir el vídeo terminado, o
+al abrir Mis vídeos. El vídeo generado permanece guardado de forma segura en Mis vídeos.
+
+## Français
+
+Le volet Vidéo prête se ferme désormais après la lecture ou le partage de la vidéo
+terminée, ou à l’ouverture de Mes vidéos. La vidéo créée reste disponible dans Mes vidéos.
+
+## Deutsch
+
+Die Anzeige Video bereit wird jetzt geschlossen, nachdem das fertige Video angesehen
+oder geteilt oder Meine Videos geöffnet wurde. Das erstellte Video bleibt sicher unter
+Meine Videos gespeichert.
+
+## Português (Brasil)
+
+O painel Vídeo pronto agora fecha depois que você assiste ou compartilha o vídeo
+concluído, ou abre Meus vídeos. O vídeo criado continua salvo com segurança em Meus
+vídeos.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.7` and version code `26`
+- Version name `2.2.8` and version code `27`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- clear the completed Video ready tray after watching or sharing the matching video
- clear it when the user intentionally selects or reselects My videos
- preserve unacknowledged completion state across automatic startup and activity restoration
- keep the generated video in My videos
- prepare version 2.2.8 with version code 27

This is a follow-up UX refinement to #98.

## Validation

- focused MainActivity unit tests
- full Gradle test and lint suite
- GitHub and Play debug APK builds
- python -m pytest -q, 26 passed
- git diff --check