### PR TITLE
Fix unstable video export ETA in v2.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.11
+
+- Wait for video-rendering throughput to stabilize before showing an estimated remaining time.
+- Calculate the estimate from recent journey-frame throughput instead of fixed whole-export phase weights.
+- Hide the estimate during map preparation, finishing, and materially unstable rendering speeds.
+- Use the same estimator for the in-app progress tray and foreground notification.
+- Set Android version code 30 and version name 2.2.11.
+
 ## 2.2.10
 
 - Move settings, video-export state, and the creations list behind lifecycle-aware ViewModels.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 29
-        versionName = "2.2.10"
+        versionCode = 30
+        versionName = "2.2.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.provider.Settings
 import android.text.InputType
 import android.util.Log
@@ -64,6 +65,7 @@ import dev.mahlernim.timelinevisualizer.databinding.ScreenPlayerBinding
 import dev.mahlernim.timelinevisualizer.databinding.ScreenSettingsBinding
 import dev.mahlernim.timelinevisualizer.databinding.ScreenVideosBinding
 import dev.mahlernim.timelinevisualizer.export.ExportProgress
+import dev.mahlernim.timelinevisualizer.export.ExportEtaEstimator
 import dev.mahlernim.timelinevisualizer.export.ExportPhase
 import dev.mahlernim.timelinevisualizer.export.VideoExportRequest
 import dev.mahlernim.timelinevisualizer.export.VideoExportRequestStore
