### PR TITLE
Document web distance units and Close-up mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ in Safari. There is no app to install and no Timeline file is uploaded.
 1. In Google Maps, open **profile picture → Settings → Personal content →
    Export Timeline data** and save `Timeline.json` in Files.
 2. Return to the web app and select **Choose Timeline.json**.
-3. Choose a month range or exact dates, select the camera movement, and confirm
-   the map privacy notice.
+3. Choose a month range or exact dates, select the distance unit and camera
+   movement, and confirm the map privacy notice.
 4. Preview the journey, then select **Create MP4**.
 5. Play, share, or download the finished video.
 

--- a/web/README.md
+++ b/web/README.md
@@ -56,8 +56,11 @@ The current implementation supports the complete private browser path.
 2. Read absolute path timestamps or current minute offsets from segment start.
    When timezone data is absent, preserve the exported route order and recorded
    calendar dates so date-line travel is not reordered by the browser timezone.
-3. Choose a month range or exact dates, title, and duration.
-4. Choose Fixed zoom, Steady following, or Dynamic following camera movement.
+3. Choose a month range or exact dates, title, duration, and distance unit.
+   Distance units can follow the browser region automatically or be set to
+   Kilometers or Miles, and the selection applies to summaries and video text.
+4. Choose Fixed zoom, Steady following, Dynamic following, or Close-up camera
+   movement.
 5. Choose a video format: square 480p, 720p, or 1080p, portrait 1080x1920, or
    landscape 1920x1080. The camera, map tiles, and overlay follow the selected
    aspect ratio.


### PR DESCRIPTION
## Summary

- add distance-unit selection to the iPhone web workflow
- document Automatic, Kilometers, and Miles behavior
- add Close-up to the current web camera modes

## Validation

- `git diff --check`
- verified the documented labels against the live web implementation

Related to #91. The original Android request remains closed; this records the later web parity work from #170.