### PR TITLE
Add distance-unit selection to the web app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -62,6 +62,14 @@
           </select>
         </label>
         <p id="language-warning" class="status hidden" role="status"></p>
+        <label id="distance-unit-field">
+          <span data-i18n="distanceUnitLabel">Distance unit</span>
+          <select id="distance-unit">
+            <option value="automatic" selected>Automatic · Kilometers</option>
+            <option value="kilometers" data-i18n="distanceUnitKilometers">Kilometers</option>
+            <option value="miles" data-i18n="distanceUnitMiles">Miles</option>
+          </select>
+        </label>
       </section>
 
       <section id="settings-card" class="card hidden" aria-labelledby="settings-heading">

--- a/web/src/distance-unit.test.ts
+++ b/web/src/distance-unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  automaticDistanceUnit,
+  convertDistanceFromKilometers,
+  isDistanceUnitPreference,
+  resolveDistanceUnit,
+} from './distance-unit';
+
+describe('distance units', () => {
+  it.each(['en-US', 'en-GB', 'my-MM', 'en-LR'])('uses miles for %s', (locale) => {
+    expect(automaticDistanceUnit([locale])).toBe('miles');
+  });
+
+  it.each(['ko-KR', 'ja-JP', 'de-DE', 'fr-CA'])('uses kilometers for %s', (locale) => {
+    expect(automaticDistanceUnit([locale])).toBe('kilometers');
+  });
+
+  it('maximizes a language-only locale and skips invalid locale tags', () => {
+    expect(automaticDistanceUnit(['not_a_locale', 'en'])).toBe('miles');
+    expect(automaticDistanceUnit(['not_a_locale'])).toBe('kilometers');
+  });
+
+  it('keeps explicit preferences independent of the browser locale', () => {
+    expect(resolveDistanceUnit('kilometers', ['en-US'])).toBe('kilometers');
+    expect(resolveDistanceUnit('miles', ['ko-KR'])).toBe('miles');
+  });
+
+  it('recognizes only supported stored preferences', () => {
+    expect(isDistanceUnitPreference('automatic')).toBe(true);
+    expect(isDistanceUnitPreference('kilometers')).toBe(true);
+    expect(isDistanceUnitPreference('miles')).toBe(true);
+    expect(isDistanceUnitPreference('mi')).toBe(false);
+  });
+
+  it('converts display values without changing the kilometer source value', () => {
+    expect(convertDistanceFromKilometers(10, 'kilometers')).toBe(10);
+    expect(convertDistanceFromKilometers(10, 'miles')).toBeCloseTo(6.21371192237334, 12);
+  });
+});

--- a/web/src/distance-unit.ts
+++ b/web/src/distance-unit.ts
@@ -1,0 +1,63 @@
+export type DistanceUnit = 'kilometers' | 'miles';
+export type DistanceUnitPreference = 'automatic' | DistanceUnit;
+
+export const DISTANCE_UNIT_STORAGE_KEY = 'timeline-visualizer.distance-unit';
+
+const MILE_REGIONS = new Set(['GB', 'LR', 'MM', 'US']);
+
+export function isDistanceUnitPreference(value: string): value is DistanceUnitPreference {
+  return value === 'automatic' || value === 'kilometers' || value === 'miles';
+}
+
+function localeRegion(localeTag: string): string | undefined {
+  try {
+    return new Intl.Locale(localeTag).maximize().region;
+  } catch {
+    return undefined;
+  }
+}
+
+export function automaticDistanceUnit(preferredLocales: readonly string[]): DistanceUnit {
+  for (const locale of preferredLocales) {
+    const region = localeRegion(locale);
+    if (region !== undefined) return MILE_REGIONS.has(region.toUpperCase()) ? 'miles' : 'kilometers';
+  }
+  return 'kilometers';
+}
+
+export function resolveDistanceUnit(
+  preference: DistanceUnitPreference,
+  preferredLocales: readonly string[],
+): DistanceUnit {
+  return preference === 'automatic' ? automaticDistanceUnit(preferredLocales) : preference;
+}
+
+export function convertDistanceFromKilometers(kilometers: number, unit: DistanceUnit): number {
+  return unit === 'miles' ? kilometers * 0.621371192237334 : kilometers;
+}
+
+function storage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readDistanceUnitPreference(): DistanceUnitPreference {
+  try {
+    const stored = storage()?.getItem(DISTANCE_UNIT_STORAGE_KEY);
+    if (stored !== null && stored !== undefined && isDistanceUnitPreference(stored)) return stored;
+  } catch {
+    // A blocked storage API has the same behavior as an unset preference.
+  }
+  return 'automatic';
+}
+
+export function writeDistanceUnitPreference(preference: DistanceUnitPreference): void {
+  try {
+    storage()?.setItem(DISTANCE_UNIT_STORAGE_KEY, preference);
+  } catch {
+    // Private browsing can reject writes. The preference still applies to this page session.
+  }
+}

