### PR TITLE
Fix completed export notifications for v2.3.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 34
-        versionName = "2.3.1"
+        versionCode = 35
+        versionName = "2.3.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -386,6 +386,11 @@ class MainActivity : AppCompatActivity() {
         val incoming = intent?.data
         if (intent?.action == ACTION_WATCH_VIDEO && incoming != null) {
             if (savedInstanceState == null) watchVideo(incoming) else showVideoPlayer(incoming, resetPosition = false)
+            VideoExportService.clearNotification(applicationContext)
+        } else if (intent?.action == ACTION_SHARE_VIDEO && incoming != null) {
+            showVideos()
+            if (savedInstanceState == null) shareVideo(incoming)
+            VideoExportService.clearNotification(applicationContext)
         } else if (incoming != null && PresetLink.isPresetLink(incoming.toString())) {
             showNewVideo(loadRemembered = true)
             if (savedInstanceState == null) showIncomingPreset(incoming)
@@ -432,13 +437,23 @@ class MainActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         intent.data?.let { uri ->
-            if (intent.action == ACTION_WATCH_VIDEO) watchVideo(uri)
-            else if (PresetLink.isPresetLink(uri.toString())) {
-                showNewVideo(loadRemembered = true)
-                showIncomingPreset(uri)
-            } else {
-                showNewVideo(loadRemembered = false)
-                requestTimelineImport(uri)
+            when (intent.action) {
+                ACTION_WATCH_VIDEO -> {
+                    watchVideo(uri)
+                    VideoExportService.clearNotification(applicationContext)
+                }
+                ACTION_SHARE_VIDEO -> {
+                    showVideos()
+                    shareVideo(uri)
+                    VideoExportService.clearNotification(applicationContext)
+                }
+                else -> if (PresetLink.isPresetLink(uri.toString())) {
+                    showNewVideo(loadRemembered = true)
+                    showIncomingPreset(uri)
+                } else {
+                    showNewVideo(loadRemembered = false)
+                    requestTimelineImport(uri)
+                }
             }
         }
     }
@@ -2650,6 +2665,7 @@ class MainActivity : AppCompatActivity() {
         private const val STATE_DRAFT_LOCAL_FRAMING = "draft_local_framing_v1"
         private const val STATE_ACTIVE_PRESET_ID = "active_preset_id_v1"
         internal const val ACTION_WATCH_VIDEO = "dev.mahlernim.timelinevisualizer.action.WATCH_VIDEO"
+        internal const val ACTION_SHARE_VIDEO = "dev.mahlernim.timelinevisualizer.action.SHARE_VIDEO"
         private const val PROJECT_URL = "https://github.com/mahlernim/google-timeline-visualizer"
         private const val PRIVACY_URL =
             "https://github.com/mahlernim/google-timeline-visualizer/blob/main/docs/privacy.md"
@@ -2670,7 +2686,23 @@ class MainActivity : AppCompatActivity() {
                 action = ACTION_WATCH_VIDEO
                 data = uri
                 clipData = ClipData.newRawUri(context.getString(R.string.timeline_video), uri)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                addFlags(
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP,
+                )
+            }
+
+        internal fun shareIntent(context: Context, uri: Uri): Intent =
+            Intent(context, MainActivity::class.java).apply {
+                action = ACTION_SHARE_VIDEO
+                data = uri
+                clipData = ClipData.newRawUri(context.getString(R.string.timeline_video), uri)
+                addFlags(
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP,
+                )
             }
 
         internal fun restoreGuideUrl(language: String?): String = when (language) {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportService.kt
@@ -5,7 +5,6 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
-import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
@@ -50,7 +49,7 @@ class VideoExportService : Service() {
         notificationManager = getSystemService(NotificationManager::class.java)
         requestStore = VideoExportRequestStore(applicationContext)
         VideoExportCoordinator.restore(applicationContext)
-        createNotificationChannel()
+        createNotificationChannels()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -288,15 +287,10 @@ class VideoExportService : Service() {
             .build()
     }
 
-    private fun buildCompletedNotification(uri: Uri, title: String): Notification {
+    internal fun buildCompletedNotification(uri: Uri, title: String): Notification {
         val watch = MainActivity.playbackIntent(this, uri)
-        val share = Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
-            type = "video/mp4"
-            putExtra(Intent.EXTRA_STREAM, uri)
-            clipData = ClipData.newRawUri(getString(R.string.timeline_video), uri)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }, getString(R.string.share_travel_video))
-        return notificationBuilder()
+        val share = MainActivity.shareIntent(this, uri)
+        return completionNotificationBuilder()
             .setContentTitle(getString(R.string.video_ready))
             .setContentText(title)
             .setAutoCancel(true)
@@ -329,6 +323,14 @@ class VideoExportService : Service() {
         .setCategory(NotificationCompat.CATEGORY_PROGRESS)
         .setPriority(NotificationCompat.PRIORITY_LOW)
         .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+
+    private fun completionNotificationBuilder(): NotificationCompat.Builder =
+        NotificationCompat.Builder(this, COMPLETION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentIntent(openAppPendingIntent())
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 
     private fun progressText(progress: ExportProgress): String {
         val base = when (progress.phase) {
@@ -387,17 +389,26 @@ class VideoExportService : Service() {
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
     )
 
-    private fun createNotificationChannel() {
+    private fun createNotificationChannels() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        notificationManager.createNotificationChannel(
-            NotificationChannel(
-                CHANNEL_ID,
-                getString(R.string.video_creation_notification_channel),
-                NotificationManager.IMPORTANCE_LOW,
-            ).apply {
-                description = getString(R.string.video_creation_notification_channel_description)
-                setShowBadge(false)
-            },
+        notificationManager.createNotificationChannels(
+            listOf(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    getString(R.string.video_creation_notification_channel),
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description = getString(R.string.video_creation_notification_channel_description)
+                    setShowBadge(false)
+                },
+                NotificationChannel(
+                    COMPLETION_CHANNEL_ID,
+                    getString(R.string.video_completion_notification_channel),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply {
+                    description = getString(R.string.video_completion_notification_channel_description)
+                },
+            ),
         )
     }
 
@@ -405,7 +416,8 @@ class VideoExportService : Service() {
         private const val ACTION_START = "dev.mahlernim.timelinevisualizer.action.START_EXPORT"
         private const val ACTION_CANCEL = "dev.mahlernim.timelinevisualizer.action.CANCEL_EXPORT"
         private const val CHANNEL_ID = "video_creation"
-        private const val NOTIFICATION_ID = 4102
+        private const val COMPLETION_CHANNEL_ID = "video_completion"
+        internal const val NOTIFICATION_ID = 4102
         private const val NOTIFICATION_UPDATE_INTERVAL_MS = 500L
         private const val OPEN_APP_REQUEST_CODE = 4103
         private const val CANCEL_REQUEST_CODE = 4104

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -65,7 +65,9 @@
     <string name="creating_video_notification_title">Erstellen Sie Ihr timeline-Video</string>
     <string name="starting_video_creation">Videoerstellung beginnt…</string>
     <string name="video_creation_notification_channel">Videoerstellung</string>
-    <string name="video_creation_notification_channel_description">Fortschritts- und Abschlusswarnungen für timeline-Videos</string>
+    <string name="video_creation_notification_channel_description">Fortschrittsmeldungen für Timeline-Videos</string>
+    <string name="video_completion_notification_channel">Videofertigstellung</string>
+    <string name="video_completion_notification_channel_description">Benachrichtigungen, wenn Timeline-Videos fertig sind</string>
     <string name="no_video_player">Für die Wiedergabe dieses Videos ist keine App verfügbar</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -66,7 +66,9 @@
     <string name="creating_video_notification_title">Creando tu vídeo timeline</string>
     <string name="starting_video_creation">Iniciando la creación de vídeo...</string>
     <string name="video_creation_notification_channel">Creación de vídeos</string>
-    <string name="video_creation_notification_channel_description">Alertas de progreso y finalización de videos timeline</string>
+    <string name="video_creation_notification_channel_description">Actualizaciones del progreso de los vídeos de la cronología</string>
+    <string name="video_completion_notification_channel">Finalización del vídeo</string>
+    <string name="video_completion_notification_channel_description">Alertas cuando los vídeos de la cronología están listos</string>
     <string name="no_video_player">No hay ninguna aplicación disponible para reproducir este vídeo.</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,7 +66,9 @@
     <string name="creating_video_notification_title">Création de votre vidéo timeline</string>
     <string name="starting_video_creation">Démarrage de la création vidéo…</string>
     <string name="video_creation_notification_channel">Création vidéo</string>
-    <string name="video_creation_notification_channel_description">Alertes de progression et d\'achèvement pour les vidéos timeline</string>
+    <string name="video_creation_notification_channel_description">Progression des vidéos de la chronologie</string>
+    <string name="video_completion_notification_channel">Vidéos terminées</string>
+    <string name="video_completion_notification_channel_description">Alertes lorsque les vidéos de la chronologie sont prêtes</string>
     <string name="no_video_player">Aucune application n\'est disponible pour lire cette vidéo</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,7 +63,9 @@
     <string name="creating_video_notification_title">タイムライン動画を作成中</string>
     <string name="starting_video_creation">動画作成を開始しています…</string>
     <string name="video_creation_notification_channel">動画作成</string>
-    <string name="video_creation_notification_channel_description">タイムライン動画の進行状況と完了通知</string>
+    <string name="video_creation_notification_channel_description">タイムライン動画の進行状況</string>
+    <string name="video_completion_notification_channel">動画の完成</string>
+    <string name="video_completion_notification_channel_description">タイムライン動画の準備ができたときに通知</string>
     <string name="no_video_player">この動画を再生できるアプリがありません</string>
     <string name="period_same_year">%3$d年%1$s～%2$s</string>
     <string name="period_cross_year">%2$d年%1$s～%4$d年%3$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -63,7 +63,9 @@
     <string name="creating_video_notification_title">타임라인 영상 만드는 중</string>
     <string name="starting_video_creation">영상 만들기를 시작하는 중…</string>
     <string name="video_creation_notification_channel">영상 만들기</string>
-    <string name="video_creation_notification_channel_description">타임라인 영상의 진행률과 완성 알림</string>
+    <string name="video_creation_notification_channel_description">타임라인 영상의 진행률 알림</string>
+    <string name="video_completion_notification_channel">영상 완성</string>
+    <string name="video_completion_notification_channel_description">타임라인 영상이 준비되면 알림</string>
     <string name="no_video_player">이 영상을 재생할 앱이 없습니다</string>
     <string name="period_same_year">%3$d년 %1$s–%2$s</string>
     <string name="period_cross_year">%2$d년 %1$s–%4$d년 %3$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -66,7 +66,9 @@
     <string name="creating_video_notification_title">Criando seu vídeo timeline</string>
     <string name="starting_video_creation">Iniciando a criação do vídeo…</string>
     <string name="video_creation_notification_channel">Criação de vídeo</string>
-    <string name="video_creation_notification_channel_description">Alertas de progresso e conclusão para vídeos timeline</string>
+    <string name="video_creation_notification_channel_description">Atualizações do progresso dos vídeos da linha do tempo</string>
+    <string name="video_completion_notification_channel">Conclusão do vídeo</string>
+    <string name="video_completion_notification_channel_description">Alertas quando os vídeos da linha do tempo estiverem prontos</string>
     <string name="no_video_player">Nenhum aplicativo está disponível para reproduzir este vídeo</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -64,7 +64,9 @@
     <string name="creating_video_notification_title">创建您的 timeline 视频</string>
     <string name="starting_video_creation">开始视频创作...</string>
     <string name="video_creation_notification_channel">视频创作</string>
-    <string name="video_creation_notification_channel_description">timeline 视频的进度和完成提醒</string>
+    <string name="video_creation_notification_channel_description">时间轴视频的生成进度</string>
+    <string name="video_completion_notification_channel">视频完成</string>
+    <string name="video_completion_notification_channel_description">时间轴视频准备就绪时发出提醒</string>
     <string name="no_video_player">没有可用的应用程序来播放该视频</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -64,7 +64,9 @@
     <string name="creating_video_notification_title">正在建立您的時間軸影片</string>
     <string name="starting_video_creation">正在開始建立影片…</string>
     <string name="video_creation_notification_channel">建立影片</string>
-    <string name="video_creation_notification_channel_description">時間軸影片的產生進度和完成提醒</string>
+    <string name="video_creation_notification_channel_description">時間軸影片的產生進度</string>
+    <string name="video_completion_notification_channel">影片完成</string>
+    <string name="video_completion_notification_channel_description">時間軸影片準備就緒時發出提醒</string>
     <string name="no_video_player">沒有應用程式可播放該影片</string>
     <string name="period_same_year">%3$d 年 %1$s–%2$s</string>
     <string name="period_cross_year">%2$d 年 %1$s–%4$d 年 %3$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,9 @@
     <string name="creating_video_notification_title">Creating your timeline video</string>
     <string name="starting_video_creation">Starting video creation…</string>
     <string name="video_creation_notification_channel">Video creation</string>
-    <string name="video_creation_notification_channel_description">Progress and completion alerts for timeline videos</string>
+    <string name="video_creation_notification_channel_description">Progress updates for timeline videos</string>
+    <string name="video_completion_notification_channel">Video completion</string>
+    <string name="video_completion_notification_channel_description">Alerts when timeline videos are ready</string>
     <string name="no_video_player">No app is available to play this video</string>
     <string name="period_same_year">%1$s–%2$s %3$d</string>
     <string name="period_cross_year">%1$s %2$d–%3$s %4$d</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -1,5 +1,8 @@
 package dev.mahlernim.timelinevisualizer
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -30,6 +33,7 @@ import dev.mahlernim.timelinevisualizer.export.ExportProgress
 import dev.mahlernim.timelinevisualizer.export.VideoExportSnapshot
 import dev.mahlernim.timelinevisualizer.export.VideoExportStateStore
 import dev.mahlernim.timelinevisualizer.export.VideoExportStatus
+import dev.mahlernim.timelinevisualizer.export.VideoExportService
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
@@ -70,6 +74,7 @@ class MainActivityTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val store = VideoStore(context)
     private val timelineSourceStore = TimelineSourceStore(context)
+    private val testNotificationChannel = "test_completed_export"
     private lateinit var controller: ActivityController<MainActivity>
 
     @Before
@@ -83,6 +88,7 @@ class MainActivityTest {
         context.getSharedPreferences("distance-unit-settings", Context.MODE_PRIVATE).edit().clear().commit()
         timelineSourceStore.clearForTest()
         context.getSharedPreferences("video-presets", Context.MODE_PRIVATE).edit().clear().commit()
+        context.getSystemService(NotificationManager::class.java).deleteNotificationChannel(testNotificationChannel)
     }
 
     @Test
@@ -203,6 +209,7 @@ class MainActivityTest {
         VideoExportCoordinator.resetForTest()
         timelineSourceStore.clearForTest()
         context.getSharedPreferences("video-presets", Context.MODE_PRIVATE).edit().clear().commit()
+        context.getSystemService(NotificationManager::class.java).deleteNotificationChannel(testNotificationChannel)
     }
 
     @Test
@@ -1184,22 +1191,128 @@ class MainActivityTest {
         assertEquals(MainActivity.ACTION_WATCH_VIDEO, intent.action)
         assertEquals(uri, intent.data)
         assertEquals(MainActivity::class.java.name, intent.component?.className)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP != 0)
     }
 
     @Test
     fun playbackIntentDisplaysTheFullScreenInternalPlayer() {
         val uri = Uri.parse("content://example/video/internal")
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.COMPLETE,
+                outputUri = uri.toString(),
+                title = "Completed video",
+            ),
+        )
+        postCompletionNotification()
         val activity = launchActivity(MainActivity.playbackIntent(context, uri))
 
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.playerScreen).visibility)
         assertEquals(View.GONE, activity.findViewById<View>(R.id.bottomNavigation).visibility)
         assertEquals(View.GONE, activity.findViewById<View>(R.id.videosScreen).visibility)
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertCompletionNotificationDismissed()
+    }
+
+    @Test
+    fun shareIntentRoutesThroughTheAppAndClearsCompletion() {
+        val uri = Uri.parse("content://example/video/internal")
+        val intent = MainActivity.shareIntent(context, uri)
+        assertEquals(MainActivity.ACTION_SHARE_VIDEO, intent.action)
+        assertEquals(uri, intent.data)
+        assertEquals(MainActivity::class.java.name, intent.component?.className)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP != 0)
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.COMPLETE,
+                outputUri = uri.toString(),
+                title = "Completed video",
+            ),
+        )
+        postCompletionNotification()
+
+        val activity = launchActivity(intent)
+        val chooser = shadowOf(activity).nextStartedActivity
+        val send = chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+
+        assertEquals(Intent.ACTION_CHOOSER, chooser.action)
+        assertEquals(Intent.ACTION_SEND, send?.action)
+        assertEquals(uri, send?.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+        assertTrue(send!!.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertCompletionNotificationDismissed()
+    }
+
+    @Test
+    fun warmActivityHandlesShareNotificationIntent() {
+        val uri = Uri.parse("content://example/video/warm")
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.COMPLETE,
+                outputUri = uri.toString(),
+                title = "Completed video",
+            ),
+        )
+
+        controller.newIntent(MainActivity.shareIntent(context, uri))
+        val chooser = shadowOf(activity).nextStartedActivity
+
+        assertEquals(Intent.ACTION_CHOOSER, chooser.action)
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+    }
+
+    @Test
+    fun warmActivityHandlesWatchNotificationIntent() {
+        val uri = Uri.parse("content://example/video/warm")
+        val activity = launchActivity()
+        VideoExportCoordinator.publish(
+            context,
+            VideoExportSnapshot(
+                status = VideoExportStatus.COMPLETE,
+                outputUri = uri.toString(),
+                title = "Completed video",
+            ),
+        )
+        postCompletionNotification()
+
+        controller.newIntent(MainActivity.playbackIntent(context, uri))
+
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.playerScreen).visibility)
+        assertEquals(VideoExportStatus.IDLE, VideoExportStateStore(context).load().status)
+        assertCompletionNotificationDismissed()
     }
 
     private fun acceptPrivacyDisclosure() {
         context.getSharedPreferences("display", Context.MODE_PRIVATE).edit()
             .putBoolean("map_privacy_accepted_v1", true)
             .commit()
+    }
+
+    private fun postCompletionNotification() {
+        val manager = context.getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(
+            NotificationChannel(
+                testNotificationChannel,
+                "Test completion",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ),
+        )
+        manager.notify(
+            VideoExportService.NOTIFICATION_ID,
+            Notification.Builder(context, testNotificationChannel)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle("Completed video")
+                .build(),
+        )
+    }
+
+    private fun assertCompletionNotificationDismissed() {
+        val active = context.getSystemService(NotificationManager::class.java).activeNotifications
+        assertTrue(active.none { it.id == VideoExportService.NOTIFICATION_ID })
     }
 
     private fun assertCompactButtons() {

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportServiceTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportServiceTest.kt
@@ -1,10 +1,45 @@
 package dev.mahlernim.timelinevisualizer.export
 
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
 import android.content.pm.ServiceInfo
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import dev.mahlernim.timelinevisualizer.MainActivity
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
 class VideoExportServiceTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val notificationManager = context.getSystemService(NotificationManager::class.java)
+    private lateinit var controller: ServiceController<VideoExportService>
+
+    @Before
+    fun setUp() {
+        notificationManager.deleteNotificationChannel("video_creation")
+        notificationManager.deleteNotificationChannel("video_completion")
+        controller = Robolectric.buildService(VideoExportService::class.java).create()
+    }
+
+    @After
+    fun tearDown() {
+        controller.destroy()
+        notificationManager.deleteNotificationChannel("video_creation")
+        notificationManager.deleteNotificationChannel("video_completion")
+    }
+
     @Test
     fun usesMediaProcessingTypeOnAndroid15AndNewer() {
         assertEquals(
@@ -23,5 +58,38 @@ class VideoExportServiceTest {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
             VideoExportService.foregroundServiceTypeForApi(34),
         )
+    }
+
+    @Test
+    fun separatesQuietProgressFromAlertingCompletionChannels() {
+        assertEquals(
+            NotificationManager.IMPORTANCE_LOW,
+            notificationManager.getNotificationChannel("video_creation").importance,
+        )
+        assertEquals(
+            NotificationManager.IMPORTANCE_DEFAULT,
+            notificationManager.getNotificationChannel("video_completion").importance,
+        )
+    }
+
+    @Test
+    fun completedNotificationUsesExplicitAppActions() {
+        val uri = Uri.parse("content://example/video/completed")
+        val notification = controller.get().buildCompletedNotification(uri, "Completed video")
+
+        assertEquals("video_completion", notification.channelId)
+        assertEquals(Notification.CATEGORY_STATUS, notification.category)
+        assertEquals(2, notification.actions.size)
+
+        val watch = shadowOf(notification.actions[0].actionIntent).savedIntent
+        assertEquals(MainActivity::class.java.name, watch.component?.className)
+        assertEquals(MainActivity.ACTION_WATCH_VIDEO, watch.action)
+        assertEquals(uri, watch.data)
+
+        val share = shadowOf(notification.actions[1].actionIntent).savedIntent
+        assertEquals(MainActivity::class.java.name, share.component?.className)
+        assertEquals(MainActivity.ACTION_SHARE_VIDEO, share.action)
+        assertEquals(uri, share.data)
+        assertTrue(share.flags and android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP != 0)
     }
 }

--- a/docs/release-notes-v2.3.2.md
+++ b/docs/release-notes-v2.3.2.md
@@ -1,0 +1,66 @@
+# Timeline Visualizer 2.3.2
+
+Completed video notifications are now more dependable. Video completion uses a normal
+alert channel while progress updates remain quiet. Watch and Share from the system
+notification now open the app's working playback and sharing flows, and either action
+dismisses the notification. Your Android notification settings still control alerts.
+
+## 한국어
+
+완성된 영상 알림을 더 안정적으로 개선했습니다. 진행 상황 알림은 조용히 유지하면서 영상이
+완성되면 일반 알림 채널로 알려 줍니다. 시스템 알림의 보기와 공유는 이제 앱의 정상적인 재생 및
+공유 기능을 사용하며, 어느 작업을 선택해도 알림이 사라집니다. 알림 방식은 Android 알림 설정의
+영향을 받습니다.
+
+## 日本語
+
+動画の完成通知をより確実にしました。進行状況の通知は静かなままにし、動画が完成すると通常の
+通知チャンネルでお知らせします。システム通知の「見る」と「共有」は、アプリ内の正常な再生と
+共有の流れを使用するようになり、どちらを選んでも通知が消えます。通知方法はAndroidの通知設定
+に従います。
+
+## 简体中文
+
+视频完成通知现在更加可靠。进度通知仍保持静默，而视频完成后会通过普通提醒渠道通知您。系统
+通知中的“观看”和“分享”现在会使用应用内正常的播放和分享流程，选择任一操作都会关闭通知。
+提醒方式仍受 Android 通知设置控制。
+
+## 繁體中文
+
+影片完成通知現在更加可靠。進度通知仍保持靜音，而影片完成後會透過一般提醒管道通知您。系統
+通知中的「觀看」與「分享」現在會使用應用程式內正常的播放與分享流程，選取任一操作都會關閉
+通知。提醒方式仍受 Android 通知設定控制。
+
+## Español
+
+Las notificaciones de vídeo completado ahora son más fiables. Las actualizaciones de
+progreso permanecen silenciosas, mientras que la finalización del vídeo utiliza un
+canal de aviso normal. Ver y Compartir desde la notificación del sistema ahora abren
+los flujos de reproducción y uso compartido de la aplicación, y ambas acciones cierran
+la notificación. La configuración de notificaciones de Android sigue controlando los
+avisos.
+
+## Français
+
+Les notifications de vidéo terminée sont désormais plus fiables. Les mises à jour de
+progression restent silencieuses, tandis que la fin de la vidéo utilise un canal
+d'alerte normal. Regarder et Partager depuis la notification système ouvrent maintenant
+les fonctions de lecture et de partage de l'application, et les deux actions ferment la
+notification. Les réglages de notification Android continuent de contrôler les alertes.
+
+## Deutsch
+
+Benachrichtigungen über fertige Videos sind jetzt zuverlässiger. Fortschrittsmeldungen
+bleiben lautlos, während die Fertigstellung eines Videos über einen normalen
+Benachrichtigungskanal gemeldet wird. Ansehen und Teilen in der Systembenachrichtigung
+öffnen jetzt die funktionierenden Wiedergabe- und Freigabeabläufe der App. Beide
+Aktionen schließen die Benachrichtigung. Die Android-Benachrichtigungseinstellungen
+bestimmen weiterhin, wie Hinweise ausgegeben werden.
+
+## Português (Brasil)
+
+As notificações de vídeo concluído agora são mais confiáveis. As atualizações de
+progresso permanecem silenciosas, enquanto a conclusão do vídeo usa um canal de alerta
+normal. Assistir e Compartilhar pela notificação do sistema agora abrem os fluxos de
+reprodução e compartilhamento do aplicativo, e ambas as ações dispensam a notificação.
+As configurações de notificação do Android continuam controlando os alertas.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.3.1` and version code `34`
+- Version name `2.3.2` and version code `35`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- separate quiet export progress from normal video-completion alerts
- route notification Watch and Share actions through the app's tested playback and sharing flows
- dismiss the completed notification after either action
- add regression coverage for channel importance, cold and warm activity routing, URI sharing, and notification cancellation
- prepare version 2.3.2 with version code 35 and localized release notes

## Validation

- `./gradlew test lint assembleGithubDebug assemblePlayDebug --stacktrace`
- `python -m pytest` with 36 passing tests
- connected device suite with 6 tests each on API 35 and API 36
- manual API 36 verification that Watch plays an app-owned MP4 and Share opens the Android chooser with the MP4 attached

Closes #140