### PR TITLE
Refine Raw Data availability in v2.4.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 39
-        versionName = "2.4.0"
+        versionCode = 40
+        versionName = "2.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -92,6 +92,7 @@ import dev.mahlernim.timelinevisualizer.export.VideoExportViewModel
 import dev.mahlernim.timelinevisualizer.export.EncoderSupport
 import dev.mahlernim.timelinevisualizer.export.VideoEncoderSupport
 import dev.mahlernim.timelinevisualizer.export.describe
+import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
 import dev.mahlernim.timelinevisualizer.model.Timeline
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
@@ -1723,15 +1724,22 @@ class MainActivity : AppCompatActivity() {
         val visible = currentCreateStep == CreateStep.PROJECT && activeProjectKind == TripKind.RAW_DATA
         editor.rawDataAvailabilityGroup.visibility = if (visible) View.VISIBLE else View.GONE
         if (!visible) return
-        rawDateBounds()?.let { (first, last) ->
-            editor.rawDataAvailabilityText.text = getString(
-                R.string.raw_data_available_range,
-                formatExactDate(first),
-                formatExactDate(last),
-            )
-        }
+        editor.rawDataAvailabilityText.text = rawDataAvailability(renderRawSignalsTimeline?.points.orEmpty())
         editor.rawDataRangeConflictGroup.visibility = if (rawProjectRangeConflict) View.VISIBLE else View.GONE
         editor.wizardContinueButton.isEnabled = !rawProjectRangeConflict
+    }
+
+    internal fun rawDataAvailability(points: List<GeoPoint>): String {
+        if (points.isEmpty()) return getString(R.string.raw_data_unavailable)
+        val zone = ZoneId.systemDefault()
+        val first = points.minOf { it.instant }.atZone(zone).toLocalDate()
+        val last = points.maxOf { it.instant }.atZone(zone).toLocalDate()
+        val date = formatExactDate(first)
+        return when {
+            points.size == 1 -> getString(R.string.raw_data_available_one_point, date)
+            first == last -> getString(R.string.raw_data_available_one_day, date)
+            else -> getString(R.string.raw_data_available_range, date, formatExactDate(last))
+        }
     }
 
     private fun useAvailableRawRange() {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -303,6 +303,8 @@
     <string name="backup_restore_timeline">Timeline sichern und wiederherstellen</string>
     <string name="raw_data_retention_explanation">Nur die neuesten, gewöhnlich bis zu 30 Tage bleiben als rohe Standortdaten erhalten. Ältere Aktivitäten werden im Timeline-Format dargestellt.</string>
     <string name="raw_data_available_range">Rohdaten verfügbar vom %1$s bis %2$s</string>
+    <string name="raw_data_available_one_day">Rohdaten verfügbar am %1$s</string>
+    <string name="raw_data_available_one_point">1 Rohdatenstandort verfügbar am %1$s</string>
     <string name="raw_data_range_conflict">Dieses Projekt verwendet Daten außerhalb der derzeit verfügbaren Rohdaten. Wähle einen gültigen Zeitraum aus.</string>
     <string name="use_available_range">Verfügbaren Zeitraum verwenden</string>
     <string name="save_preset_choice_title">Änderungen speichern</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -308,6 +308,8 @@
     <string name="backup_restore_timeline">Copia de seguridad y restauración de Timeline</string>
     <string name="raw_data_retention_explanation">Solo los datos más recientes, normalmente hasta 30 días, permanecen como ubicaciones sin procesar antes de que la actividad anterior se represente en formato Timeline.</string>
     <string name="raw_data_available_range">Datos sin procesar disponibles del %1$s al %2$s</string>
+    <string name="raw_data_available_one_day">Datos sin procesar disponibles el %1$s</string>
+    <string name="raw_data_available_one_point">1 ubicación sin procesar disponible el %1$s</string>
     <string name="raw_data_range_conflict">Este proyecto usa fechas fuera de los datos sin procesar disponibles. Elige un intervalo válido.</string>
     <string name="use_available_range">Usar intervalo disponible</string>
     <string name="save_preset_choice_title">Guardar cambios del ajuste</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -308,6 +308,8 @@
     <string name="backup_restore_timeline">Sauvegarder et restaurer Timeline</string>
     <string name="raw_data_retention_explanation">Seules les données les plus récentes, généralement jusqu’à 30 jours, restent sous forme brute avant que l’activité plus ancienne soit représentée au format Timeline.</string>
     <string name="raw_data_available_range">Données brutes disponibles du %1$s au %2$s</string>
+    <string name="raw_data_available_one_day">Données brutes disponibles le %1$s</string>
+    <string name="raw_data_available_one_point">1 position brute disponible le %1$s</string>
     <string name="raw_data_range_conflict">Ce projet utilise des dates hors des données brutes disponibles. Choisissez une plage valide.</string>
     <string name="use_available_range">Utiliser la plage disponible</string>
     <string name="save_preset_choice_title">Enregistrer les modifications</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -306,6 +306,8 @@
     <string name="backup_restore_timeline">タイムラインのバックアップと復元</string>
     <string name="raw_data_retention_explanation">通常、直近最大30日分だけが未処理の位置情報として残り、それ以前の活動はタイムライン形式で表されます。</string>
     <string name="raw_data_available_range">未処理データの期間 %1$s〜%2$s</string>
+    <string name="raw_data_available_one_day">未処理データの利用可能日: %1$s</string>
+    <string name="raw_data_available_one_point">未処理の位置情報 1 件の利用可能日: %1$s</string>
     <string name="raw_data_range_conflict">このプロジェクトの日付は現在利用できる未処理データの範囲外です。有効な期間を選択してください。</string>
     <string name="use_available_range">利用可能な期間を使用</string>
     <string name="save_preset_choice_title">プリセットの変更を保存</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -360,6 +360,8 @@
     <string name="backup_restore_timeline">타임라인 백업 및 복원</string>
     <string name="raw_data_retention_explanation">일반적으로 최근 최대 30일만 원시 위치 데이터로 남고 이전 활동은 타임라인 형식으로 표시됩니다.</string>
     <string name="raw_data_available_range">원시 데이터 사용 가능 기간 %1$s~%2$s</string>
+    <string name="raw_data_available_one_day">원시 데이터 사용 가능일: %1$s</string>
+    <string name="raw_data_available_one_point">원시 위치 1개 사용 가능일: %1$s</string>
     <string name="raw_data_range_conflict">이 프로젝트의 날짜가 현재 사용 가능한 원시 데이터 범위를 벗어납니다. 유효한 기간을 선택하세요.</string>
     <string name="use_available_range">사용 가능한 기간 적용</string>
     <string name="save_preset_choice_title">프리셋 변경 저장</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -308,6 +308,8 @@
     <string name="backup_restore_timeline">Fazer backup e restaurar a Linha do tempo</string>
     <string name="raw_data_retention_explanation">Somente os dados mais recentes, normalmente até 30 dias, permanecem como localização bruta antes que a atividade anterior seja representada no formato da Linha do tempo.</string>
     <string name="raw_data_available_range">Dados brutos disponíveis de %1$s a %2$s</string>
+    <string name="raw_data_available_one_day">Dados brutos disponíveis em %1$s</string>
+    <string name="raw_data_available_one_point">1 localização bruta disponível em %1$s</string>
     <string name="raw_data_range_conflict">Este projeto usa datas fora dos dados brutos disponíveis. Escolha um período válido.</string>
     <string name="use_available_range">Usar período disponível</string>
     <string name="save_preset_choice_title">Salvar alterações da predefinição</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -299,6 +299,8 @@
     <string name="backup_restore_timeline">备份和恢复时间轴</string>
     <string name="raw_data_retention_explanation">通常只有最近最多30天保留为原始位置数据，更早的活动会以时间轴格式表示。</string>
     <string name="raw_data_available_range">原始数据可用范围：%1$s至%2$s</string>
+    <string name="raw_data_available_one_day">原始数据可用日期：%1$s</string>
+    <string name="raw_data_available_one_point">1 个原始位置可用于 %1$s</string>
     <string name="raw_data_range_conflict">此项目使用的日期超出当前原始数据范围。请选择有效范围。</string>
     <string name="use_available_range">使用可用范围</string>
     <string name="save_preset_choice_title">保存预设更改</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -299,6 +299,8 @@
     <string name="backup_restore_timeline">備份與還原時間軸</string>
     <string name="raw_data_retention_explanation">通常只有最近最多30天會保留為原始位置資料，更早的活動會以時間軸格式呈現。</string>
     <string name="raw_data_available_range">原始資料可用範圍：%1$s至%2$s</string>
+    <string name="raw_data_available_one_day">原始資料可用日期：%1$s</string>
+    <string name="raw_data_available_one_point">1 個原始位置可用於 %1$s</string>
     <string name="raw_data_range_conflict">此專案使用的日期超出目前原始資料範圍。請選擇有效範圍。</string>
     <string name="use_available_range">使用可用範圍</string>
     <string name="save_preset_choice_title">儲存預設組合變更</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,6 +476,8 @@
     <string name="backup_restore_timeline">Backup and restore Timeline</string>
     <string name="raw_data_retention_explanation">Only the most recent, usually up to 30 days, remain as raw location data before older activity is represented in Timeline format.</string>
     <string name="raw_data_available_range">Raw data available from %1$s to %2$s</string>
+    <string name="raw_data_available_one_day">Raw data available on %1$s</string>
+    <string name="raw_data_available_one_point">1 raw location available on %1$s</string>
     <string name="raw_data_range_conflict">This project uses dates outside the raw data currently available. Choose a valid range to continue.</string>
     <string name="use_available_range">Use available range</string>
     <string name="save_preset_choice_title">Save preset changes</string>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -1243,7 +1243,10 @@ class MainActivityTest {
 
         waitUntil { activity.findViewById<View>(R.id.rawDataAvailabilityGroup).visibility == View.VISIBLE }
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.rawDataAvailabilityGroup).visibility)
-        assertTrue(activity.findViewById<TextView>(R.id.rawDataAvailabilityText).text.toString().contains("Feb"))
+        assertEquals(
+            "Raw data available from Feb 1, 2026 to Feb 5, 2026",
+            activity.findViewById<TextView>(R.id.rawDataAvailabilityText).text.toString(),
+        )
         assertEquals("Recent 5-day recap", activity.findViewById<TextView>(R.id.projectTitleInput).text.toString())
         assertEquals("Recent 5-day recap", activity.findViewById<TextView>(R.id.titleInput).text.toString())
         activity.findViewById<TextView>(R.id.ownerInput).text = "Mina"
