### PR TITLE
Release v2.3.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 37
-        versionName = "2.3.4"
+        versionCode = 38
+        versionName = "2.3.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/docs/release-notes-v2.3.5.md
+++ b/docs/release-notes-v2.3.5.md
@@ -1,0 +1,67 @@
+# Timeline Visualizer 2.3.5
+
+Added flexible video export quality settings. Choose 480p, 720p, 1080p, 1440p,
+2160p, or a custom resolution, and choose 24, 30, 60, or a custom frame rate.
+The app checks the device's H.264 encoders, prefers hardware encoding, retries
+compatible alternatives, and blocks unsupported formats before export.
+
+## 한국어
+
+유연한 동영상 내보내기 품질 설정을 추가했습니다. 480p, 720p, 1080p, 1440p,
+2160p 또는 사용자 지정 해상도와 24, 30, 60 또는 사용자 지정 프레임 속도를 선택할
+수 있습니다. 앱은 기기의 H.264 인코더를 확인하고 하드웨어 인코딩을 우선 사용하며,
+호환되는 다른 인코더를 재시도하고 지원되지 않는 형식은 내보내기 전에 차단합니다.
+
+## 日本語
+
+動画の書き出し品質を柔軟に設定できるようになりました。480p、720p、1080p、
+1440p、2160p、またはカスタム解像度と、24、30、60、またはカスタムフレーム
+レートを選択できます。アプリは端末のH.264エンコーダーを確認し、ハードウェア
+エンコードを優先して互換性のある代替手段を再試行し、非対応の形式を書き出し前に
+ブロックします。
+
+## 简体中文
+
+新增灵活的视频导出质量设置。现在可以选择 480p、720p、1080p、1440p、2160p
+或自定义分辨率，以及 24、30、60 或自定义帧率。应用会检查设备的 H.264 编码器，
+优先使用硬件编码，在配置失败时尝试兼容的替代编码器，并在导出前阻止不受支持的格式。
+
+## 繁體中文
+
+新增彈性的影片匯出品質設定。現在可以選擇 480p、720p、1080p、1440p、2160p
+或自訂解析度，以及 24、30、60 或自訂影格率。應用程式會檢查裝置的 H.264 編碼器，
+優先使用硬體編碼，在設定失敗時嘗試相容的替代編碼器，並在匯出前阻止不支援的格式。
+
+## Español
+
+Se añadieron ajustes flexibles de calidad para la exportación de vídeo. Ahora se
+puede elegir entre 480p, 720p, 1080p, 1440p, 2160p o una resolución personalizada,
+y entre 24, 30, 60 o una frecuencia de fotogramas personalizada. La aplicación
+comprueba los codificadores H.264 del dispositivo, prioriza la codificación por
+hardware, prueba alternativas compatibles y bloquea los formatos no compatibles
+antes de exportar.
+
+## Français
+
+Ajout de réglages flexibles pour la qualité d'exportation vidéo. Vous pouvez
+choisir une résolution de 480p, 720p, 1080p, 1440p, 2160p ou personnalisée, ainsi
+qu'une fréquence de 24, 30, 60 images par seconde ou personnalisée. L'application
+vérifie les encodeurs H.264 de l'appareil, privilégie l'encodage matériel, essaie
+des solutions compatibles et bloque les formats non pris en charge avant
+l'exportation.
+
+## Deutsch
+
+Flexible Einstellungen für die Videoexportqualität wurden hinzugefügt. Zur Auswahl
+stehen 480p, 720p, 1080p, 1440p, 2160p oder eine benutzerdefinierte Auflösung sowie
+24, 30, 60 oder eine benutzerdefinierte Bildrate. Die App prüft die H.264-Encoder
+des Geräts, bevorzugt Hardware-Encoding, versucht kompatible Alternativen und
+blockiert nicht unterstützte Formate vor dem Export.
+
+## Português (Brasil)
+
+Foram adicionadas configurações flexíveis de qualidade para exportação de vídeo.
+Agora é possível escolher 480p, 720p, 1080p, 1440p, 2160p ou uma resolução
+personalizada, além de 24, 30, 60 ou uma taxa de quadros personalizada. O app
+verifica os codificadores H.264 do dispositivo, prioriza a codificação por hardware,
+tenta alternativas compatíveis e bloqueia formatos incompatíveis antes da exportação.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.3.4` and version code `37`
+- Version name `2.3.5` and version code `38`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- bump the Android version to 2.3.5 with version code 38
- add release notes for the new resolution, frame-rate, and encoder compatibility controls in all supported languages
- update the Play submission checklist version metadata

## Validation

- `python -m pytest -q` (52 passed)
- `./gradlew test lint assembleGithubDebug --stacktrace`
- `git diff --check`

Refs #41