### PR TITLE
Refactor app state and harden CLI errors for v2.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.10
+
+- Move settings, video-export state, and the creations list behind lifecycle-aware ViewModels.
+- Replace the creations thumbnail generation counter with structured coroutine cancellation and retain the stable row identity guard.
+- Preserve the v2.2.9 preprocessed Timeline cache and v2.2.8 completed-export acknowledgment behavior.
+- Make the desktop CLI reject missing input files and unavailable FFmpeg before parsing or frame preparation.
+- Raise typed Timeline parsing and no-data errors instead of terminating from reusable parsing code.
+- Document the intentionally process-lifetime desktop tile cache and add focused failure-path tests.
+- Set Android version code 29 and version name 2.2.10.
+
 ## 2.2.9
 
 - Save normalized semantic and raw-signal points in the app-private cache after a successful Timeline import.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 28
-        versionName = "2.2.9"
+        versionCode = 29
+        versionName = "2.2.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -73,6 +73,7 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.12.4")
     implementation("androidx.core:core-ktx:1.18.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.10.0")
     implementation("com.google.android.material:material:1.13.0")
     implementation("com.google.code.gson:gson:2.13.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -22,6 +22,7 @@ import android.widget.AutoCompleteTextView
 import android.widget.SeekBar
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.addCallback
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
@@ -36,6 +37,8 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -62,12 +65,12 @@ import dev.mahlernim.timelinevisualizer.databinding.ScreenSettingsBinding
 import dev.mahlernim.timelinevisualizer.databinding.ScreenVideosBinding
 import dev.mahlernim.timelinevisualizer.export.ExportProgress
 import dev.mahlernim.timelinevisualizer.export.ExportPhase
-import dev.mahlernim.timelinevisualizer.export.VideoExportCoordinator
 import dev.mahlernim.timelinevisualizer.export.VideoExportRequest
 import dev.mahlernim.timelinevisualizer.export.VideoExportRequestStore
 import dev.mahlernim.timelinevisualizer.export.VideoExportService
 import dev.mahlernim.timelinevisualizer.export.VideoExportSnapshot
 import dev.mahlernim.timelinevisualizer.export.VideoExportStatus
+import dev.mahlernim.timelinevisualizer.export.VideoExportViewModel
 import dev.mahlernim.timelinevisualizer.export.EncoderSupport
 import dev.mahlernim.timelinevisualizer.export.VideoEncoderSupport
 import dev.mahlernim.timelinevisualizer.export.describe
@@ -89,9 +92,11 @@ import dev.mahlernim.timelinevisualizer.ui.DistanceUnitPreferences
 import dev.mahlernim.timelinevisualizer.ui.AppLanguage
 import dev.mahlernim.timelinevisualizer.ui.LocationFilterPreferences
 import dev.mahlernim.timelinevisualizer.ui.SelectionArrayAdapter
+import dev.mahlernim.timelinevisualizer.ui.SettingsViewModel
 import dev.mahlernim.timelinevisualizer.videos.GeneratedMediaRepository
 import dev.mahlernim.timelinevisualizer.videos.VideoMedia
 import dev.mahlernim.timelinevisualizer.videos.VideoRecord
+import dev.mahlernim.timelinevisualizer.videos.VideoLibraryViewModel
 import dev.mahlernim.timelinevisualizer.videos.VideoStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
@@ -145,14 +150,27 @@ class MainActivity : AppCompatActivity() {
     private val titleHandler = Handler(Looper.getMainLooper())
     private val monthNames by lazy { DateFormatSymbols.getInstance().months.take(12) }
     private val preferences by lazy { getSharedPreferences("display", MODE_PRIVATE) }
-    private val videoStore by lazy { VideoStore(applicationContext) }
     private val videoMedia by lazy { VideoMedia(applicationContext) }
     private val generatedMedia by lazy { GeneratedMediaRepository(applicationContext) }
     private val timelineLoader by lazy { CachedTimelineLoader(applicationContext) }
     private val timelineSourceStore by lazy { TimelineSourceStore(applicationContext) }
-    private val cameraSettingsPreferences by lazy { CameraSettingsPreferences(applicationContext) }
-    private val distanceUnitPreferences by lazy { DistanceUnitPreferences(applicationContext) }
-    private val locationFilterPreferences by lazy { LocationFilterPreferences(applicationContext) }
+    private val settingsViewModel by viewModels<SettingsViewModel> {
+        viewModelFactory {
+            initializer {
+                SettingsViewModel(
+                    CameraSettingsPreferences(applicationContext),
+                    DistanceUnitPreferences(applicationContext),
+                    LocationFilterPreferences(applicationContext),
+                )
+            }
+        }
+    }
+    private val videoExportViewModel by viewModels<VideoExportViewModel> {
+        viewModelFactory { initializer { VideoExportViewModel(applicationContext) } }
+    }
+    private val videoLibraryViewModel by viewModels<VideoLibraryViewModel> {
+        viewModelFactory { initializer { VideoLibraryViewModel(VideoStore(applicationContext)) } }
+    }
     private val videoEncoderProfiles by lazy { VideoEncoderSupport.deviceProfiles() }
     private var cameraSettings = CameraSettings.DEFAULT
     private var distanceUnitPreference = DistanceUnitPreference.AUTOMATIC
@@ -160,7 +178,7 @@ class MainActivity : AppCompatActivity() {
     private var locationFilterMode = LocationFilterMode.CONSERVATIVE
     private var routeDurationSeconds = VideoDuration.DEFAULT_SECONDS
     private val applyTitleChanges = Runnable { commitTitlePreferences() }
-    private var videoRenderGeneration = 0
+    private var videoRenderJob: Job? = null
     private var videosExpanded = false
     private var currentScreen = Screen.VIDEOS
     private var rememberedTimelineLoaded = false
@@ -258,10 +276,10 @@ class MainActivity : AppCompatActivity() {
         binding.exportTrayWatchButton.setOnClickListener { lastVideoUri?.let(::watchVideo) }
         binding.exportTrayShareButton.setOnClickListener { lastVideoUri?.let(::shareVideo) }
         binding.exportTrayDismissButton.setOnClickListener {
-            VideoExportCoordinator.clear(applicationContext)
+            videoExportViewModel.clear()
         }
         editor.doneButton.setOnClickListener {
-            VideoExportCoordinator.clear(applicationContext)
+            videoExportViewModel.clear()
             editor.videoReadyGroup.visibility = View.GONE
             showVideos()
         }
@@ -289,7 +307,9 @@ class MainActivity : AppCompatActivity() {
         playerScreen.playerBackButton.setOnClickListener { showVideos(acknowledgeCompletion = true) }
         playerScreen.playerShareButton.setOnClickListener { playerUri?.let(::shareVideo) }
         playerScreen.playerMoreButton.setOnClickListener {
-            playerUri?.let { uri -> videoStore.list().firstOrNull { it.uri == uri.toString() }?.let(::showVideoActions) }
+            playerUri?.let { uri ->
+                videoLibraryViewModel.records.value.firstOrNull { it.uri == uri.toString() }?.let(::showVideoActions)
+            }
         }
         playerScreen.playerExternalButton.setOnClickListener { playerUri?.let(::openExternalVideoPlayer) }
         onBackPressedDispatcher.addCallback(this) {
@@ -339,7 +359,6 @@ class MainActivity : AppCompatActivity() {
         configureExactDates()
         renderVideos()
         lifecycleScope.launch(Dispatchers.IO) { videoMedia.pruneOverviewCache() }
-        VideoExportCoordinator.restore(applicationContext)
         observeVideoExport()
         VideoExportService.resumeIfNeeded(applicationContext)
 
@@ -362,8 +381,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showDefaultLaunchScreen() {
-        val exportInProgress = VideoExportCoordinator.state.value.status == VideoExportStatus.RUNNING
-        if (videoStore.list().isEmpty() && !exportInProgress) {
+        val exportInProgress = videoExportViewModel.current.status == VideoExportStatus.RUNNING
+        if (videoLibraryViewModel.records.value.isEmpty() && !exportInProgress) {
             showNewVideo(loadRemembered = true)
         } else {
             showVideos()
@@ -463,7 +482,8 @@ class MainActivity : AppCompatActivity() {
         settingsScreen.root.visibility = View.GONE
         playerScreen.root.visibility = View.VISIBLE
         binding.bottomNavigation.visibility = View.GONE
-        playerScreen.playerTitle.text = videoStore.list().firstOrNull { it.uri == uri.toString() }?.title
+        playerScreen.playerTitle.text =
+            videoLibraryViewModel.records.value.firstOrNull { it.uri == uri.toString() }?.title
             ?: getString(R.string.timeline_video)
         playerScreen.playerErrorGroup.visibility = View.GONE
         initializeVideoPlayer()
@@ -1159,11 +1179,13 @@ class MainActivity : AppCompatActivity() {
             updateAdvancedSettings(cameraSettings.copy(videoQuality = VideoQuality.values()[position]))
         }
         settingsScreen.resetAdvancedSettingsButton.setOnClickListener {
-            applyDistanceUnitPreference(DistanceUnitPreference.AUTOMATIC)
-            applyAdvancedSettings(cameraSettingsPreferences.reset())
+            settingsViewModel.resetCameraAndDistance()
+            val state = settingsViewModel.state.value
+            applyDistanceUnitPreference(state.distanceUnit, save = false)
+            applyAdvancedSettings(state.camera)
             Snackbar.make(binding.root, R.string.advanced_defaults_restored, Snackbar.LENGTH_SHORT).show()
         }
-        applyAdvancedSettings(cameraSettingsPreferences.load())
+        applyAdvancedSettings(settingsViewModel.state.value.camera)
     }
 
     private fun configureLocationFiltering() {
@@ -1178,16 +1200,16 @@ class MainActivity : AppCompatActivity() {
         makeDropdownOpenReliably(settingsScreen.locationFilterDropdown)
         settingsScreen.locationFilterDropdown.setOnItemClickListener { _, _, position, _ ->
             locationFilterMode = modes[position]
-            locationFilterPreferences.save(locationFilterMode)
+            settingsViewModel.updateLocationFilter(locationFilterMode)
             updateLocationFilterLabel()
             rebuildRenderTimeline(reselect = true)
         }
-        locationFilterMode = locationFilterPreferences.load()
+        locationFilterMode = settingsViewModel.state.value.locationFilter
         updateLocationFilterLabel()
     }
 
     private fun configureDistanceUnitSelection() {
-        distanceUnitPreference = distanceUnitPreferences.load()
+        distanceUnitPreference = settingsViewModel.state.value.distanceUnit
         val dropdown = settingsScreen.distanceUnitDropdown
         dropdown.setAdapter(SelectionArrayAdapter(this, distanceUnitLabels()))
         makeDropdownOpenReliably(dropdown)
@@ -1199,7 +1221,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun applyDistanceUnitPreference(preference: DistanceUnitPreference, save: Boolean = true) {
         distanceUnitPreference = preference
-        if (save) distanceUnitPreferences.save(preference)
+        if (save) settingsViewModel.updateDistanceUnit(preference)
         updateDistanceUnitLabel()
         editor.timelineView.renderText = currentRenderText()
         journey?.let { editor.periodSummaryText.text = selectedPeriodSummary(it, selectedIgnoredCount) }
@@ -1326,7 +1348,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun updateAdvancedSettings(settings: CameraSettings) {
-        cameraSettingsPreferences.save(settings)
+        settingsViewModel.updateCamera(settings)
         applyAdvancedSettings(settings)
     }
 
@@ -1495,11 +1517,10 @@ class MainActivity : AppCompatActivity() {
             outputUri = completeRequest.outputUri,
             title = completeRequest.title,
         )
-        VideoExportCoordinator.publish(applicationContext, snapshot)
+        videoExportViewModel.publish(snapshot)
         runCatching { VideoExportService.start(applicationContext) }.onFailure {
             generatedMedia.discard(uri)
-            VideoExportCoordinator.publish(
-                applicationContext,
+            videoExportViewModel.publish(
                 VideoExportSnapshot(
                     status = VideoExportStatus.FAILED,
                     outputUri = uri.toString(),
@@ -1513,7 +1534,7 @@ class MainActivity : AppCompatActivity() {
     private fun observeVideoExport() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                VideoExportCoordinator.state.collect(::renderVideoExport)
+                videoExportViewModel.state.collect(::renderVideoExport)
             }
         }
     }
@@ -1655,7 +1676,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun retryVideoExport(request: VideoExportRequest?) {
         if (request == null) {
-            VideoExportCoordinator.clear(applicationContext)
+            videoExportViewModel.clear()
             showNewVideo(loadRemembered = true)
             Snackbar.make(binding.root, R.string.video_request_unavailable, Snackbar.LENGTH_LONG).show()
             return
@@ -1668,8 +1689,7 @@ class MainActivity : AppCompatActivity() {
             runCatching { generatedMedia.createVideoDestination(retryRequest.title, retryRequest.journey.period) }
                 .onSuccess { uri -> uri?.let { startVideoExport(it, retryRequest) } }
                 .onFailure {
-                    VideoExportCoordinator.publish(
-                        applicationContext,
+                    videoExportViewModel.publish(
                         VideoExportSnapshot(
                             status = VideoExportStatus.FAILED,
                             title = retryRequest.title,
@@ -1723,7 +1743,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun prepareAnotherVideo() {
-        VideoExportCoordinator.clear(applicationContext)
+        videoExportViewModel.clear()
         editor.videoReadyGroup.visibility = View.GONE
         editor.timelineSeek.progress = 0
         showProgress(0f)
@@ -1753,7 +1773,7 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
                 result.onSuccess { record ->
-                    videoStore.upsert(record)
+                    videoLibraryViewModel.upsert(record)
                     imported += 1
                 }.onFailure { failed += 1 }
             }
@@ -1772,8 +1792,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun renderVideos() {
-        val records = videoStore.list()
-        val generation = ++videoRenderGeneration
+        videoLibraryViewModel.refresh()
+        val records = videoLibraryViewModel.records.value
+        videoRenderJob?.cancel()
         home.emptyVideosText.visibility = if (records.isEmpty()) View.VISIBLE else View.GONE
         home.showAllVideosButton.visibility = if (records.size > COLLAPSED_CREATION_COUNT) View.VISIBLE else View.GONE
         home.deleteAllVideosButton.visibility = if (records.isEmpty()) View.GONE else View.VISIBLE
@@ -1784,39 +1805,46 @@ class MainActivity : AppCompatActivity() {
         }
         home.videosList.removeAllViews()
         val visibleRecords = if (videosExpanded) records else records.take(COLLAPSED_CREATION_COUNT)
-        visibleRecords.forEach { record ->
-            val item = ItemVideoBinding.inflate(layoutInflater, home.videosList, false)
-            val uri = record.uri.toUri()
-            item.root.tag = record.uri
-            item.videoTitle.text = record.title
-            item.videoDetails.text = videoDetails(record, available = true)
-            item.videoWatchButton.isEnabled = false
-            item.videoShareButton.isEnabled = false
-            item.root.isClickable = false
-            item.videoWatchButton.setOnClickListener { watchVideo(uri) }
-            item.videoShareButton.setOnClickListener { shareVideo(uri) }
-            item.videoMoreButton.setOnClickListener { showVideoActions(record) }
-            item.root.setOnClickListener { watchVideo(uri) }
-            home.videosList.addView(item.root)
+        videoRenderJob = lifecycleScope.launch {
+            visibleRecords.forEach { record ->
+                val item = ItemVideoBinding.inflate(layoutInflater, home.videosList, false)
+                val uri = record.uri.toUri()
+                item.root.tag = record.uri
+                item.videoTitle.text = record.title
+                item.videoDetails.text = videoDetails(record, available = true)
+                item.videoWatchButton.isEnabled = false
+                item.videoShareButton.isEnabled = false
+                item.root.isClickable = false
+                item.videoWatchButton.setOnClickListener { watchVideo(uri) }
+                item.videoShareButton.setOnClickListener { shareVideo(uri) }
+                item.videoMoreButton.setOnClickListener { showVideoActions(record) }
+                item.root.setOnClickListener { watchVideo(uri) }
+                home.videosList.addView(item.root)
 
-            lifecycleScope.launch {
-                val mediaState = withContext(Dispatchers.IO) {
-                    val available = videoMedia.isAvailable(uri)
-                    val thumbnail = if (available) runCatching { videoMedia.createThumbnail(uri) }.getOrNull() else null
-                    available to thumbnail
-                }
-                if (generation != videoRenderGeneration || item.root.tag != record.uri) {
-                    mediaState.second?.recycle()
-                    return@launch
-                }
-                val available = mediaState.first
-                item.videoDetails.text = videoDetails(record, available)
-                item.videoWatchButton.isEnabled = available
-                item.videoShareButton.isEnabled = available
-                item.root.isClickable = available
-                mediaState.second?.let { thumbnail ->
-                    item.videoThumbnail.setPadding(0, 0, 0, 0)
-                    item.videoThumbnail.setImageBitmap(thumbnail)
+                launch {
+                    var thumbnail: android.graphics.Bitmap? = null
+                    var applied = false
+                    try {
+                        val available = withContext(Dispatchers.IO) {
+                            videoMedia.isAvailable(uri).also { mediaAvailable ->
+                                if (mediaAvailable) {
+                                    thumbnail = runCatching { videoMedia.createThumbnail(uri) }.getOrNull()
+                                }
+                            }
+                        }
+                        if (item.root.tag != record.uri) return@launch
+                        item.videoDetails.text = videoDetails(record, available)
+                        item.videoWatchButton.isEnabled = available
+                        item.videoShareButton.isEnabled = available
+                        item.root.isClickable = available
+                        thumbnail?.let { bitmap ->
+                            item.videoThumbnail.setPadding(0, 0, 0, 0)
+                            item.videoThumbnail.setImageBitmap(bitmap)
+                        }
+                        applied = true
+                    } finally {
+                        if (!applied) thumbnail?.recycle()
+                    }
                 }
             }
         }
@@ -1877,14 +1905,14 @@ class MainActivity : AppCompatActivity() {
 
     private fun removeVideo(record: VideoRecord) {
         val uri = record.uri.toUri()
-        videoStore.remove(record.uri)
+        videoLibraryViewModel.remove(record)
         videoMedia.deleteThumbnail(uri)
         renderVideos()
         var restored = false
         Snackbar.make(binding.root, R.string.video_removed, Snackbar.LENGTH_LONG)
             .setAction(R.string.undo) {
                 restored = true
-                videoStore.upsert(record)
+                videoLibraryViewModel.upsert(record)
                 renderVideos()
             }
             .addCallback(object : Snackbar.Callback() {
@@ -1905,7 +1933,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun confirmDeleteAllVideos() {
-        val records = videoStore.list()
+        val records = videoLibraryViewModel.records.value
         if (records.isEmpty()) return
         MaterialAlertDialogBuilder(this)
             .setTitle(R.string.delete_all_videos_title)
@@ -1929,7 +1957,7 @@ class MainActivity : AppCompatActivity() {
                     removed
                 }
             }
-            videoStore.removeAll(deleted.mapTo(mutableSetOf(), VideoRecord::uri))
+            videoLibraryViewModel.removeAll(deleted)
             deleted.forEach { record ->
                 releaseUriAccess(record.uri.toUri())
                 if (lastVideoUri?.toString() == record.uri) lastVideoUri = null
@@ -1954,7 +1982,7 @@ class MainActivity : AppCompatActivity() {
             val uri = record.uri.toUri()
             val deleted = withContext(Dispatchers.IO) { videoMedia.delete(uri) }
             if (deleted) {
-                videoStore.remove(record.uri)
+                videoLibraryViewModel.remove(record)
                 videoMedia.deleteThumbnail(uri)
                 videoMedia.deleteOverview(uri)
                 releaseUriAccess(uri)
@@ -2075,18 +2103,18 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun acknowledgeCompletedExport(uri: Uri? = null) {
-        val snapshot = VideoExportCoordinator.state.value
+        val snapshot = videoExportViewModel.current
         if (
             snapshot.status == VideoExportStatus.COMPLETE &&
             (uri == null || snapshot.outputUri == uri.toString())
         ) {
-            VideoExportCoordinator.clear(applicationContext)
+            videoExportViewModel.clear()
         }
     }
 
     private fun chooseVideoCopyDestination(source: Uri) {
         pendingVideoCopyUri = source
-        val record = videoStore.list().firstOrNull { it.uri == source.toString() }
+        val record = videoLibraryViewModel.records.value.firstOrNull { it.uri == source.toString() }
         copyCompletedVideo.launch(record?.fileName ?: getString(R.string.default_video_filename))
     }
 
@@ -2111,7 +2139,7 @@ class MainActivity : AppCompatActivity() {
             return
         }
         val title = lastVideoTitle.orEmpty().ifBlank { getString(R.string.default_title) }
-        val periodSuffix = videoStore.list()
+        val periodSuffix = videoLibraryViewModel.records.value
             .firstOrNull { it.uri == videoUri.toString() }
             ?.let(::periodFileSuffix)
         val baseName = listOfNotNull(title, periodSuffix).joinToString("-")

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportViewModel.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportViewModel.kt
@@ -1,0 +1,42 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.StateFlow
+
+internal interface VideoExportStateGateway {
+    val state: StateFlow<VideoExportSnapshot>
+    fun restore()
+    fun publish(snapshot: VideoExportSnapshot)
+    fun clear()
+}
+
+private class CoordinatorVideoExportStateGateway(context: Context) : VideoExportStateGateway {
+    private val applicationContext = context.applicationContext
+
+    override val state: StateFlow<VideoExportSnapshot> = VideoExportCoordinator.state
+
+    override fun restore() = VideoExportCoordinator.restore(applicationContext)
+
+    override fun publish(snapshot: VideoExportSnapshot) =
+        VideoExportCoordinator.publish(applicationContext, snapshot)
+
+    override fun clear() = VideoExportCoordinator.clear(applicationContext)
+}
+
+class VideoExportViewModel internal constructor(
+    private val gateway: VideoExportStateGateway,
+) : ViewModel() {
+    constructor(context: Context) : this(CoordinatorVideoExportStateGateway(context))
+
+    val state: StateFlow<VideoExportSnapshot> = gateway.state
+    val current: VideoExportSnapshot get() = state.value
+
+    init {
+        gateway.restore()
+    }
+
+    fun publish(snapshot: VideoExportSnapshot) = gateway.publish(snapshot)
+
+    fun clear() = gateway.clear()
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModel.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModel.kt
@@ -1,0 +1,54 @@
+package dev.mahlernim.timelinevisualizer.ui
+
+import androidx.lifecycle.ViewModel
+import dev.mahlernim.timelinevisualizer.data.LocationFilterMode
+import dev.mahlernim.timelinevisualizer.render.CameraSettings
+import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class SettingsState(
+    val camera: CameraSettings,
+    val distanceUnit: DistanceUnitPreference,
+    val locationFilter: LocationFilterMode,
+)
+
+class SettingsViewModel(
+    private val cameraPreferences: CameraSettingsPreferences,
+    private val distanceUnitPreferences: DistanceUnitPreferences,
+    private val locationFilterPreferences: LocationFilterPreferences,
+) : ViewModel() {
+    private val mutableState = MutableStateFlow(
+        SettingsState(
+            camera = cameraPreferences.load(),
+            distanceUnit = distanceUnitPreferences.load(),
+            locationFilter = locationFilterPreferences.load(),
+        ),
+    )
+    val state: StateFlow<SettingsState> = mutableState.asStateFlow()
+
+    fun updateCamera(settings: CameraSettings) {
+        cameraPreferences.save(settings)
+        mutableState.value = mutableState.value.copy(camera = settings)
+    }
+
+    fun resetCameraAndDistance() {
+        val distanceUnit = DistanceUnitPreference.AUTOMATIC
+        distanceUnitPreferences.save(distanceUnit)
+        mutableState.value = mutableState.value.copy(
+            camera = cameraPreferences.reset(),
+            distanceUnit = distanceUnit,
+        )
+    }
+
+    fun updateDistanceUnit(preference: DistanceUnitPreference) {
+        distanceUnitPreferences.save(preference)
+        mutableState.value = mutableState.value.copy(distanceUnit = preference)
+    }
+
+    fun updateLocationFilter(mode: LocationFilterMode) {
+        locationFilterPreferences.save(mode)
+        mutableState.value = mutableState.value.copy(locationFilter = mode)
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/VideoLibraryViewModel.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/VideoLibraryViewModel.kt
@@ -1,0 +1,32 @@
+package dev.mahlernim.timelinevisualizer.videos
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class VideoLibraryViewModel(
+    private val repository: VideoRecordRepository,
+) : ViewModel() {
+    private val mutableRecords = MutableStateFlow(repository.list())
+    val records: StateFlow<List<VideoRecord>> = mutableRecords.asStateFlow()
+
+    fun refresh() {
+        mutableRecords.value = repository.list()
+    }
+
+    fun upsert(record: VideoRecord) {
+        repository.upsert(record)
+        refresh()
+    }
+
+    fun remove(record: VideoRecord) {
+        repository.remove(record.uri)
+        refresh()
+    }
+
+    fun removeAll(records: Collection<VideoRecord>) {
+        repository.removeAll(records.mapTo(mutableSetOf(), VideoRecord::uri))
+        refresh()
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/VideoStore.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/VideoStore.kt
@@ -17,26 +17,33 @@ data class VideoRecord(
     val endMonth: Int? = null,
 )
 
+interface VideoRecordRepository {
+    fun list(): List<VideoRecord>
+    fun upsert(record: VideoRecord)
+    fun remove(uri: String)
+    fun removeAll(uris: Set<String>)
+}
+
 /**
  * Stores video records using the original preference file and JSON schema.
  * The stable names are intentional so existing installs upgrade without migration.
  */
-class VideoStore(private val context: Context) {
+class VideoStore(private val context: Context) : VideoRecordRepository {
     private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
 
-    fun list(): List<VideoRecord> = decode(preferences.getString(KEY_RECORDS, null))
+    override fun list(): List<VideoRecord> = decode(preferences.getString(KEY_RECORDS, null))
         .sortedByDescending(VideoRecord::createdAtMillis)
 
-    fun upsert(record: VideoRecord) {
+    override fun upsert(record: VideoRecord) {
         save(buildList {
             add(record)
             addAll(list().filterNot { it.uri == record.uri })
         }.sortedByDescending(VideoRecord::createdAtMillis))
     }
 
-    fun remove(uri: String) = save(list().filterNot { it.uri == uri })
+    override fun remove(uri: String) = save(list().filterNot { it.uri == uri })
 
-    fun removeAll(uris: Set<String>) = save(list().filterNot { it.uri in uris })
+    override fun removeAll(uris: Set<String>) = save(list().filterNot { it.uri in uris })
 
     internal fun clear() {
         preferences.edit { remove(KEY_RECORDS) }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportViewModelTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportViewModelTest.kt
@@ -1,0 +1,39 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoExportViewModelTest {
+    @Test
+    fun restoresOnceAndDelegatesStateChanges() {
+        val gateway = FakeGateway()
+        val viewModel = VideoExportViewModel(gateway)
+        val running = VideoExportSnapshot(status = VideoExportStatus.RUNNING, title = "Trip")
+
+        assertEquals(1, gateway.restoreCount)
+        viewModel.publish(running)
+        assertEquals(running, viewModel.current)
+        viewModel.clear()
+        assertEquals(VideoExportSnapshot(), viewModel.current)
+    }
+
+    private class FakeGateway : VideoExportStateGateway {
+        private val mutableState = MutableStateFlow(VideoExportSnapshot())
+        override val state: StateFlow<VideoExportSnapshot> = mutableState
+        var restoreCount = 0
+
+        override fun restore() {
+            restoreCount += 1
+        }
+
+        override fun publish(snapshot: VideoExportSnapshot) {
+            mutableState.value = snapshot
+        }
+
+        override fun clear() {
+            mutableState.value = VideoExportSnapshot()
+        }
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModelTest.kt
@@ -1,0 +1,76 @@
+package dev.mahlernim.timelinevisualizer.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import dev.mahlernim.timelinevisualizer.data.LocationFilterMode
+import dev.mahlernim.timelinevisualizer.render.CameraMovement
+import dev.mahlernim.timelinevisualizer.render.CameraSettings
+import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
+import dev.mahlernim.timelinevisualizer.render.LongTripCompression
+import dev.mahlernim.timelinevisualizer.render.VideoQuality
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsViewModelTest {
+    private lateinit var cameraPreferences: CameraSettingsPreferences
+    private lateinit var distancePreferences: DistanceUnitPreferences
+    private lateinit var filterPreferences: LocationFilterPreferences
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        cameraPreferences = CameraSettingsPreferences(context)
+        distancePreferences = DistanceUnitPreferences(context)
+        filterPreferences = LocationFilterPreferences(context)
+        clearPreferences()
+    }
+
+    @After
+    fun tearDown() = clearPreferences()
+
+    @Test
+    fun updatesArePersistedAndExposedAsOneState() {
+        val viewModel = viewModel()
+        val camera = CameraSettings(
+            cameraMovement = CameraMovement.DYNAMIC,
+            longTripCompression = LongTripCompression.STRONG,
+            videoQuality = VideoQuality.PORTRAIT,
+        )
+
+        viewModel.updateCamera(camera)
+        viewModel.updateDistanceUnit(DistanceUnitPreference.MILES)
+        viewModel.updateLocationFilter(LocationFilterMode.OFF)
+
+        assertEquals(SettingsState(camera, DistanceUnitPreference.MILES, LocationFilterMode.OFF), viewModel.state.value)
+        assertEquals(camera, cameraPreferences.load())
+        assertEquals(DistanceUnitPreference.MILES, distancePreferences.load())
+        assertEquals(LocationFilterMode.OFF, filterPreferences.load())
+    }
+
+    @Test
+    fun resetPreservesLocationFilterWhileResettingCameraAndDistance() {
+        val viewModel = viewModel()
+        viewModel.updateCamera(CameraSettings.DEFAULT.copy(videoQuality = VideoQuality.ULTRA))
+        viewModel.updateDistanceUnit(DistanceUnitPreference.MILES)
+        viewModel.updateLocationFilter(LocationFilterMode.OFF)
+
+        viewModel.resetCameraAndDistance()
+
+        assertEquals(CameraSettings.DEFAULT, viewModel.state.value.camera)
+        assertEquals(DistanceUnitPreference.AUTOMATIC, viewModel.state.value.distanceUnit)
+        assertEquals(LocationFilterMode.OFF, viewModel.state.value.locationFilter)
+    }
+
+    private fun viewModel() = SettingsViewModel(cameraPreferences, distancePreferences, filterPreferences)
+
+    private fun clearPreferences() {
+        cameraPreferences.reset()
+        distancePreferences.clear()
+        filterPreferences.reset()
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModelTest.kt
@@ -14,8 +14,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
 class SettingsViewModelTest {
     private lateinit var cameraPreferences: CameraSettingsPreferences
     private lateinit var distancePreferences: DistanceUnitPreferences

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/VideoLibraryViewModelTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/VideoLibraryViewModelTest.kt
@@ -1,0 +1,51 @@
+package dev.mahlernim.timelinevisualizer.videos
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoLibraryViewModelTest {
+    @Test
+    fun mutationsRefreshThePublishedCreationList() {
+        val repository = FakeRepository()
+        val viewModel = VideoLibraryViewModel(repository)
+        val first = record("content://videos/first", 1L)
+        val second = record("content://videos/second", 2L)
+
+        viewModel.upsert(first)
+        viewModel.upsert(second)
+        assertEquals(listOf(second, first), viewModel.records.value)
+
+        viewModel.remove(second)
+        assertEquals(listOf(first), viewModel.records.value)
+
+        viewModel.removeAll(listOf(first))
+        assertEquals(emptyList<VideoRecord>(), viewModel.records.value)
+    }
+
+    private fun record(uri: String, createdAt: Long) = VideoRecord(
+        uri = uri,
+        title = uri.substringAfterLast('/'),
+        fileName = "video.mp4",
+        createdAtMillis = createdAt,
+        durationSeconds = 10,
+    )
+
+    private class FakeRepository : VideoRecordRepository {
+        private val records = mutableListOf<VideoRecord>()
+
+        override fun list(): List<VideoRecord> = records.sortedByDescending(VideoRecord::createdAtMillis)
+
+        override fun upsert(record: VideoRecord) {
+            records.removeAll { it.uri == record.uri }
+            records += record
+        }
+
+        override fun remove(uri: String) {
+            records.removeAll { it.uri == uri }
+        }
+
+        override fun removeAll(uris: Set<String>) {
+            records.removeAll { it.uri in uris }
+        }
+    }
+}

--- a/docs/release-notes-v2.2.10.md
+++ b/docs/release-notes-v2.2.10.md
@@ -1,0 +1,56 @@
+# Timeline Visualizer 2.2.10
+
+This maintenance release improves internal state handling for settings, video creation,
+and My videos while preserving the existing workflow. The desktop Python tool now
+detects missing input files and FFmpeg before rendering and reports Timeline parsing
+errors more clearly.
+
+## 한국어
+
+이번 유지 관리 업데이트에서는 기존 사용 흐름을 그대로 유지하면서 설정, 동영상 생성, 내 동영상의
+내부 상태 처리를 개선했습니다. 데스크톱 Python 도구는 렌더링 전에 입력 파일과 FFmpeg 누락을
+확인하고 Timeline 분석 오류를 더 명확하게 알려 줍니다.
+
+## 日本語
+
+このメンテナンス更新では、従来の操作手順を維持したまま、設定、動画作成、マイ動画の内部状態
+処理を改善しました。デスクトップ版 Python ツールは、レンダリング前に入力ファイルと FFmpeg
+の不足を確認し、Timeline の解析エラーをより明確に表示します。
+
+## 简体中文
+
+此维护版本在保留现有操作流程的同时，改进了设置、视频创建和“我的视频”的内部状态处理。
+桌面 Python 工具现在会在渲染前检查输入文件和 FFmpeg，并更清晰地报告 Timeline 解析错误。
+
+## 繁體中文
+
+此維護版本在保留現有操作流程的同時，改善了設定、影片建立和「我的影片」的內部狀態處理。
+桌面 Python 工具現在會在轉譯前檢查輸入檔案和 FFmpeg，並更清楚地回報 Timeline 解析錯誤。
+
+## Español
+
+Esta actualización de mantenimiento mejora la gestión interna del estado de los ajustes,
+la creación de vídeos y Mis vídeos sin cambiar el flujo de uso. La herramienta de Python
+para escritorio ahora comprueba el archivo de entrada y FFmpeg antes de renderizar y
+muestra con mayor claridad los errores de análisis de Timeline.
+
+## Français
+
+Cette mise à jour de maintenance améliore la gestion interne de l’état des réglages, de
+la création vidéo et de Mes vidéos sans modifier le parcours existant. L’outil Python
+pour ordinateur vérifie désormais le fichier d’entrée et FFmpeg avant le rendu et signale
+plus clairement les erreurs d’analyse de Timeline.
+
+## Deutsch
+
+Dieses Wartungsupdate verbessert die interne Statusverwaltung für Einstellungen,
+Videoerstellung und Meine Videos, ohne den bisherigen Ablauf zu ändern. Das Python-Tool
+für Desktop prüft nun vor dem Rendern die Eingabedatei und FFmpeg und meldet Fehler beim
+Einlesen der Timeline verständlicher.
+
+## Português (Brasil)
+
+Esta atualização de manutenção melhora o gerenciamento interno de estado das configurações,
+da criação de vídeos e de Meus vídeos sem alterar o fluxo existente. A ferramenta Python
+para desktop agora verifica o arquivo de entrada e o FFmpeg antes da renderização e informa
+com mais clareza os erros de leitura da Timeline.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.9` and version code `28`
+- Version name `2.2.10` and version code `29`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -18,8 +18,11 @@ def progress_at_distance(distance_at, target):
     return (low + high) / 2
 
 
-def test_cli_defaults_match_android():
-    args = build_argument_parser().parse_args(['--input', 'Timeline.json'])
+def test_cli_defaults_match_android(tmp_path):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_text('[]', encoding='utf-8')
+    args = build_argument_parser().parse_args(['--input', str(timeline)])
+    assert args.input == timeline
     assert args.camera_movement == 'steady'
     assert args.long_trip_compression == 'balanced'
 

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,111 @@
+import json
+
+import pytest
+
+import visualizer
+from visualizer import (
+    FfmpegUnavailableError,
+    NoDataFoundError,
+    TimelineParseError,
+    build_argument_parser,
+    ensure_ffmpeg_available,
+    parse_timeline,
+)
+
+
+def test_missing_input_is_rejected_by_argparse(tmp_path):
+    missing = tmp_path / 'missing.json'
+
+    with pytest.raises(SystemExit) as error:
+        build_argument_parser().parse_args(['--input', str(missing)])
+
+    assert error.value.code == 2
+
+
+def test_directory_input_is_rejected_by_argparse(tmp_path):
+    with pytest.raises(SystemExit) as error:
+        build_argument_parser().parse_args(['--input', str(tmp_path)])
+
+    assert error.value.code == 2
+
+
+def test_malformed_json_raises_typed_error(tmp_path):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_text('{not json', encoding='utf-8')
+
+    with pytest.raises(TimelineParseError) as error:
+        parse_timeline(timeline, 2026)
+
+    assert isinstance(error.value.__cause__, json.JSONDecodeError)
+
+
+def test_invalid_utf8_raises_typed_error(tmp_path):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_bytes(b'\xff\xfe')
+
+    with pytest.raises(TimelineParseError) as error:
+        parse_timeline(timeline, 2026)
+
+    assert isinstance(error.value.__cause__, UnicodeDecodeError)
+
+
+def test_missing_file_raises_typed_error_when_parser_is_called_directly(tmp_path):
+    with pytest.raises(TimelineParseError) as error:
+        parse_timeline(tmp_path / 'missing.json', 2026)
+
+    assert isinstance(error.value.__cause__, OSError)
+
+
+def test_no_matching_year_raises_no_data_error(tmp_path):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_text('[]', encoding='utf-8')
+
+    with pytest.raises(NoDataFoundError, match='2026'):
+        parse_timeline(timeline, 2026)
+
+
+def test_ffmpeg_availability_uses_matplotlib_configuration(monkeypatch):
+    monkeypatch.setattr(visualizer.animation.writers, 'is_available', lambda name: name == 'ffmpeg')
+
+    ensure_ffmpeg_available()
+
+
+def test_missing_ffmpeg_raises_typed_error(monkeypatch):
+    monkeypatch.setattr(visualizer.animation.writers, 'is_available', lambda _name: False)
+
+    with pytest.raises(FfmpegUnavailableError, match='ffmpeg is required'):
+        ensure_ffmpeg_available()
+
+
+def test_main_checks_ffmpeg_before_parsing(monkeypatch, tmp_path, capsys):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_text('[]', encoding='utf-8')
+    parsed = False
+
+    def fail_ffmpeg():
+        raise FfmpegUnavailableError('ffmpeg unavailable')
+
+    def mark_parsed(*_args):
+        nonlocal parsed
+        parsed = True
+
+    monkeypatch.setattr(visualizer, 'ensure_ffmpeg_available', fail_ffmpeg)
+    monkeypatch.setattr(visualizer, 'parse_timeline', mark_parsed)
+
+    assert visualizer.main(['--input', str(timeline)]) == 1
+    assert not parsed
+    assert 'ffmpeg unavailable' in capsys.readouterr().err
+
+
+def test_main_reports_typed_parse_failure(monkeypatch, tmp_path, capsys):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_text('[]', encoding='utf-8')
+    monkeypatch.setattr(visualizer, 'ensure_ffmpeg_available', lambda: None)
+    monkeypatch.setattr(
+        visualizer,
+        'parse_timeline',
+        lambda *_args: (_ for _ in ()).throw(NoDataFoundError('no matching points')),
+    )
+
+    assert visualizer.main(['--input', str(timeline)]) == 1
+    assert 'no matching points' in capsys.readouterr().err

--- a/visualizer.py
+++ b/visualizer.py
@@ -45,6 +45,22 @@ DEFAULT_TAIL_KM = 500
 THEME_COLOR = '#ff0055' # Pink/Red
 TILE_URL = "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
 
+
+class TimelineCliError(Exception):
+    """Base class for expected command-line failures."""
+
+
+class TimelineParseError(TimelineCliError):
+    """Raised when a Timeline export cannot be decoded."""
+
+
+class NoDataFoundError(TimelineCliError):
+    """Raised when an export contains no usable points for the requested year."""
+
+
+class FfmpegUnavailableError(TimelineCliError):
+    """Raised when Matplotlib cannot find a configured ffmpeg executable."""
+
 # Camera behavior matches the Android renderer defaults and options.
 CAMERA_MOVEMENTS = {
     'fixed': dict(context_fraction=0.10, minimum_context_km=25.0, maximum_context_km=350.0,
@@ -250,7 +266,10 @@ def tile_to_bounds_meters(xtile, ytile, zoom):
     min_y = max_y - tile_size
     return min_x, max_x, min_y, max_y
 
+# Rendering is a single short-lived process, so retaining decoded tiles avoids repeated downloads.
 TILE_CACHE = {}
+
+
 def fetch_tile_img(x, y, z):
     key = (x, y, z)
     if key in TILE_CACHE: return TILE_CACHE[key]
@@ -481,17 +500,15 @@ def parse_timeline(input_path, year):
     try:
         with open(input_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-    except Exception as e:
-        print(f"Error reading JSON: {e}")
-        sys.exit(1)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise TimelineParseError(f"Could not read Timeline JSON: {error}") from error
         
     segments = data if isinstance(data, list) else data.get('semanticSegments', []) if isinstance(data, dict) else []
     print(f"Parsing {len(segments)} segments for year {year}...")
     points = extract_timeline_points(data, year)
 
     if not points:
-        print(f"No data points found for year {year}.")
-        sys.exit(1)
+        raise NoDataFoundError(f"No data points found for year {year}.")
         
     print(f"Found {len(points)} valid points.")
     
@@ -609,9 +626,23 @@ def camera_at(track, progress):
     span = math.exp(math.log(before[2]) + (math.log(after[2]) - math.log(before[2])) * fraction)
     return center_x, center_y, span
 
+def existing_file(value):
+    path = Path(value)
+    if not path.is_file():
+        raise argparse.ArgumentTypeError(f"input file does not exist or is not a file: {value}")
+    return path
+
+
+def ensure_ffmpeg_available():
+    if not animation.writers.is_available('ffmpeg'):
+        raise FfmpegUnavailableError(
+            "ffmpeg is required to create MP4 video. Install ffmpeg or configure Matplotlib's animation.ffmpeg_path.",
+        )
+
+
 def build_argument_parser():
     parser = argparse.ArgumentParser(description="Google Timeline Visualizer")
-    parser.add_argument('--input', '-i', required=True, help="Path to Timeline.json")
+    parser.add_argument('--input', '-i', required=True, type=existing_file, help="Path to Timeline.json")
     parser.add_argument('--year', '-y', type=int, default=datetime.now().year, help="Year to visualize")
     parser.add_argument('--output', '-o', default='travel_history.mp4', help="Output video path")
     parser.add_argument('--title', '-t', default="My Trips", help="Title displayed on video")
@@ -622,13 +653,17 @@ def build_argument_parser():
     return parser
 
 
-def main():
+def main(argv=None):
     parser = build_argument_parser()
 
-    args = parser.parse_args()
-    
-    # Load
-    timestamps, xs, ys, cum_dist, lats, lons = parse_timeline(args.input, args.year)
+    args = parser.parse_args(argv)
+
+    try:
+        ensure_ffmpeg_available()
+        timestamps, xs, ys, cum_dist, lats, lons = parse_timeline(args.input, args.year)
+    except TimelineCliError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
     
     total_km = cum_dist[-1]
     print(f"Total distance: {total_km:.1f} km")
@@ -724,6 +759,7 @@ def main():
     print(f"Saving to {args.output}...")
     ani.save(args.output, writer='ffmpeg', fps=DEFAULT_FPS, dpi=100)
     print("Done!")
+    return 0
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- move settings, export state, and creation-list ownership behind lifecycle-aware ViewModels
- replace creation thumbnail generation counters with structured coroutine cancellation and retain row identity checks
- harden the desktop Python CLI with typed parse failures, input validation, and an early FFmpeg check
- prepare Android version 2.2.10 with version code 29 and localized release notes

Closes #121

## Compatibility and privacy

- preserves the v2.2.9 private Timeline cache and remembered-import recovery path
- preserves the v2.2.8 completed-export acknowledgment, watch, share, retry, and dismiss behavior
- retains Android 8 and later support and all existing storage schemas
- adds no network destinations and does not upload Timeline contents

## Validation

- Android full unit tests, lint, GitHub debug build, and Play debug build
- Android GitHub release APK and Play release bundle with R8
- Python 36 tests
- Web 42 tests, TypeScript build, and Vite production build
- local APK metadata verified as package dev.mahlernim.timelinevisualizer, version 2.2.10, code 29