--- a/web/src/i18n.test.ts
+++ b/web/src/i18n.test.ts
@@ -269,10 +269,11 @@ describe('formatting', () => {
   });
 
   it('formats a distance with the locale unit pattern', () => {
-    const options = { style: 'unit', unit: 'kilometer', maximumFractionDigits: 0 } as const;
-    expect(createI18n('fr').formatDistanceKm(12345))
-      .toBe(new Intl.NumberFormat('fr', options).format(12345));
-    expect(createI18n('en').formatDistanceKm(12345.4)).toBe('12,345 km');
+    const kilometers = { style: 'unit', unit: 'kilometer', maximumFractionDigits: 0 } as const;
+    expect(createI18n('fr').formatDistance(12345, 'kilometers'))
+      .toBe(new Intl.NumberFormat('fr', kilometers).format(12345));
+    expect(createI18n('en').formatDistance(12345.4, 'kilometers')).toBe('12,345 km');
+    expect(createI18n('en').formatDistance(12345.4, 'miles')).toBe('7,671 mi');
   });
 
   it('formats a percent with the locale spacing rule', () => {
@@ -496,6 +497,14 @@ describe('index.html i18n keys', () => {
     }
   });
 
+  it('offers the three Android distance-unit preferences with Automatic selected', () => {
+    const block = /<select id="distance-unit">([\s\S]*?)<\/select>/.exec(html);
+    expect(block).not.toBeNull();
+    const options = [...(block?.[1] ?? '').matchAll(/<option value="([^"]*)"([^>]*)>/g)];
+    expect(options.map((option) => option[1])).toEqual(['automatic', 'kilometers', 'miles']);
+    expect(options[0][2]).toContain('selected');
+  });
+
   it('renders exactly the text the markup already carries', () => {
     // The HTML text is the English source and the catalog is what replaces it, so the two
     // drifting apart would change what an English user sees between first paint and
@@ -542,12 +551,12 @@ describe('English rendering', () => {
     expect(en.join(en.t('summaryNoMovement', { count: 1234 }), ''))
       .toBe('1,234 location points · No movement');
     expect(en.join(
-      en.t('summaryDistanceAbout', { count: 1234, distance: en.formatDistanceKm(12345.4) }),
+      en.t('summaryDistanceAbout', { count: 1234, distance: en.formatDistance(12345.4, 'kilometers') }),
       '',
       en.t('summaryOutliersIgnored', { count: 2 }),
     )).toBe('1,234 location points · About 12,345 km · 2 suspicious locations ignored');
     expect(en.join(
-      en.t('summaryDistanceEstimated', { count: 40, distance: en.formatDistanceKm(3) }),
+      en.t('summaryDistanceEstimated', { count: 40, distance: en.formatDistance(3, 'kilometers') }),
       en.t('summaryRawRejected', { count: 2000 }),
     )).toBe('40 location points · Estimated 3 km · 2,000 noisy or inaccurate points ignored');
   });

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -7,6 +7,8 @@ import { ko } from './locales/ko';
 import { ptBR } from './locales/pt-BR';
 import { zhCN } from './locales/zh-CN';
 import { zhTW } from './locales/zh-TW';
+import { convertDistanceFromKilometers } from './distance-unit';
+import type { DistanceUnit } from './distance-unit';
 
 export type LocaleTag =
   | 'en'
@@ -77,7 +79,7 @@ export type PluralEntry =
  *   'Add to Home Screen' and 'Files app' are official Google Maps and iOS labels. Use the
  *   official localized label for each platform, never a literal translation.
  * - Frozen tokens inside translated sentences: Timeline.json, semanticSegments, rawSignals,
- *   CARTO, OpenStreetMap, Google Maps, Safari, H.264, MP4, MB, km, iPhone.
+ *   CARTO, OpenStreetMap, Google Maps, Safari, H.264, MP4, MB, km, mi, iPhone.
  */
 export interface Strings {
   // --- app shell and document metadata ---
@@ -112,6 +114,12 @@ export interface Strings {
   languageSystemDefault: string;
   languageLockedExporting: string;
   languageLockedPreparing: string;
+  distanceUnitLabel: string;
+  distanceUnitAutomatic: string;
+  distanceUnitKilometers: string;
+  distanceUnitMiles: string;
+  /** {automatic} {resolved} */
+  distanceUnitAutomaticResolved: string;
 
   // --- settings card ---
   settingsTitle: string;
@@ -406,7 +414,7 @@ export interface I18n {
   /** `count` is required by the type system for plural keys and optional for text keys. */
   t<K extends StringKey>(key: K, ...args: TranslateArgs<K>): string;
   formatNumber(value: number, options?: Intl.NumberFormatOptions): string;
-  formatDistanceKm(kilometers: number): string;
+  formatDistance(kilometers: number, unit: DistanceUnit): string;
   formatPercent(fraction: number): string;
   formatMonth(date: Date): string;
   formatMediumDate(date: Date): string;
@@ -447,11 +455,18 @@ export function createI18n(locale: LocaleTag, formatLocale: string = locale): I1
     }
     return format;
   };
-  const distanceFormat = new Intl.NumberFormat(formatLocale, {
-    style: 'unit',
-    unit: 'kilometer',
-    maximumFractionDigits: 0,
-  });
+  const distanceFormats: Readonly<Record<DistanceUnit, Intl.NumberFormat>> = {
+    kilometers: new Intl.NumberFormat(formatLocale, {
+      style: 'unit',
+      unit: 'kilometer',
+      maximumFractionDigits: 0,
+    }),
+    miles: new Intl.NumberFormat(formatLocale, {
+      style: 'unit',
+      unit: 'mile',
+      maximumFractionDigits: 0,
+    }),
+  };
   const percentFormat = new Intl.NumberFormat(formatLocale, {
     style: 'percent',
     maximumFractionDigits: 0,
@@ -478,8 +493,10 @@ export function createI18n(locale: LocaleTag, formatLocale: string = locale): I1
     strings,
     t: translate as I18n['t'],
     formatNumber,
-    // Rounded before formatting so the digits match the previous Math.round exactly.
-    formatDistanceKm: (kilometers) => distanceFormat.format(Math.round(kilometers)),
+    // Rounded before formatting so the digits retain the previous Math.round behavior.
+    formatDistance: (kilometers, unit) => distanceFormats[unit].format(
+      Math.round(convertDistanceFromKilometers(kilometers, unit)),
+    ),
     // Rounded to whole percent first: Intl rounds the shortest decimal of the double while
     // Math.round rounds the double itself, and the two disagree on values such as 0.575.
     formatPercent: (fraction) => percentFormat.format(Math.round(fraction * 100) / 100),

--- a/web/src/locales/de.ts
+++ b/web/src/locales/de.ts
@@ -44,6 +44,11 @@ export const de: Strings = {
   languageSystemDefault: 'Systemstandard',
   languageLockedExporting: 'Die Sprache kann nicht geändert werden, während ein Video erstellt wird.',
   languageLockedPreparing: 'Die Sprache kann nicht geändert werden, während die Karte vorbereitet wird.',
+  distanceUnitLabel: 'Entfernungseinheit',
+  distanceUnitAutomatic: 'Automatisch',
+  distanceUnitKilometers: 'Kilometer',
+  distanceUnitMiles: 'Meilen',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: 'Ihre Reise erstellen',
   rawSignalsToggle: 'Unverarbeitete Standortdaten verwenden',

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -44,6 +44,11 @@ export const en: Strings = {
   languageSystemDefault: 'System default',
   languageLockedExporting: 'Language cannot change while a video is being created.',
   languageLockedPreparing: 'Language cannot change while the map is being prepared.',
+  distanceUnitLabel: 'Distance unit',
+  distanceUnitAutomatic: 'Automatic',
+  distanceUnitKilometers: 'Kilometers',
+  distanceUnitMiles: 'Miles',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: 'Create your journey',
   rawSignalsToggle: 'Use raw location data',

--- a/web/src/locales/es.ts
+++ b/web/src/locales/es.ts
@@ -45,6 +45,11 @@ export const es: Strings = {
   languageSystemDefault: 'Predeterminado del sistema',
   languageLockedExporting: 'No se puede cambiar el idioma mientras se crea un vídeo.',
   languageLockedPreparing: 'No se puede cambiar el idioma mientras se prepara el mapa.',
+  distanceUnitLabel: 'Unidad de distancia',
+  distanceUnitAutomatic: 'Automático',
+  distanceUnitKilometers: 'Kilómetros',
+  distanceUnitMiles: 'Millas',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: 'Crea tu viaje',
   rawSignalsToggle: 'Usar datos de ubicación sin procesar',

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -45,6 +45,11 @@ export const fr: Strings = {
   languageSystemDefault: 'Valeur par défaut du système',
   languageLockedExporting: 'La langue ne peut pas être modifiée pendant la création d’une vidéo.',
   languageLockedPreparing: 'La langue ne peut pas être modifiée pendant la préparation de la carte.',
+  distanceUnitLabel: 'Unité de distance',
+  distanceUnitAutomatic: 'Automatique',
+  distanceUnitKilometers: 'Kilomètres',
+  distanceUnitMiles: 'Miles',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: 'Créez votre voyage',
   rawSignalsToggle: 'Utiliser les données de localisation brutes',

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -44,6 +44,11 @@ export const ja: Strings = {
   languageSystemDefault: 'システムのデフォルト',
   languageLockedExporting: '動画の作成中は言語を変更できません。',
   languageLockedPreparing: '地図の準備中は言語を変更できません。',
+  distanceUnitLabel: '距離の単位',
+  distanceUnitAutomatic: '自動',
+  distanceUnitKilometers: 'キロメートル',
+  distanceUnitMiles: 'マイル',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: '移動経路を作成',
   rawSignalsToggle: '未処理の位置情報を使用',

--- a/web/src/locales/ko.ts
+++ b/web/src/locales/ko.ts
@@ -46,6 +46,11 @@ export const ko: Strings = {
   languageSystemDefault: '시스템 기본값',
   languageLockedExporting: '영상을 만드는 중에는 언어를 변경할 수 없습니다.',
   languageLockedPreparing: '지도를 준비하는 중에는 언어를 변경할 수 없습니다.',
+  distanceUnitLabel: '거리 단위',
+  distanceUnitAutomatic: '자동',
+  distanceUnitKilometers: '킬로미터',
+  distanceUnitMiles: '마일',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: '이동 경로 만들기',
   rawSignalsToggle: '원시 위치 데이터 사용',

--- a/web/src/locales/pt-BR.ts
+++ b/web/src/locales/pt-BR.ts
@@ -45,6 +45,11 @@ export const ptBR: Strings = {
   languageSystemDefault: 'Padrão do sistema',
   languageLockedExporting: 'O idioma não pode ser alterado enquanto um vídeo está sendo criado.',
   languageLockedPreparing: 'O idioma não pode ser alterado enquanto o mapa está sendo preparado.',
+  distanceUnitLabel: 'Unidade de distância',
+  distanceUnitAutomatic: 'Automático',
+  distanceUnitKilometers: 'Quilômetros',
+  distanceUnitMiles: 'Milhas',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: 'Crie sua jornada',
   rawSignalsToggle: 'Usar dados de localização brutos',

--- a/web/src/locales/zh-CN.ts
+++ b/web/src/locales/zh-CN.ts
@@ -46,6 +46,11 @@ export const zhCN: Strings = {
   languageSystemDefault: '系统默认',
   languageLockedExporting: '创建视频期间无法更改语言。',
   languageLockedPreparing: '准备地图期间无法更改语言。',
+  distanceUnitLabel: '距离单位',
+  distanceUnitAutomatic: '自动',
+  distanceUnitKilometers: '公里',
+  distanceUnitMiles: '英里',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: '创建您的旅程',
   rawSignalsToggle: '使用原始位置数据',

--- a/web/src/locales/zh-TW.ts
+++ b/web/src/locales/zh-TW.ts
@@ -41,6 +41,11 @@ export const zhTW: Strings = {
   languageSystemDefault: '系統預設值',
   languageLockedExporting: '建立影片時無法變更語言。',
   languageLockedPreparing: '準備地圖時無法變更語言。',
+  distanceUnitLabel: '距離單位',
+  distanceUnitAutomatic: '自動',
+  distanceUnitKilometers: '公里',
+  distanceUnitMiles: '英里',
+  distanceUnitAutomaticResolved: '{automatic} · {resolved}',
 
   settingsTitle: '建立您的行程',
   rawSignalsToggle: '使用原始定位資料',

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -3,6 +3,12 @@ import { frameAtElapsedSeconds, totalDurationSeconds } from './animation';
 import { AppError } from './errors';
 import { cumulativeDistances } from './geo';
 import {
+  isDistanceUnitPreference,
+  readDistanceUnitPreference,
+  resolveDistanceUnit,
+  writeDistanceUnitPreference,
+} from './distance-unit';
+import {
   activeLocale,
   createI18n,
   formattingLocale,
@@ -26,6 +32,7 @@ import {
   TimelineParseError,
 } from './timeline';
 import type { I18n, LanguagePreference, TextKey } from './i18n';
+import type { DistanceUnit, DistanceUnitPreference } from './distance-unit';
 import type { LocationFilterMode } from './outlier';
 import type { OverlayText } from './renderer';
 import type { RawSignalPoint, RawSignalProcessingResult, TimelineParseReason } from './timeline';
@@ -63,6 +70,7 @@ const fileStatus = element<HTMLParagraphElement>('file-status');
 const compatibilityStatus = element<HTMLParagraphElement>('compatibility-status');
 const languageSelect = element<HTMLSelectElement>('app-language');
 const languageWarning = element<HTMLParagraphElement>('language-warning');
+const distanceUnitSelect = element<HTMLSelectElement>('distance-unit');
 const settingsCard = element<HTMLElement>('settings-card');
 const exactDateToggle = element<HTMLInputElement>('exact-date-toggle');
 const periodControls = element<HTMLElement>('period-controls');
@@ -130,6 +138,11 @@ function buildI18n(preference: LanguagePreference): I18n {
 
 let languagePreference: LanguagePreference = readLanguagePreference();
 let i18n: I18n = buildI18n(languagePreference);
+let distanceUnitPreference: DistanceUnitPreference = readDistanceUnitPreference();
+
+function currentDistanceUnit(): DistanceUnit {
+  return resolveDistanceUnit(distanceUnitPreference, browserLanguages());
+}
 
 /** Where the loaded points came from. The sample has no filename, so it carries a catalog key. */
 interface TimelineSource {
@@ -382,9 +395,13 @@ function currentPeriodLabel(): string {
 
 /** The renderer holds no copy, so the title fallback is resolved here against the catalog. */
 function overlayText(): OverlayText {
+  const unit = currentDistanceUnit();
+  const exportI18n = i18n;
   return {
     title: titleInput.value.trim() || i18n.t('defaultVideoTitle'),
     periodLabel: currentPeriodLabel(),
+    separator: i18n.strings.listSeparator,
+    formatDistance: (kilometers) => exportI18n.formatDistance(kilometers, unit),
   };
 }
 
@@ -627,7 +644,7 @@ function renderSelection(): void {
     selectionSummary.textContent = i18n.join(
       i18n.t(rawSignalsToggle.checked ? 'summaryDistanceEstimated' : 'summaryDistanceAbout', {
         count: points.length,
-        distance: i18n.formatDistanceKm(distanceKm),
+        distance: i18n.formatDistance(distanceKm, currentDistanceUnit()),
       }),
       rejected,
       outlierNote,
@@ -689,6 +706,7 @@ function requireMapConsent(): boolean {
 function renderLocalizedText(): void {
   applyStrings(document, i18n);
   syncDocumentLang(i18n);
+  renderDistanceUnitOptions();
   renderFrameRateOptions();
   renderCompatibilityStatus();
   renderFileStatus();
@@ -696,6 +714,28 @@ function renderLocalizedText(): void {
   renderErrorMessage();
   renderSettingsError();
   updateLanguageAvailability();
+}
+
+function renderDistanceUnitOptions(): void {
+  const automaticOption = distanceUnitSelect.querySelector<HTMLOptionElement>('option[value="automatic"]');
+  if (!automaticOption) throw new Error('Missing automatic distance unit option');
+  const resolvedKey = currentDistanceUnit() === 'miles' ? 'distanceUnitMiles' : 'distanceUnitKilometers';
+  automaticOption.textContent = i18n.t('distanceUnitAutomaticResolved', {
+    automatic: i18n.t('distanceUnitAutomatic'),
+    resolved: i18n.t(resolvedKey),
+  });
+}
+
+function onDistanceUnitChange(): void {
+  const value = distanceUnitSelect.value;
+  if (!isDistanceUnitPreference(value)) return;
+  distanceUnitPreference = value;
+  writeDistanceUnitPreference(distanceUnitPreference);
+  stopPreview();
+  if (!settingsCard.classList.contains('hidden')) renderSelection();
+  if (prepared && lastPreviewFrame && !previewCard.classList.contains('hidden')) {
+    drawFrame(canvas, prepared, lastPreviewFrame, overlayText());
+  }
 }
 
 /**
@@ -852,6 +892,7 @@ endDateInput.addEventListener('change', updateSelection);
 durationSelect.addEventListener('change', updateSelection);
 cameraMovementSelect.addEventListener('change', updateSelection);
 languageSelect.addEventListener('change', onLanguageChange);
+distanceUnitSelect.addEventListener('change', onDistanceUnitChange);
 formatSelect.addEventListener('change', () => {
   stopPreview();
   renderFrameRateOptions();
@@ -1072,6 +1113,7 @@ function applyFormatSupport(support: VideoFormatSupport): void {
 // Before anything else touches the DOM: the HTML ships the English source text so a failed
 // script still renders a usable page, and this replaces it with the active catalog.
 languageSelect.value = languagePreference;
+distanceUnitSelect.value = distanceUnitPreference;
 renderLocalizedText();
 // Safari restores form control values on reload and on bfcache restore without firing
 // change, so the canvas has to be synced to the selected format before anything is drawn.

--- a/web/src/renderer.test.ts
+++ b/web/src/renderer.test.ts
@@ -158,7 +158,12 @@ function splitFontSize(value: unknown): { size: number; rest: string } {
 
 function render(canvasSize: RenderSize, journey: PreparedJourney, frame: TimelineFrame): RecordedCall[] {
   const { canvas, calls } = recordingCanvas(canvasSize.width, canvasSize.height);
-  drawFrame(canvas, journey, frame, { title: 'Seoul to Busan', periodLabel: 'March 2026' });
+  drawFrame(canvas, journey, frame, {
+    title: 'Seoul to Busan',
+    periodLabel: 'March 2026',
+    separator: ' · ',
+    formatDistance: (kilometers) => `${Math.round(kilometers)} km`,
+  });
   return calls;
 }
 
@@ -427,10 +432,13 @@ describe('map attribution', () => {
     drawFrame(canvas, preparedAt(FORMATS[0]), { journeyProgress: 0.5, outroProgress: 0 }, {
       title: 'Seoul to Busan',
       periodLabel: 'March 2026',
+      separator: ' · ',
+      formatDistance: (kilometers) => `${Math.round(kilometers * 0.621371192237334)} mi`,
     });
     const drawn = calls.filter((call) => call.method === 'fillText').map((call) => call.args[0]);
     expect(drawn).toContain(MAP_ATTRIBUTION);
     expect(drawn).toContain('Seoul to Busan');
-    expect(drawn).toContain('March 2026');
+    const halfwayMiles = Math.round(preparedAt(FORMATS[0]).totalDistanceKm * 0.5 * 0.621371192237334);
+    expect(drawn).toContain(`March 2026 · ${halfwayMiles} mi`);
   });
 });

--- a/web/src/renderer.ts
+++ b/web/src/renderer.ts
@@ -34,6 +34,8 @@ export interface OverlayText {
   /** Already resolved and guaranteed non-empty by the caller. */
   readonly title: string;
   readonly periodLabel: string;
+  readonly separator: string;
+  readonly formatDistance: (kilometers: number) => string;
 }
 
 /**
@@ -395,7 +397,13 @@ export function drawFrame(
   context.fillText(text.title, card.centerX, 72 * scale, card.width - 36 * scale);
   context.fillStyle = '#5c4b52';
   context.font = `${20 * scale}px -apple-system, BlinkMacSystemFont, sans-serif`;
-  context.fillText(text.periodLabel, card.centerX, 108 * scale);
+  const distanceLabel = text.formatDistance(currentDistance);
+  context.fillText(
+    `${text.periodLabel}${text.separator}${distanceLabel}`,
+    card.centerX,
+    108 * scale,
+    card.width - 36 * scale,
+  );
 
   context.textAlign = 'right';
   context.fillStyle = 'rgba(36, 25, 29, 0.78)';

--- a/web/src/video.test.ts
+++ b/web/src/video.test.ts
@@ -275,7 +275,12 @@ describe('createJourneyMp4', () => {
   const canvas = { width: format.width, height: format.height } as HTMLCanvasElement;
   const options = {
     durationSeconds: 1,
-    overlay: { title: 'Trip', periodLabel: 'March 2026' },
+    overlay: {
+      title: 'Trip',
+      periodLabel: 'March 2026',
+      separator: ' · ',
+      formatDistance: (kilometers: number) => `${Math.round(kilometers)} km`,
+    },
     format,
   };
 


### PR DESCRIPTION
## Summary

- add persistent Automatic, Kilometers, and Miles choices to the web app
- resolve Automatic from the browser region using the same mile-region policy as Android
- convert selection summaries and animated video distance while keeping calculations in kilometers
- add Android-matched translations for all nine supported locales

## Validation

- `pnpm --dir web test` with 301 passing tests
- `pnpm --dir web typecheck`
- `pnpm --dir web build`
- `python -m pytest` with 53 passing tests
- verified Automatic, kilometer, and mile summaries with the fictional sample
- verified persisted Miles selection, changing mile overlay, and a playable 10-second 480x480 MP4
- verified Korean labels and 390 px layout with no overflow or console warnings