### PR TITLE
Prepare Android release v2.2.13

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 31
-        versionName = "2.2.12"
+        versionCode = 32
+        versionName = "2.2.13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/docs/release-notes-v2.2.13.md
+++ b/docs/release-notes-v2.2.13.md
@@ -1,0 +1,48 @@
+# Timeline Visualizer 2.2.13
+
+This update dismisses the completed video export notification when you acknowledge the
+result in the app, keeping the notification drawer in sync with the in-app export tray.
+
+## 한국어
+
+이번 업데이트에서는 앱에서 완료된 동영상 내보내기 결과를 확인하면 알림도 사라져, 시스템 알림
+창과 앱 내 내보내기 상태 표시가 일치합니다.
+
+## 日本語
+
+このアップデートでは、アプリで動画の書き出し完了を確認すると通知も消え、システムの通知
+ドロワーとアプリ内の書き出し状態が一致します。
+
+## 简体中文
+
+此更新会在您于应用中确认视频导出完成后关闭相应通知，使系统通知栏与应用内导出状态保持
+一致。
+
+## 繁體中文
+
+此更新會在您於應用程式中確認影片匯出完成後關閉相應通知，使系統通知欄與應用程式內的匯出
+狀態保持一致。
+
+## Español
+
+Esta actualización descarta la notificación de exportación de vídeo completada cuando
+confirmas el resultado en la aplicación, manteniendo sincronizados el panel de
+notificaciones y el estado de exportación de la aplicación.
+
+## Français
+
+Cette mise à jour ferme la notification d’exportation vidéo terminée lorsque vous
+confirmez le résultat dans l’application, afin que le volet des notifications et l’état
+d’exportation dans l’application restent synchronisés.
+
+## Deutsch
+
+Dieses Update entfernt die Benachrichtigung über den abgeschlossenen Videoexport,
+sobald Sie das Ergebnis in der App bestätigen. Dadurch bleiben die Systemmeldungen und
+der Exportstatus in der App synchron.
+
+## Português (Brasil)
+
+Esta atualização dispensa a notificação de exportação de vídeo concluída quando você
+confirma o resultado no aplicativo, mantendo o painel de notificações sincronizado com
+o status de exportação no aplicativo.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.2.12` and version code `31`
+- Version name `2.2.13` and version code `32`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary
- set Android version name to 2.2.13 and version code to 32
- add localized GitHub release notes for the notification dismissal fix
- update the Play submission checklist to the new build metadata

## Validation
- python -m pytest -q
- gradlew test lint assembleGithubDebug assemblePlayDebug --stacktrace
- git diff --check

Follow-up release metadata for #132 and #131.