### PR TITLE
Fix: dismiss video export notification when acknowledging in-app tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.13
+
+- Fix issue where the video-generation notification remained visible in the system tray after the user clicked Done in the app.
+
 ## 2.2.12
 
 - Render every map tile intersecting portrait and landscape export frames instead of truncating the visible tile grid.

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
@@ -437,5 +437,9 @@ class VideoExportService : Service() {
                 start(context)
             }
         }
+
+        fun clearNotification(context: Context) {
+            context.getSystemService(NotificationManager::class.java)?.cancel(NOTIFICATION_ID)
+        }
     }
 }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportState.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportState.kt
@@ -104,6 +104,7 @@ object VideoExportCoordinator {
     fun clear(context: Context) {
         VideoExportStateStore(context.applicationContext).clear()
         mutableState.value = VideoExportSnapshot()
+        VideoExportService.clearNotification(context)
     }
 
     internal fun resetForTest() {


### PR DESCRIPTION
Summary
Resolves #131
Fixes an issue where the completed video export system notification remains in the notification drawer after the user clicks "Done" in the in-app export tray.

Changes
- Add `clearNotification` function to `VideoExportService` companion object to explicitly cancel the export foreground service notification.
- Update `VideoExportCoordinator.clear` to call `VideoExportService.clearNotification`, ensuring the system notification is dismissed alongside the internal state cleanup.
Testing
- Initiated a video export using mock data and waited for it to complete.
- Verified the "Video Ready" system notification appeared.
- Clicked "Done" in the app's bottom export tray.
- Verified the system notification is immediately removed from the drawer.
- Verified on an Infinix Hot 60i (Android 15).
