### PR TITLE
Keep the outro within the selected video duration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 36
-        versionName = "2.3.3"
+        versionCode = 37
+        versionName = "2.3.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -64,8 +64,7 @@ class Mp4Exporter(
         val overviewWidth = overviewWidth(videoFormat)
         val overviewHeight = overviewHeight(videoFormat)
         val painter = TimelinePainter()
-        val journeyFrameCount = durationSeconds * fps
-        val outroFrameCount = (TimelineAnimation.OUTRO_SECONDS * fps).toInt()
+        val (journeyFrameCount, outroFrameCount) = videoFrameCounts(durationSeconds, fps)
         val frameCount = journeyFrameCount + outroFrameCount
 
         val requiredTiles = requiredTilesForExport(
@@ -305,6 +304,15 @@ class Mp4Exporter(
         private const val PREPARING_PROGRESS_WEIGHT = 0.10f
         private const val JOURNEY_PROGRESS_WEIGHT = 0.80f
         private const val FINISHING_PROGRESS_WEIGHT = 0.10f
+
+        internal fun videoFrameCounts(durationSeconds: Int, fps: Int): Pair<Int, Int> {
+            val frameCount = durationSeconds.coerceAtLeast(1) * fps.coerceAtLeast(1)
+            val outroFrameCount = minOf(
+                (TimelineAnimation.OUTRO_SECONDS * fps).toInt(),
+                frameCount - 1,
+            )
+            return frameCount - outroFrameCount to outroFrameCount
+        }
 
         internal fun overviewWidth(format: dev.mahlernim.timelinevisualizer.render.VideoQuality): Int =
             if (format.width >= format.height) {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelineAnimation.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelineAnimation.kt
@@ -9,19 +9,20 @@ object TimelineAnimation {
     const val OUTRO_SECONDS = 1.5f
     const val OUTRO_TRANSITION_SECONDS = 1.0f
 
-    fun totalDurationSeconds(journeyDurationSeconds: Int): Float =
-        journeyDurationSeconds.coerceAtLeast(1) + OUTRO_SECONDS
+    fun totalDurationSeconds(selectedDurationSeconds: Int): Float =
+        selectedDurationSeconds.coerceAtLeast(1).toFloat()
 
-    fun frameAtOverallProgress(overallProgress: Float, journeyDurationSeconds: Int): TimelineFrame {
-        val journeySeconds = journeyDurationSeconds.coerceAtLeast(1).toFloat()
-        val elapsedSeconds = overallProgress.coerceIn(0f, 1f) * totalDurationSeconds(journeyDurationSeconds)
-        return frameAtElapsedSeconds(elapsedSeconds, journeyDurationSeconds)
+    fun frameAtOverallProgress(overallProgress: Float, selectedDurationSeconds: Int): TimelineFrame {
+        val elapsedSeconds = overallProgress.coerceIn(0f, 1f) * totalDurationSeconds(selectedDurationSeconds)
+        return frameAtElapsedSeconds(elapsedSeconds, selectedDurationSeconds)
     }
 
-    fun frameAtElapsedSeconds(elapsedSeconds: Float, journeyDurationSeconds: Int): TimelineFrame {
-        val journeySeconds = journeyDurationSeconds.coerceAtLeast(1).toFloat()
+    fun frameAtElapsedSeconds(elapsedSeconds: Float, selectedDurationSeconds: Int): TimelineFrame {
+        val totalSeconds = totalDurationSeconds(selectedDurationSeconds)
+        val journeySeconds = (totalSeconds - OUTRO_SECONDS).coerceAtLeast(0f)
         if (elapsedSeconds <= journeySeconds) {
-            return TimelineFrame((elapsedSeconds / journeySeconds).coerceIn(0f, 1f), 0f)
+            val journeyProgress = if (journeySeconds == 0f) 1f else elapsedSeconds / journeySeconds
+            return TimelineFrame(journeyProgress.coerceIn(0f, 1f), 0f)
         }
         val outroElapsed = elapsedSeconds - journeySeconds
         return TimelineFrame(

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/Mp4ExporterTileCoverageTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/Mp4ExporterTileCoverageTest.kt
@@ -16,6 +16,15 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class Mp4ExporterTileCoverageTest {
     @Test
+    fun selectedDurationIncludesTheOutroFrames() {
+        val (journeyFrames, outroFrames) = Mp4Exporter.videoFrameCounts(90, 30)
+
+        assertEquals(2_655, journeyFrames)
+        assertEquals(45, outroFrames)
+        assertEquals(2_700, journeyFrames + outroFrames)
+    }
+
+    @Test
     fun preparationIncludesEveryVideoFrameAndTheOverview() {
         val journey = Journey.from(
             listOf(

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/JourneyTimingTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/JourneyTimingTest.kt
@@ -31,7 +31,7 @@ class JourneyTimingTest {
         assertEquals(originalPoints, journey.points)
         assertEquals(0.0, balanced.distanceAt(0f), 1e-9)
         assertEquals(journey.totalDistanceKm, balanced.distanceAt(1f), 1e-6)
-        assertEquals(31.5f, TimelineAnimation.totalDurationSeconds(30), 0f)
+        assertEquals(30f, TimelineAnimation.totalDurationSeconds(30), 0f)
     }
 
     @Test

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelineAnimationTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelineAnimationTest.kt
@@ -5,16 +5,19 @@ import org.junit.Test
 
 class TimelineAnimationTest {
     @Test
-    fun selectedDurationIsFollowedByOneAndAHalfSecondEnding() {
-        assertEquals(31.5f, TimelineAnimation.totalDurationSeconds(30), 0.001f)
-        assertEquals(76.5f, TimelineAnimation.totalDurationSeconds(75), 0.001f)
+    fun selectedDurationIncludesTheOneAndAHalfSecondEnding() {
+        assertEquals(30f, TimelineAnimation.totalDurationSeconds(30), 0.001f)
+        assertEquals(75f, TimelineAnimation.totalDurationSeconds(75), 0.001f)
     }
 
     @Test
     fun endingZoomCompletesBeforeTheFinalHalfSecondHold() {
-        val transitionEnd = TimelineAnimation.frameAtElapsedSeconds(31f, 30)
-        val heldFrame = TimelineAnimation.frameAtElapsedSeconds(31.4f, 30)
+        val journeyEnd = TimelineAnimation.frameAtElapsedSeconds(28.5f, 30)
+        val transitionEnd = TimelineAnimation.frameAtElapsedSeconds(29.5f, 30)
+        val heldFrame = TimelineAnimation.frameAtElapsedSeconds(29.9f, 30)
 
+        assertEquals(1f, journeyEnd.journeyProgress, 0.001f)
+        assertEquals(0f, journeyEnd.outroProgress, 0.001f)
         assertEquals(1f, transitionEnd.journeyProgress, 0.001f)
         assertEquals(1f, transitionEnd.outroProgress, 0.001f)
         assertEquals(1f, heldFrame.outroProgress, 0.001f)

--- a/docs/release-notes-v2.3.4.md
+++ b/docs/release-notes-v2.3.4.md
@@ -1,0 +1,54 @@
+# Timeline Visualizer 2.3.4
+
+Fixed generated videos being 1.5 seconds longer than the selected duration. The
+existing 1.5-second route overview ending is now included within the selected total,
+so a 90-second selection creates a 90-second video.
+
+## 한국어
+
+생성된 동영상이 선택한 길이보다 1.5초 길어지는 문제를 수정했습니다. 기존의 1.5초
+전체 경로 마무리 화면을 선택한 총 길이에 포함하여, 90초를 선택하면 90초 동영상이
+생성됩니다.
+
+## 日本語
+
+生成された動画が選択した長さより1.5秒長くなる問題を修正しました。既存の1.5秒の
+ルート全体表示を選択した合計時間に含め、90秒を選択すると90秒の動画が作成されます。
+
+## 简体中文
+
+修复了生成的视频比所选时长多出 1.5 秒的问题。现有的 1.5 秒完整路线结尾现已包含在
+所选总时长内，因此选择 90 秒会生成 90 秒的视频。
+
+## 繁體中文
+
+修復了產生的影片比所選時長多出 1.5 秒的問題。現有的 1.5 秒完整路線結尾現已包含在
+所選總時長內，因此選擇 90 秒會產生 90 秒的影片。
+
+## Español
+
+Se corrigió un problema por el que los vídeos generados duraban 1,5 segundos más
+de lo seleccionado. El cierre existente de 1,5 segundos con la ruta completa ahora
+se incluye en la duración total elegida, por lo que seleccionar 90 segundos crea un
+vídeo de 90 segundos.
+
+## Français
+
+Correction d'un problème qui ajoutait 1,5 seconde à la durée sélectionnée des
+vidéos générées. La séquence finale existante de 1,5 seconde montrant l'itinéraire
+complet est désormais comprise dans la durée totale choisie. Une sélection de
+90 secondes produit donc une vidéo de 90 secondes.
+
+## Deutsch
+
+Ein Problem wurde behoben, durch das erstellte Videos 1,5 Sekunden länger als die
+ausgewählte Dauer waren. Der vorhandene 1,5-sekündige Abschluss mit der gesamten
+Route ist jetzt in der gewählten Gesamtdauer enthalten. Bei einer Auswahl von
+90 Sekunden wird daher ein 90-sekündiges Video erstellt.
+
+## Português (Brasil)
+
+Corrigido um problema que deixava os vídeos gerados 1,5 segundo mais longos que a
+duração selecionada. O encerramento existente de 1,5 segundo com a rota completa
+agora faz parte da duração total escolhida. Assim, selecionar 90 segundos cria um
+vídeo de 90 segundos.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.3.3` and version code `36`
+- Version name `2.3.4` and version code `37`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/web/src/animation.test.ts
+++ b/web/src/animation.test.ts
@@ -6,15 +6,15 @@ import {
 } from './animation';
 
 describe('timeline ending', () => {
-  it('adds the Android ending duration after the selected journey duration', () => {
-    expect(totalDurationSeconds(30)).toBe(31.5);
-    expect(totalDurationSeconds(75)).toBe(76.5);
+  it('includes the Android ending within the selected duration', () => {
+    expect(totalDurationSeconds(30)).toBe(30);
+    expect(totalDurationSeconds(75)).toBe(75);
   });
 
   it('zooms to the overview for one second and holds it for the last half-second', () => {
-    expect(frameAtElapsedSeconds(30, 30)).toEqual({ journeyProgress: 1, outroProgress: 0 });
-    expect(frameAtElapsedSeconds(31, 30)).toEqual({ journeyProgress: 1, outroProgress: 1 });
-    expect(frameAtElapsedSeconds(31.4, 30)).toEqual({ journeyProgress: 1, outroProgress: 1 });
+    expect(frameAtElapsedSeconds(28.5, 30)).toEqual({ journeyProgress: 1, outroProgress: 0 });
+    expect(frameAtElapsedSeconds(29.5, 30)).toEqual({ journeyProgress: 1, outroProgress: 1 });
+    expect(frameAtElapsedSeconds(29.9, 30)).toEqual({ journeyProgress: 1, outroProgress: 1 });
   });
 
   it('maps overall export progress across the journey and ending', () => {

--- a/web/src/animation.ts
+++ b/web/src/animation.ts
@@ -7,17 +7,21 @@ function clamp(value: number, minimum = 0, maximum = 1): number {
   return Math.max(minimum, Math.min(maximum, value));
 }
 
-export function totalDurationSeconds(journeyDurationSeconds: number): number {
-  return Math.max(1, journeyDurationSeconds) + OUTRO_SECONDS;
+export function totalDurationSeconds(selectedDurationSeconds: number): number {
+  return Math.max(1, selectedDurationSeconds);
 }
 
 export function frameAtElapsedSeconds(
   elapsedSeconds: number,
-  journeyDurationSeconds: number,
+  selectedDurationSeconds: number,
 ): TimelineFrame {
-  const journeySeconds = Math.max(1, journeyDurationSeconds);
+  const totalSeconds = totalDurationSeconds(selectedDurationSeconds);
+  const journeySeconds = Math.max(0, totalSeconds - OUTRO_SECONDS);
   if (elapsedSeconds <= journeySeconds) {
-    return { journeyProgress: clamp(elapsedSeconds / journeySeconds), outroProgress: 0 };
+    return {
+      journeyProgress: journeySeconds === 0 ? 1 : clamp(elapsedSeconds / journeySeconds),
+      outroProgress: 0,
+    };
   }
   return {
     journeyProgress: 1,
@@ -27,11 +31,11 @@ export function frameAtElapsedSeconds(
 
 export function frameAtOverallProgress(
   overallProgress: number,
-  journeyDurationSeconds: number,
+  selectedDurationSeconds: number,
 ): TimelineFrame {
   return frameAtElapsedSeconds(
-    clamp(overallProgress) * totalDurationSeconds(journeyDurationSeconds),
-    journeyDurationSeconds,
+    clamp(overallProgress) * totalDurationSeconds(selectedDurationSeconds),
+    selectedDurationSeconds,
   );
 }
 

--- a/web/src/video.test.ts
+++ b/web/src/video.test.ts
@@ -313,6 +313,7 @@ describe('createJourneyMp4', () => {
     const blob = await createJourneyMp4(canvas, journey, options);
 
     expect(blob.type).toBe('video/mp4');
+    expect(encoder.add).toHaveBeenCalledTimes(options.durationSeconds * format.frameRate);
     expect(encoder.finalize).toHaveBeenCalledTimes(1);
     expect(encoder.cancel).not.toHaveBeenCalled();
   });

--- a/web/src/video.ts
+++ b/web/src/video.ts
@@ -172,9 +172,9 @@ export async function createJourneyMp4(
   }
 
   const frameDuration = 1 / fps;
-  const journeyFrameCount = Math.max(1, Math.round(options.durationSeconds * fps));
-  const outroFrameCount = Math.round(OUTRO_SECONDS * fps);
-  const frameCount = journeyFrameCount + outroFrameCount;
+  const frameCount = Math.max(1, Math.round(options.durationSeconds * fps));
+  const outroFrameCount = Math.min(Math.round(OUTRO_SECONDS * fps), frameCount - 1);
+  const journeyFrameCount = frameCount - outroFrameCount;
   const target = new BufferTarget();
   const output = new Output({
     format: new Mp4OutputFormat({ fastStart: 'in-memory' }),
@@ -207,7 +207,7 @@ export async function createJourneyMp4(
           outroProgress: 0,
         }
         : frameAtElapsedSeconds(
-          options.durationSeconds + (frame - journeyFrameCount) / fps,
+          options.durationSeconds - outroFrameCount / fps + (frame - journeyFrameCount) / fps,
           options.durationSeconds,
         );
       drawFrame(canvas, journey, animationFrame, options.overlay);


### PR DESCRIPTION
## Summary

- include the existing 1.5-second outro within the selected video duration
- keep Android preview, Android export, and web export timing aligned
- encode exactly 2,700 frames for a 90-second video at 30 fps
- prepare Android version 2.3.4 with version code 37

## Validation

- `gradlew test lint assembleGithubRelease bundlePlayRelease`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Android regression coverage confirms 2,655 journey frames plus 45 outro frames equals 2,700 total frames
- Web regression coverage confirms the encoder receives exactly the selected duration times the frame rate

Closes #155