### PR TITLE
Add Close-up camera mode to the web app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -132,6 +132,7 @@
             <option value="fixed" data-i18n="cameraFixed">Fixed zoom</option>
             <option value="steady" selected data-i18n="cameraSteady">Steady following</option>
             <option value="dynamic" data-i18n="cameraDynamic">Dynamic following</option>
+            <option value="close-up" data-i18n="cameraCloseUp">Close-up</option>
           </select>
         </label>
         <label>

--- a/web/src/camera.test.ts
+++ b/web/src/camera.test.ts
@@ -79,15 +79,15 @@ describe('camera track', () => {
     [35.1796, 129.0756],
   ]);
 
-  it.each<CameraMovement>(['fixed', 'steady', 'dynamic'])('%s follows the journey instead of freezing', (movement) => {
+  it.each<CameraMovement>(['fixed', 'steady', 'dynamic', 'close-up'])('%s follows the journey instead of freezing', (movement) => {
     const track = buildCameraTrack(koreanJourney, SQUARE_480, movement);
     const [startX, startY] = center(cameraViewportAt(track, 0));
     const [endX, endY] = center(cameraViewportAt(track, 1));
     expect(Math.hypot(endX - startX, endY - startY)).toBeGreaterThan(0.001);
   });
 
-  it('keeps the marker inside the stable central area', () => {
-    const track = buildCameraTrack(koreanJourney, SQUARE_480, 'dynamic');
+  it.each<CameraMovement>(['dynamic', 'close-up'])('keeps the marker inside the stable central area in %s mode', (movement) => {
+    const track = buildCameraTrack(koreanJourney, SQUARE_480, movement);
     for (let sample = 0; sample <= 40; sample += 1) {
       const progress = sample / 40;
       const viewport = cameraViewportAt(track, progress);
@@ -110,9 +110,9 @@ describe('camera track', () => {
     spans.forEach((span) => expect(span).toBeCloseTo(spans[0], 12));
   });
 
-  it('uses the short camera path and wrapped tiles across the date line', () => {
+  it.each<CameraMovement>(['dynamic', 'close-up'])('uses the short camera path and wrapped tiles across the date line in %s mode', (movement) => {
     const dateLineJourney = journey([[10, 179], [10.2, -179]]);
-    const track = buildCameraTrack(dateLineJourney, SQUARE_480, 'dynamic');
+    const track = buildCameraTrack(dateLineJourney, SQUARE_480, movement);
     const middle = cameraViewportAt(track, 0.5);
     expect(middle.maxX - middle.minX).toBeLessThan(0.05);
     const count = 2 ** middle.zoom;
@@ -143,21 +143,56 @@ describe('camera track', () => {
     expect(endX).toBeLessThan(turnX);
   });
 
-  it('smooths changing spans and stabilizes integer tile zoom', () => {
+  it.each<CameraMovement>(['dynamic', 'close-up'])('smooths changing spans and stabilizes integer tile zoom in %s mode', (movement) => {
     const changingJourney = journey([
       [37.5665, 126.9780],
       [37.5650, 126.9850],
       [35.1796, 129.0756],
       [35.1800, 129.0800],
     ]);
-    const track = buildCameraTrack(changingJourney, SQUARE_480, 'dynamic');
+    const track = buildCameraTrack(changingJourney, SQUARE_480, movement);
+    const maximumLogSpanChange = movement === 'close-up' ? 1.1 : 0.8;
     for (let index = 1; index < track.frames.length; index += 1) {
       const previous = track.frames[index - 1];
       const current = track.frames[index];
       expect(Number.isFinite(current.spanY)).toBe(true);
-      expect(Math.abs(Math.log(current.spanY / previous.spanY))).toBeLessThan(0.8);
+      expect(Math.abs(Math.log(current.spanY / previous.spanY))).toBeLessThan(maximumLogSpanChange);
       expect(Math.abs(current.zoom - previous.zoom)).toBeLessThanOrEqual(3);
     }
+  });
+
+  it('frames local travel more tightly in close-up mode than dynamic mode', () => {
+    const localJourney = journey(densify([
+      [37.5665, 126.9780],
+      [37.5200, 127.0200],
+      [37.5000, 127.0600],
+    ], 12));
+    const closeUp = cameraViewportAt(buildCameraTrack(localJourney, SQUARE_480, 'close-up'), 0.5);
+    const dynamic = cameraViewportAt(buildCameraTrack(localJourney, SQUARE_480, 'dynamic'), 0.5);
+
+    expect(closeUp.maxY - closeUp.minY).toBeLessThan(dynamic.maxY - dynamic.minY);
+  });
+
+  it('keeps both ends of a long transfer visible while close-up mode crosses it', () => {
+    const transfer = journey([
+      [37.5665, 126.9780],
+      [48.8566, 2.3522],
+    ]);
+    const viewport = cameraViewportAt(buildCameraTrack(transfer, SQUARE_480, 'close-up'), 0.5);
+
+    transfer.worldPoints.forEach((point) => {
+      expect(point.x).toBeGreaterThanOrEqual(viewport.minX);
+      expect(point.x).toBeLessThanOrEqual(viewport.maxX);
+      expect(point.y).toBeGreaterThanOrEqual(viewport.minY);
+      expect(point.y).toBeLessThanOrEqual(viewport.maxY);
+    });
+  });
+
+  it.each(FORMATS)('keeps close-up camera frames at the $width x $height aspect ratio', (size) => {
+    const track = buildCameraTrack(koreanJourney, size, 'close-up');
+    [0, 0.25, 0.5, 0.75, 1].forEach((progress) => {
+      expect(ratio(cameraViewportAt(track, progress))).toBeCloseTo(size.width / size.height, 10);
+    });
   });
 
   it.each(FORMATS)('fits the complete route below the Android-style video header at $width x $height', (size) => {

--- a/web/src/camera.ts
+++ b/web/src/camera.ts
@@ -67,6 +67,17 @@ const MOVEMENT_PROFILES: Record<CameraMovement, CameraMovementProfile> = {
     legAware: true,
     fixedZoom: false,
   },
+  'close-up': {
+    contextFraction: 0.035,
+    minimumContextKm: 15,
+    maximumContextKm: 120,
+    padding: 1.7,
+    minimumViewportSpan: 0.00030,
+    zoomOutAlpha: 0.30,
+    zoomInAlpha: 0.075,
+    legAware: true,
+    fixedZoom: false,
+  },
 };
 
 const CAMERA_TRACK_SAMPLES = 480;

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -144,6 +144,7 @@ export interface Strings {
   cameraFixed: string;
   cameraSteady: string;
   cameraDynamic: string;
+  cameraCloseUp: string;
   videoFormatLabel: string;
   formatSquare480: string;
   formatSquare720: string;

--- a/web/src/locales/de.ts
+++ b/web/src/locales/de.ts
@@ -74,6 +74,7 @@ export const de: Strings = {
   cameraFixed: 'Fester Zoom',
   cameraSteady: 'Stetiges Folgen',
   cameraDynamic: 'Dynamisches Folgen',
+  cameraCloseUp: 'Nah',
   videoFormatLabel: 'Videoformat',
   formatSquare480: 'Quadratisch · 480p',
   formatSquare720: 'Quadratisch · 720p',

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -74,6 +74,7 @@ export const en: Strings = {
   cameraFixed: 'Fixed zoom',
   cameraSteady: 'Steady following',
   cameraDynamic: 'Dynamic following',
+  cameraCloseUp: 'Close-up',
   videoFormatLabel: 'Video format',
   formatSquare480: 'Square · 480p',
   formatSquare720: 'Square · 720p',

--- a/web/src/locales/es.ts
+++ b/web/src/locales/es.ts
@@ -76,6 +76,7 @@ export const es: Strings = {
   cameraFixed: 'Zoom fijo',
   cameraSteady: 'Seguimiento estable',
   cameraDynamic: 'Seguimiento dinámico',
+  cameraCloseUp: 'Cercano',
   videoFormatLabel: 'Formato de vídeo',
   formatSquare480: 'Cuadrado · 480p',
   formatSquare720: 'Cuadrado · 720p',

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -76,6 +76,7 @@ export const fr: Strings = {
   cameraFixed: 'Zoom fixe',
   cameraSteady: 'Suivi fluide',
   cameraDynamic: 'Suivi dynamique',
+  cameraCloseUp: 'Rapproché',
   videoFormatLabel: 'Format vidéo',
   formatSquare480: 'Carré · 480p',
   formatSquare720: 'Carré · 720p',

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -73,6 +73,7 @@ export const ja: Strings = {
   cameraFixed: '固定ズーム',
   cameraSteady: '安定追従',
   cameraDynamic: 'ダイナミック追従',
+  cameraCloseUp: 'クローズアップ',
   videoFormatLabel: '動画形式',
   formatSquare480: '正方形 · 480p',
   formatSquare720: '正方形 · 720p',

--- a/web/src/locales/ko.ts
+++ b/web/src/locales/ko.ts
@@ -75,6 +75,7 @@ export const ko: Strings = {
   cameraFixed: '고정 줌',
   cameraSteady: '안정적 따라가기',
   cameraDynamic: '역동적 따라가기',
+  cameraCloseUp: '근접',
   videoFormatLabel: '영상 형식',
   formatSquare480: '정사각형 · 480p',
   formatSquare720: '정사각형 · 720p',

--- a/web/src/locales/pt-BR.ts
+++ b/web/src/locales/pt-BR.ts
@@ -76,6 +76,7 @@ export const ptBR: Strings = {
   cameraFixed: 'Zoom fixo',
   cameraSteady: 'Acompanhamento estável',
   cameraDynamic: 'Acompanhamento dinâmico',
+  cameraCloseUp: 'Próximo',
   videoFormatLabel: 'Formato de vídeo',
   formatSquare480: 'Quadrado · 480p',
   formatSquare720: 'Quadrado · 720p',

--- a/web/src/locales/zh-CN.ts
+++ b/web/src/locales/zh-CN.ts
@@ -75,6 +75,7 @@ export const zhCN: Strings = {
   cameraFixed: '固定缩放',
   cameraSteady: '平稳跟随',
   cameraDynamic: '动态跟随',
+  cameraCloseUp: '近距离',
   videoFormatLabel: '视频格式',
   formatSquare480: '正方形 · 480p',
   formatSquare720: '正方形 · 720p',

--- a/web/src/locales/zh-TW.ts
+++ b/web/src/locales/zh-TW.ts
@@ -70,6 +70,7 @@ export const zhTW: Strings = {
   cameraFixed: '固定縮放',
   cameraSteady: '穩定跟隨',
   cameraDynamic: '動態跟隨',
+  cameraCloseUp: '近距離',
   videoFormatLabel: '影片格式',
   formatSquare480: '正方形 · 480p',
   formatSquare720: '正方形 · 720p',

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,7 +29,7 @@ export interface Viewport {
   zoom: number;
 }
 
-export type CameraMovement = 'fixed' | 'steady' | 'dynamic';
+export type CameraMovement = 'fixed' | 'steady' | 'dynamic' | 'close-up';
 
 export interface CameraFrame {
   centerX: number;


### PR DESCRIPTION
## Summary

- add the Android Close-up camera profile to the web camera engine
- expose Close-up in the web selector with matching translations for all supported locales
- cover tight local framing, long transfers, date-line wrapping, marker containment, smoothing, and all export aspects

## Validation

- `pnpm --dir web test` with 288 passing tests
- `pnpm --dir web typecheck`
- `pnpm --dir web build`
- `python -m pytest` with 53 passing tests
- fictional sample preview and 10-second 480x480 MP4 export
- desktop and 390 px browser checks with no horizontal overflow or console errors