### PR TITLE
Fix incomplete map tiles in high-resolution videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.2.12
+
+- Render every map tile intersecting portrait and landscape export frames instead of truncating the visible tile grid.
+- Preserve complete right-side and lower-edge map coverage during preview, video rendering, and overview generation.
+- Add regression coverage for high-resolution portrait and landscape tile grids that require more than 36 tiles.
+- Set Android version code 31 and version name 2.2.12.
+
 ## 2.2.11
 
 - Wait for video-rendering throughput to stabilize before showing an estimated remaining time.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 30
-        versionName = "2.2.11"
+        versionCode = 31
+        versionName = "2.2.12"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -558,7 +558,7 @@ class TimelinePainter {
                 val normalizedX = ((worldX % count) + count) % count
                 for (y in yMin..yMax) add(VisibleTile(TileId(viewport.zoom, normalizedX, y), worldX))
             }
-        }.take(36)
+        }
     }
 
     fun draw(

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
@@ -169,6 +169,32 @@ class TimelinePainterTest {
     }
 
     @Test
+    fun highResolutionExportShapesIncludeEveryIntersectingMapTile() {
+        val painter = TimelinePainter()
+        val cases = listOf(
+            "portrait" to tileViewport(width = 1080, height = 1920),
+            "landscape" to tileViewport(width = 1920, height = 1080),
+        )
+
+        cases.forEach { (name, viewport) ->
+            val xMin = kotlin.math.floor(viewport.minX * TILE_COUNT).toInt()
+            val xMax = kotlin.math.floor(viewport.maxX * TILE_COUNT).toInt()
+            val yMin = kotlin.math.floor(viewport.minY * TILE_COUNT).toInt()
+            val yMax = kotlin.math.floor(viewport.maxY * TILE_COUNT).toInt()
+            val expected = buildList {
+                for (worldX in xMin..xMax) {
+                    for (y in yMin..yMax) {
+                        add(VisibleTile(TileId(TILE_ZOOM, worldX, y), worldX))
+                    }
+                }
+            }
+
+            assertTrue("The $name case must exercise more than the old 36-tile limit", expected.size > 36)
+            assertEquals("The $name frame omitted visible map tiles", expected, painter.requiredTiles(viewport))
+        }
+    }
+
+    @Test
     fun indexedCameraBoundsMatchThePreviousRouteScan() {
         val routes = listOf(
             List(2_000) { index ->
@@ -258,6 +284,18 @@ class TimelinePainterTest {
         longitude,
     )
 
+    private fun tileViewport(width: Int, height: Int): Viewport {
+        val minTileX = 10.9
+        val minTileY = 20.9
+        return Viewport(
+            minX = minTileX / TILE_COUNT,
+            maxX = (minTileX + width / 256.0) / TILE_COUNT,
+            minY = minTileY / TILE_COUNT,
+            maxY = (minTileY + height / 256.0) / TILE_COUNT,
+            zoom = TILE_ZOOM,
+        )
+    }
+
     private fun unwrapNear(value: Double, reference: Double): Double {
         var result = value
         while (result - reference > 0.5) result -= 1.0
@@ -284,5 +322,7 @@ class TimelinePainterTest {
 
     companion object {
         private const val SIZE = 360
+        private const val TILE_ZOOM = 7
+        private const val TILE_COUNT = 1 shl TILE_ZOOM
     }
 }

--- a/docs/release-notes-v2.2.12.md
+++ b/docs/release-notes-v2.2.12.md
@@ -1,0 +1,49 @@
+# Timeline Visualizer 2.2.12
+
+This update keeps the map fully visible across high-resolution portrait and landscape
+videos. Tiles along the right side and lower edge are now prepared and rendered instead
+of leaving grey areas in the exported video.
+
+## 한국어
+
+이번 업데이트에서는 고해상도 세로 및 가로 동영상에서 지도가 끝까지 표시됩니다. 이제 오른쪽과
+아래쪽 가장자리의 지도 타일도 준비하고 렌더링하여 내보낸 동영상에 회색 영역이 남지 않습니다.
+
+## 日本語
+
+このアップデートでは、高解像度の縦向きおよび横向き動画で地図全体が表示されます。右端と
+下端の地図タイルも準備して描画し、書き出した動画に灰色の領域が残らないようにしました。
+
+## 简体中文
+
+此更新可在高分辨率竖屏和横屏视频中完整显示地图。现在会准备并渲染右侧和底部边缘的地图
+图块，避免导出的视频中出现灰色区域。
+
+## 繁體中文
+
+此更新可在高解析度直向和橫向影片中完整顯示地圖。現在會準備並轉譯右側和底部邊緣的地圖
+圖磚，避免匯出的影片中出現灰色區域。
+
+## Español
+
+Esta actualización mantiene el mapa completo en los vídeos verticales y horizontales
+de alta resolución. Los mosaicos de los bordes derecho e inferior ahora se preparan y
+renderizan para evitar zonas grises en el vídeo exportado.
+
+## Français
+
+Cette mise à jour affiche la carte entière dans les vidéos haute résolution en mode
+portrait et paysage. Les tuiles des bords droit et inférieur sont désormais préparées
+et rendues afin d’éviter les zones grises dans la vidéo exportée.
+
+## Deutsch
+
+Dieses Update zeigt die Karte in hochauflösenden Videos im Hoch- und Querformat
+vollständig an. Die Kartenkacheln am rechten und unteren Rand werden nun vorbereitet
+und gerendert, damit im exportierten Video keine grauen Bereiche bleiben.
+
+## Português (Brasil)
+
+Esta atualização mantém o mapa completo em vídeos de alta resolução nos formatos
+retrato e paisagem. Os blocos das bordas direita e inferior agora são preparados e
+renderizados para evitar áreas cinzas no vídeo exportado.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.11` and version code `30`
+- Version name `2.2.12` and version code `31`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- remove the fixed 36-tile rendering cap that truncated high-resolution export frames
- cover every intersecting map tile in portrait and landscape videos
- add regression coverage for 54-tile portrait and landscape grids
- prepare Android v2.2.12 release metadata and localized notes

## Root cause

Tile enumeration runs from left to right and top to bottom, then previously kept only the first 36 tiles. A 1080 by 1920 portrait frame can need 54 tiles, so the rightmost columns and sometimes the lower part of the final retained column were never prepared or drawn.

## Validation

- `git diff --check`
- regression test added for 1080 by 1920 and 1920 by 1080 tile grids
- local Gradle execution unavailable because the current machine has no JDK
- GitHub Actions is the required build, unit-test, lint, signing, and artifact gate

Closes #125