@@ -185,6 +187,7 @@ class MainActivity : AppCompatActivity() {
     private var interruptedTimelineRecovered = false
     private var lastRenderedExportStatus = VideoExportStatus.IDLE
     private var lastAnnouncedExportPhase: ExportPhase? = null
+    private val exportEtaEstimator = ExportEtaEstimator()
     private var videoPlayer: ExoPlayer? = null
     private var playerUri: Uri? = null
     private var playerPositionMs = 0L
@@ -1546,9 +1549,10 @@ class MainActivity : AppCompatActivity() {
                 hideExportTray()
             }
             VideoExportStatus.RUNNING -> {
+                if (lastRenderedExportStatus != VideoExportStatus.RUNNING) exportEtaEstimator.reset()
                 setExporting(true)
                 showRunningExportTray()
-                snapshot.progress?.let { showExportProgress(it, snapshot.startedAtMillis) }
+                snapshot.progress?.let(::showExportProgress)
             }
             VideoExportStatus.COMPLETE -> {
                 setExporting(false)
@@ -1623,9 +1627,10 @@ class MainActivity : AppCompatActivity() {
     private fun hideExportTray() {
         binding.exportStatusTray.visibility = View.GONE
         lastAnnouncedExportPhase = null
+        exportEtaEstimator.reset()
     }
 
-    private fun showExportProgress(progress: ExportProgress, startedAtMillis: Long) {
+    private fun showExportProgress(progress: ExportProgress) {
         binding.exportTrayProgress.progress = (progress.fraction * 1000).toInt()
         if (progress.phase == ExportPhase.COMPLETE) return
         val base = when (progress.phase) {
@@ -1644,10 +1649,10 @@ class MainActivity : AppCompatActivity() {
             )
             ExportPhase.COMPLETE -> return
         }
-        val elapsedMs = (System.currentTimeMillis() - startedAtMillis).coerceAtLeast(0L)
-        val remaining = if (elapsedMs >= 3_000 && progress.fraction in 0.05f..0.98f) {
-            ceil(elapsedMs / 1000.0 * (1.0 - progress.fraction) / progress.fraction).toInt()
-        } else null
+        val remaining = exportEtaEstimator.estimateRemainingSeconds(
+            progress,
+            SystemClock.elapsedRealtime(),
+        )
         val status = if (remaining != null) {
             getString(R.string.progress_with_eta, base, formatRemainingTime(remaining))
         } else base

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/ExportEtaEstimator.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/ExportEtaEstimator.kt
@@ -1,0 +1,102 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import java.util.ArrayDeque
+import kotlin.math.abs
+import kotlin.math.ceil
+
+internal class ExportEtaEstimator(
+    private val minimumObservationMillis: Long = 8_000L,
+    private val minimumSamples: Int = 5,
+    private val sampleWindowSize: Int = 6,
+    private val stabilityTolerance: Double = 0.15,
+) {
+    private data class Sample(
+        val elapsedMillis: Long,
+        val completed: Int,
+    )
+
+    private val samples = ArrayDeque<Sample>()
+    private var phaseStartedAtMillis: Long? = null
+    private var phaseTotal: Int? = null
+    private var lastEstimateSeconds: Int? = null
+
+    fun estimateRemainingSeconds(progress: ExportProgress, elapsedMillis: Long): Int? {
+        if (
+            progress.phase != ExportPhase.CREATING_VIDEO ||
+            progress.total <= 0 ||
+            progress.completed <= 0 ||
+            progress.completed >= progress.total
+        ) {
+            reset()
+            return null
+        }
+
+        val previous = samples.peekLast()
+        if (
+            phaseTotal != null && phaseTotal != progress.total ||
+            previous != null && (
+                elapsedMillis < previous.elapsedMillis ||
+                    progress.completed < previous.completed
+                )
+        ) {
+            reset()
+        }
+
+        if (phaseStartedAtMillis == null) {
+            phaseStartedAtMillis = elapsedMillis
+            phaseTotal = progress.total
+        }
+
+        val currentPrevious = samples.peekLast()
+        if (currentPrevious?.completed == progress.completed) return lastEstimateSeconds
+
+        samples.addLast(Sample(elapsedMillis, progress.completed))
+        while (samples.size > sampleWindowSize) samples.removeFirst()
+
+        val observedMillis = elapsedMillis - (phaseStartedAtMillis ?: elapsedMillis)
+        if (observedMillis < minimumObservationMillis || samples.size < minimumSamples) {
+            lastEstimateSeconds = null
+            return null
+        }
+
+        val rates = samples.zipWithNext { first, second ->
+            val duration = second.elapsedMillis - first.elapsedMillis
+            val completed = second.completed - first.completed
+            if (duration <= 0L || completed <= 0) null else completed.toDouble() / duration
+        }
+        if (rates.any { it == null }) {
+            lastEstimateSeconds = null
+            return null
+        }
+
+        val measuredRates = rates.filterNotNull()
+        val medianRate = measuredRates.sorted()[measuredRates.size / 2]
+        val stable = medianRate > 0.0 && measuredRates.all { rate ->
+            abs(rate - medianRate) / medianRate <= stabilityTolerance
+        }
+        if (!stable) {
+            lastEstimateSeconds = null
+            return null
+        }
+
+        val first = requireNotNull(samples.peekFirst())
+        val last = requireNotNull(samples.peekLast())
+        val windowMillis = last.elapsedMillis - first.elapsedMillis
+        val windowCompleted = last.completed - first.completed
+        if (windowMillis <= 0L || windowCompleted <= 0) return null
+
+        val framesPerMillis = windowCompleted.toDouble() / windowMillis
+        val remainingFrames = progress.total - progress.completed
+        return ceil(remainingFrames / framesPerMillis / 1_000.0)
+            .toInt()
+            .coerceAtLeast(1)
+            .also { lastEstimateSeconds = it }
+    }
+
+    fun reset() {
+        samples.clear()
+        phaseStartedAtMillis = null
+        phaseTotal = null
+        lastEstimateSeconds = null
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
@@ -43,6 +43,7 @@ class VideoExportService : Service() {
     private var exportJob: Job? = null
     private var lastNotificationAt = 0L
     private var lastNotificationPhase: ExportPhase? = null
+    private val etaEstimator = ExportEtaEstimator()
 
     override fun onCreate() {
         super.onCreate()
@@ -91,7 +92,7 @@ class VideoExportService : Service() {
     private suspend fun runExport(request: VideoExportRequest, startId: Int) {
         val uri = request.outputUri.toUri()
         val startedAtMillis = System.currentTimeMillis()
-        val startedAtElapsed = SystemClock.elapsedRealtime()
+        etaEstimator.reset()
         publish(
             VideoExportSnapshot(
                 status = VideoExportStatus.RUNNING,
@@ -126,7 +127,7 @@ class VideoExportService : Service() {
                     lastNotificationPhase = progress.phase
                     notificationManager.notify(
                         NOTIFICATION_ID,
-                        buildProgressNotification(snapshot, startedAtElapsed),
+                        buildProgressNotification(snapshot),
                     )
                 }
             }
@@ -273,9 +274,9 @@ class VideoExportService : Service() {
         .addAction(0, getString(R.string.cancel), cancelPendingIntent())
         .build()
 
-    private fun buildProgressNotification(snapshot: VideoExportSnapshot, startedAtElapsed: Long): Notification {
+    private fun buildProgressNotification(snapshot: VideoExportSnapshot): Notification {
         val progress = snapshot.progress ?: return buildStartingNotification()
-        val text = progressText(progress, startedAtElapsed)
+        val text = progressText(progress)
         return notificationBuilder()
             .setContentTitle(getString(R.string.creating_video_notification_title))
             .setContentText(text)
@@ -329,7 +330,7 @@ class VideoExportService : Service() {
         .setPriority(NotificationCompat.PRIORITY_LOW)
         .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 
-    private fun progressText(progress: ExportProgress, startedAtElapsed: Long): String {
+    private fun progressText(progress: ExportProgress): String {
         val base = when (progress.phase) {
             ExportPhase.PREPARING_MAP -> getString(
                 R.string.preparing_map_progress,
@@ -346,10 +347,7 @@ class VideoExportService : Service() {
             )
             ExportPhase.COMPLETE -> getString(R.string.video_saved)
         }
-        val elapsedMs = SystemClock.elapsedRealtime() - startedAtElapsed
-        val remaining = if (elapsedMs >= 3_000 && progress.fraction in 0.05f..0.98f) {
-            ceil(elapsedMs / 1000.0 * (1.0 - progress.fraction) / progress.fraction).toInt()
-        } else null
+        val remaining = etaEstimator.estimateRemainingSeconds(progress, SystemClock.elapsedRealtime())
         return if (remaining == null) base else getString(
             R.string.progress_with_eta,
             base,

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/ExportEtaEstimatorTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/ExportEtaEstimatorTest.kt
@@ -1,0 +1,89 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ExportEtaEstimatorTest {
+    @Test
+    fun withholdsEstimateUntilCreatingVideoSpeedIsStable() {
+        val estimator = ExportEtaEstimator()
+
+        assertNull(estimator.estimateRemainingSeconds(progress(1), 0L))
+        assertNull(estimator.estimateRemainingSeconds(progress(25), 1_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(37), 2_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(61), 3_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(73), 4_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(97), 8_000L))
+
+        assertNull(estimator.estimateRemainingSeconds(progress(121), 9_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(145), 10_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(169), 11_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(193), 12_000L))
+        assertEquals(33, estimator.estimateRemainingSeconds(progress(217), 13_000L))
+    }
+
+    @Test
+    fun stableEstimateCountsDownFromRecentFrameThroughput() {
+        val estimator = ExportEtaEstimator()
+
+        (0..8).forEach { second ->
+            estimator.estimateRemainingSeconds(progress(1 + second * 24), second * 1_000L)
+        }
+
+        assertEquals(33, estimator.estimateRemainingSeconds(progress(217), 9_000L))
+        assertEquals(32, estimator.estimateRemainingSeconds(progress(241), 10_000L))
+        assertEquals(31, estimator.estimateRemainingSeconds(progress(265), 11_000L))
+    }
+
+    @Test
+    fun hidesEstimateAgainWhenRecentSpeedChangesMaterially() {
+        val estimator = ExportEtaEstimator()
+        (0..9).forEach { second ->
+            estimator.estimateRemainingSeconds(progress(1 + second * 24), second * 1_000L)
+        }
+
+        assertEquals(33, estimator.estimateRemainingSeconds(progress(217), 9_000L))
+        assertNull(estimator.estimateRemainingSeconds(progress(229), 10_000L))
+    }
+
+    @Test
+    fun ignoresPreparationAndFinishingPhases() {
+        val estimator = ExportEtaEstimator(
+            minimumObservationMillis = 0L,
+            minimumSamples = 2,
+            sampleWindowSize = 2,
+        )
+
+        assertNull(
+            estimator.estimateRemainingSeconds(
+                ExportProgress(0.05f, ExportPhase.PREPARING_MAP, 5, 10),
+                0L,
+            ),
+        )
+        assertNull(
+            estimator.estimateRemainingSeconds(
+                ExportProgress(0.95f, ExportPhase.FINISHING_VIDEO, 12, 36),
+                1_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun resetsWhenASecondExportStarts() {
+        val estimator = ExportEtaEstimator()
+        (0..9).forEach { second ->
+            estimator.estimateRemainingSeconds(progress(1 + second * 24), second * 1_000L)
+        }
+        assertEquals(33, estimator.estimateRemainingSeconds(progress(217), 9_000L))
+
+        assertNull(estimator.estimateRemainingSeconds(progress(1), 10_000L))
+    }
+
+    private fun progress(completed: Int, total: Int = 1_000) = ExportProgress(
+        fraction = 0.10f + 0.80f * completed / total,
+        phase = ExportPhase.CREATING_VIDEO,
+        completed = completed,
+        total = total,
+    )
+}

--- a/docs/release-notes-v2.2.11.md
+++ b/docs/release-notes-v2.2.11.md
@@ -1,0 +1,49 @@
+# Timeline Visualizer 2.2.11
+
+This update waits for video-rendering speed to stabilize before showing the estimated
+remaining time. The estimate now uses recent rendering performance and stays hidden
+during preparation, finishing, or unstable processing.
+
+## 한국어
+
+이번 업데이트에서는 동영상 렌더링 속도가 안정된 후에만 예상 남은 시간을 표시합니다. 이제 최근
+렌더링 성능을 기준으로 시간을 계산하며 준비, 마무리 또는 처리 속도가 불안정할 때는 표시하지 않습니다.
+
+## 日本語
+
+このアップデートでは、動画のレンダリング速度が安定してから推定残り時間を表示します。直近の
+レンダリング性能を基準に計算し、準備中、仕上げ中、または処理速度が不安定な間は表示しません。
+
+## 简体中文
+
+此更新会在视频渲染速度稳定后才显示预计剩余时间。估算现在基于近期渲染性能，并会在准备、
+收尾或处理速度不稳定时保持隐藏。
+
+## 繁體中文
+
+此更新會在影片轉譯速度穩定後才顯示預估剩餘時間。估算現在依據近期轉譯效能，並會在準備、
+收尾或處理速度不穩定時保持隱藏。
+
+## Español
+
+Esta actualización espera a que la velocidad de renderizado se estabilice antes de
+mostrar el tiempo restante estimado. La estimación usa el rendimiento reciente y se
+oculta durante la preparación, la finalización o un procesamiento inestable.
+
+## Français
+
+Cette mise à jour attend que la vitesse de rendu vidéo se stabilise avant d’afficher
+le temps restant estimé. L’estimation utilise les performances récentes et reste
+masquée pendant la préparation, la finalisation ou un traitement instable.
+
+## Deutsch
+
+Dieses Update zeigt die geschätzte Restzeit erst an, wenn sich die
+Video-Rendergeschwindigkeit stabilisiert hat. Die Schätzung basiert auf der aktuellen
+Renderleistung und bleibt während Vorbereitung, Abschluss oder instabiler Verarbeitung ausgeblendet.
+
+## Português (Brasil)
+
+Esta atualização aguarda a estabilização da velocidade de renderização antes de mostrar
+o tempo restante estimado. A estimativa usa o desempenho recente e fica oculta durante
+a preparação, a finalização ou quando o processamento está instável.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.10` and version code `29`
+- Version name `2.2.11` and version code `30`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- wait for journey-frame rendering throughput to stabilize before showing remaining time
- estimate from recent phase-specific throughput instead of fixed whole-export weights
- hide ETA during preparation, finishing, and materially unstable speeds
- share the estimator between the in-app tray and foreground notification
- prepare Android version 2.2.11 with version code 30

## Validation

- Android `test lint assembleGithubDebug`
- 400 Android unit tests passed across both product flavors
- 36 Python tests passed
- 264 web tests passed
- TypeScript check and production web build passed
- `git diff --check`

Fixes #124