### PR TITLE
feat: embed MP4 title metadata (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
-## 2.2.14
+## Unreleased
 
-- Embed video title and artist metadata directly into the exported MP4 container to support third-party media players.
-- Migrate the video export muxer to Media3 to enable binary metadata injection.
+- Embed the resolved video title in exported MP4 metadata for media players and galleries.
 
 ## 2.2.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.14
+
+- Embed video title and artist metadata directly into the exported MP4 container to support third-party media players.
+- Migrate the video export muxer to Media3 to enable binary metadata injection.
+
 ## 2.2.13
 
 - Fix issue where the video-generation notification remained visible in the system tray after the user clicked Done in the app.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.13.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("androidx.media3:media3-exoplayer:1.11.0")
+    implementation("androidx.media3:media3-muxer:1.11.0")
     implementation("androidx.media3:media3-ui:1.11.0")
 
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -6,7 +6,11 @@ import android.graphics.Canvas
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
-import android.media.MediaMuxer
+import androidx.media3.muxer.Mp4Muxer
+import androidx.media3.common.util.MediaFormatUtil
+import androidx.media3.container.MdtaMetadataEntry
+import androidx.media3.muxer.Muxer
+import java.io.FileOutputStream
 import android.net.Uri
 import dev.mahlernim.timelinevisualizer.data.TileRepository
 import dev.mahlernim.timelinevisualizer.model.Journey
@@ -31,10 +35,12 @@ data class ExportProgress(
     val total: Int,
 )
 
+@android.annotation.SuppressLint("UnsafeOptInUsageError")
 class Mp4Exporter(
     private val contentResolver: ContentResolver,
     private val tileRepository: TileRepository,
 ) {
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     suspend fun export(
         destination: Uri,
         journey: Journey,
@@ -100,7 +106,10 @@ class Mp4Exporter(
         val codec = MediaCodec.createByCodecName(encoder.name)
         val descriptor = contentResolver.openFileDescriptor(destination, "rwt")
             ?: error("Could not open the selected output file")
-        val muxer = MediaMuxer(descriptor.fileDescriptor, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+        @Suppress("DEPRECATION")
+        val muxer = Mp4Muxer.Builder(FileOutputStream(descriptor.fileDescriptor)).build()
+        muxer.addMetadataEntry(MdtaMetadataEntry("title", title.toByteArray(Charsets.UTF_8), 0, 1))
+        muxer.addMetadataEntry(MdtaMetadataEntry("artist", "Timeline Visualizer".toByteArray(Charsets.UTF_8), 0, 1))
         var muxerStarted = false
         var trackIndex = -1
         val bufferInfo = MediaCodec.BufferInfo()
@@ -115,8 +124,9 @@ class Mp4Exporter(
                     outputIndex == MediaCodec.INFO_TRY_AGAIN_LATER -> return false
                     outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
                         check(!muxerStarted) { "Encoder format changed twice" }
-                        trackIndex = muxer.addTrack(codec.outputFormat)
-                        muxer.start()
+                        val media3Format = MediaFormatUtil.createFormatFromMediaFormat(codec.outputFormat)
+                        trackIndex = muxer.addTrack(media3Format)
+                        // Note: Mp4Muxer doesn't have an explicit start() method, it implicitly starts when writing.
                         muxerStarted = true
                     }
                     outputIndex >= 0 -> {
@@ -127,7 +137,12 @@ class Mp4Exporter(
                             check(muxerStarted) { "Encoder produced data before its output format" }
                             encoded.position(bufferInfo.offset)
                             encoded.limit(bufferInfo.offset + bufferInfo.size)
-                            muxer.writeSampleData(trackIndex, encoded, bufferInfo)
+                            val media3BufferInfo = androidx.media3.muxer.BufferInfo(
+                                bufferInfo.presentationTimeUs,
+                                bufferInfo.size,
+                                bufferInfo.flags
+                            )
+                            muxer.writeSampleData(trackIndex, encoded, media3BufferInfo)
                         }
                         codec.releaseOutputBuffer(outputIndex, false)
                         if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) return true
@@ -224,8 +239,8 @@ class Mp4Exporter(
         } finally {
             runCatching { codec.stop() }
             codec.release()
-            if (muxerStarted) runCatching { muxer.stop() }
-            muxer.release()
+            runCatching { muxer.close() }
+            // Mp4Muxer.close() completes and releases it
             descriptor.close()
             bitmap.recycle()
         }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -6,20 +6,23 @@ import android.graphics.Canvas
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
-import androidx.media3.muxer.Mp4Muxer
-import androidx.media3.common.util.MediaFormatUtil
-import androidx.media3.container.MdtaMetadataEntry
-import androidx.media3.muxer.Muxer
-import java.io.FileOutputStream
 import android.net.Uri
+import android.os.ParcelFileDescriptor
+import androidx.annotation.OptIn
+import androidx.media3.common.util.MediaFormatUtil
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.container.MdtaMetadataEntry
+import androidx.media3.muxer.BufferInfo as MuxerBufferInfo
+import androidx.media3.muxer.Mp4Muxer
+import androidx.media3.muxer.SeekableMuxerOutput
 import dev.mahlernim.timelinevisualizer.data.TileRepository
 import dev.mahlernim.timelinevisualizer.model.Journey
-import dev.mahlernim.timelinevisualizer.render.TimelineAnimation
 import dev.mahlernim.timelinevisualizer.render.CameraSettings
-import dev.mahlernim.timelinevisualizer.render.TileId
+import dev.mahlernim.timelinevisualizer.render.RenderText
+import dev.mahlernim.timelinevisualizer.render.TimelineAnimation
 import dev.mahlernim.timelinevisualizer.render.TimelineFrame
 import dev.mahlernim.timelinevisualizer.render.TimelinePainter
-import dev.mahlernim.timelinevisualizer.render.RenderText
+import dev.mahlernim.timelinevisualizer.render.TileId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -35,12 +38,11 @@ data class ExportProgress(
     val total: Int,
 )
 
-@android.annotation.SuppressLint("UnsafeOptInUsageError")
 class Mp4Exporter(
     private val contentResolver: ContentResolver,
     private val tileRepository: TileRepository,
 ) {
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     suspend fun export(
         destination: Uri,
         journey: Journey,
@@ -106,10 +108,20 @@ class Mp4Exporter(
         val codec = MediaCodec.createByCodecName(encoder.name)
         val descriptor = contentResolver.openFileDescriptor(destination, "rwt")
             ?: error("Could not open the selected output file")
-        @Suppress("DEPRECATION")
-        val muxer = Mp4Muxer.Builder(FileOutputStream(descriptor.fileDescriptor)).build()
-        muxer.addMetadataEntry(MdtaMetadataEntry("title", title.toByteArray(Charsets.UTF_8), 0, 1))
-        muxer.addMetadataEntry(MdtaMetadataEntry("artist", "Timeline Visualizer".toByteArray(Charsets.UTF_8), 0, 1))
+        val outputStream = ParcelFileDescriptor.AutoCloseOutputStream(descriptor)
+        val muxer = try {
+            Mp4Muxer.Builder(SeekableMuxerOutput.of(outputStream)).build()
+        } catch (error: Throwable) {
+            runCatching { outputStream.close() }.onFailure(error::addSuppressed)
+            throw error
+        }
+        muxer.addMetadataEntry(
+            MdtaMetadataEntry(
+                "title",
+                title.toByteArray(Charsets.UTF_8),
+                MdtaMetadataEntry.TYPE_INDICATOR_STRING,
+            ),
+        )
         var muxerStarted = false
         var trackIndex = -1
         val bufferInfo = MediaCodec.BufferInfo()
@@ -126,7 +138,6 @@ class Mp4Exporter(
                         check(!muxerStarted) { "Encoder format changed twice" }
                         val media3Format = MediaFormatUtil.createFormatFromMediaFormat(codec.outputFormat)
                         trackIndex = muxer.addTrack(media3Format)
-                        // Note: Mp4Muxer doesn't have an explicit start() method, it implicitly starts when writing.
                         muxerStarted = true
                     }
                     outputIndex >= 0 -> {
@@ -137,10 +148,10 @@ class Mp4Exporter(
                             check(muxerStarted) { "Encoder produced data before its output format" }
                             encoded.position(bufferInfo.offset)
                             encoded.limit(bufferInfo.offset + bufferInfo.size)
-                            val media3BufferInfo = androidx.media3.muxer.BufferInfo(
+                            val media3BufferInfo = MuxerBufferInfo(
                                 bufferInfo.presentationTimeUs,
                                 bufferInfo.size,
-                                bufferInfo.flags
+                                bufferInfo.flags,
                             )
                             muxer.writeSampleData(trackIndex, encoded, media3BufferInfo)
                         }
@@ -151,6 +162,7 @@ class Mp4Exporter(
             }
         }
 
+        var exportFailure: Throwable? = null
         try {
             codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
             codec.start()
@@ -236,13 +248,24 @@ class Mp4Exporter(
             )
             onProgress(ExportProgress(1f, ExportPhase.COMPLETE, 1, 1))
             overview
+        } catch (error: Throwable) {
+            exportFailure = error
+            throw error
         } finally {
-            runCatching { codec.stop() }
-            codec.release()
-            runCatching { muxer.close() }
-            // Mp4Muxer.close() completes and releases it
-            descriptor.close()
+            var cleanupFailure: Throwable? = null
+            fun cleanUp(block: () -> Unit) {
+                try {
+                    block()
+                } catch (error: Throwable) {
+                    val priorFailure = exportFailure ?: cleanupFailure
+                    if (priorFailure == null) cleanupFailure = error else priorFailure.addSuppressed(error)
+                }
+            }
+            cleanUp { codec.stop() }
+            cleanUp { codec.release() }
+            cleanUp { muxer.close() }
             bitmap.recycle()
+            if (exportFailure == null) cleanupFailure?.let { throw it }
         }
     }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/GeneratedMediaRepository.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/GeneratedMediaRepository.kt
@@ -21,6 +21,8 @@ class GeneratedMediaRepository(private val context: Context) {
             MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
             ContentValues().apply {
                 put(MediaStore.Video.Media.DISPLAY_NAME, displayName)
+                put(MediaStore.Video.Media.TITLE, title)
+                put(MediaStore.Video.Media.ARTIST, "Timeline Visualizer")
                 put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
                 put(MediaStore.Video.Media.RELATIVE_PATH, "${Environment.DIRECTORY_MOVIES}/Timeline Visualizer")
                 put(MediaStore.Video.Media.IS_PENDING, 1)

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/GeneratedMediaRepository.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/GeneratedMediaRepository.kt
@@ -22,7 +22,6 @@ class GeneratedMediaRepository(private val context: Context) {
             ContentValues().apply {
                 put(MediaStore.Video.Media.DISPLAY_NAME, displayName)
                 put(MediaStore.Video.Media.TITLE, title)
-                put(MediaStore.Video.Media.ARTIST, "Timeline Visualizer")
                 put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
                 put(MediaStore.Video.Media.RELATIVE_PATH, "${Environment.DIRECTORY_MOVIES}/Timeline Visualizer")
                 put(MediaStore.Video.Media.IS_PENDING, 1)

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/GeneratedMediaRepositoryTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/GeneratedMediaRepositoryTest.kt
@@ -29,6 +29,7 @@ class GeneratedMediaRepositoryTest {
             uri,
             arrayOf(
                 MediaStore.Video.Media.DISPLAY_NAME,
+                MediaStore.Video.Media.TITLE,
                 MediaStore.Video.Media.MIME_TYPE,
                 MediaStore.Video.Media.RELATIVE_PATH,
                 MediaStore.Video.Media.IS_PENDING,
@@ -38,13 +39,14 @@ class GeneratedMediaRepositoryTest {
             null,
         )!!.use { cursor ->
             assertTrue(cursor.moveToFirst())
-            List(4) { cursor.getString(it) }
+            List(5) { cursor.getString(it) }
         }
 
         assertEquals("Mina 서울 東京-2025-01_2026-08.mp4", values[0])
-        assertEquals("video/mp4", values[1])
-        assertEquals("Movies/Timeline Visualizer", values[2].trimEnd('/'))
-        assertEquals("1", values[3])
+        assertEquals("Mina 서울/東京", values[1])
+        assertEquals("video/mp4", values[2])
+        assertEquals("Movies/Timeline Visualizer", values[3].trimEnd('/'))
+        assertEquals("1", values[4])
 
         repository.finalizeVideo(uri)
         val pending = context.contentResolver.query(


### PR DESCRIPTION
## Summary

Resolves #143.

Embeds the already resolved video title in exported MP4 metadata without changing the existing title UI or title-generation logic.

## Changes

- Use Media3 `Mp4Muxer` to write the UTF-8 title metadata.
- Store the same resolved title in MediaStore on Android 10 and later.
- Keep existing owner, template, localization, and preference behavior unchanged.
- Use single-owner output cleanup and preserve export and finalization failures.

## Verification

- `./gradlew test lint assembleGithubDebug assemblePlayDebug`
- `./gradlew connectedGithubDebugAndroidTest` on API 35 and 36
- `python -m pytest` with 36 tests passing
- Exported the repository sample on API 36. `ffprobe` found H.264 video, a 31.5-second duration, `title=2024 Traveler's Timeline`, and no artist tag.