@@ -1253,6 +1256,17 @@ class MainActivityTest {
         assertEquals("Recent 3-day recap", activity.findViewById<TextView>(R.id.projectTitleInput).text.toString())
         assertTrue(!activity.applyExactDateRange(LocalDate.parse("2026-01-30"), LocalDate.parse("2026-02-04")))
         assertEquals("Recent 3-day recap", activity.findViewById<TextView>(R.id.projectTitleInput).text.toString())
+    }
+
+    @Test
+    @Config(sdk = [35], qualifiers = "en-rUS")
+    fun rawDataAvailabilityDistinguishesOnePointAndOneDay() {
+        val activity = launchActivity()
+        val first = GeoPoint(Instant.parse("2026-02-03T12:00:00Z"), 37.5, 127.0)
+        val second = GeoPoint(Instant.parse("2026-02-03T13:00:00Z"), 37.6, 127.1)
+
+        assertEquals("1 raw location available on Feb 3, 2026", activity.rawDataAvailability(listOf(first)))
+        assertEquals("Raw data available on Feb 3, 2026", activity.rawDataAvailability(listOf(first, second)))
     }
 
     @Test

--- a/docs/release-notes-v2.4.1.md
+++ b/docs/release-notes-v2.4.1.md
@@ -1,0 +1,35 @@
+# Timeline Visualizer 2.4.1
+
+Raw Data projects now show clearer availability text for a single date or location. The web app also shows its effective Raw date range and offers explicit frame-rate controls.
+
+## 한국어
+
+이제 원시 데이터 프로젝트에서 하루 또는 위치 1개의 사용 가능 기간을 더 명확하게 표시합니다. 웹 앱에서도 실제 원시 데이터 기간을 표시하고 프레임 속도를 직접 선택할 수 있습니다.
+
+## 日本語
+
+未処理データのプロジェクトで、1 日または 1 件の位置情報をより明確に表示するようになりました。ウェブアプリでも実際の未処理データ期間を表示し、フレームレートを明示的に選択できます。
+
+## 简体中文
+
+原始数据项目现在能更清晰地显示单日或单个位置的可用信息。网页应用也会显示实际原始数据日期范围，并提供明确的帧率选项。
+
+## 繁體中文
+
+原始資料專案現在能更清楚地顯示單日或單一位置的可用資訊。網頁應用程式也會顯示實際原始資料日期範圍，並提供明確的影格率選項。
+
+## Español
+
+Los proyectos de datos sin procesar ahora muestran con más claridad la disponibilidad de un solo día o ubicación. La aplicación web también muestra su intervalo Raw efectivo y permite elegir la velocidad de fotogramas.
+
+## Français
+
+Les projets de données brutes indiquent maintenant plus clairement la disponibilité d’une seule date ou position. L’application web affiche également sa plage Raw effective et permet de choisir la fréquence d’images.
+
+## Deutsch
+
+Rohdatenprojekte zeigen die Verfügbarkeit für einen einzelnen Tag oder Standort jetzt klarer an. Die Web-App zeigt außerdem ihren effektiven Rohdatenzeitraum und bietet eine direkte Auswahl der Bildrate.
+
+## Português (Brasil)
+
+Os projetos de dados brutos agora mostram com mais clareza a disponibilidade de um único dia ou local. O app da web também exibe o período Raw efetivo e permite escolher a taxa de quadros.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `2.4.0` and version code `39`
+- Version name `2.4.1` and version code `40`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases


### PR DESCRIPTION
## Summary

- clarify the existing Android Raw Data availability line for one location and one day
- keep multi-day bounds based on the processed Raw points and reuse the existing unavailable state
- prepare version 2.4.1 with version code 40 and multilingual release notes

## Validation

- Android string resources parsed across all nine locale sets
- focused Raw Data project and formatter regression tests added
- full required checks run in CI

Addresses #145. Keep the issue open until the v2.4.1 GitHub release is published and verified.

## Distribution

GitHub release only. The Play bundle is retained as a workflow artifact and is not submitted to Closed Alpha.