### PR TITLE
Realign the desktop CLI with the Android renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 - Embed the resolved video title in exported MP4 metadata for media players and galleries.
+- Decode current preset tokens in the desktop CLI so links shared from the Android app apply their camera settings and video duration.
+- Reject a preset token whose duration falls outside the supported 10 to 300 second range instead of accepting it.
+- Match the Android transfer-arrival framing floor in the desktop CLI instead of clamping short arrival legs to 15 km.
+- Give desktop map tile requests a timeout and retry a transient failure once.
+- Reuse a placeholder for a map tile that already failed instead of repeating the request on every frame.
+- Stop the desktop export with a typed error when too many map tiles are missing rather than writing a video with blank areas.
+- Remove the gentle long-trip compression option from the desktop CLI, matching the Android migration of that setting to balanced.
 
 ## 2.2.13
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,3 +1,4 @@
+import visualizer
 from visualizer import (
     build_argument_parser,
     build_camera_track,
@@ -6,6 +7,7 @@ from visualizer import (
     ease_in_out_cubic,
     ease_out_cubic,
     latlon_to_meters,
+    raw_camera_sample,
 )
 
 
@@ -111,3 +113,42 @@ def test_outro_easing_bounds():
     assert ease_in_out_cubic(1.0) == 1.0
     assert 0.0 < ease_out_cubic(0.5) <= 1.0
     assert 0.0 < ease_in_out_cubic(0.5) <= 1.0
+
+
+def arrival_span(local_leg_km):
+    """Camera span while arriving at a local leg of the given length after a long transfer."""
+    cumulative = [0.0, 2.5, 5.0, 500.0, 500.0 + local_leg_km / 2, 500.0 + local_leg_km]
+    lats = [37.50, 37.52, 37.54, 13.15, 13.16, 13.17]
+    lons = [127.00, 127.02, 127.04, 123.75, 123.76, 123.77]
+    projected = [latlon_to_meters(lat, lon) for lat, lon in zip(lats, lons)]
+    xs = [point[0] for point in projected]
+    ys = [point[1] for point in projected]
+    legs = build_legs(cumulative)
+    assert legs[1][2], 'the middle leg must be detected as a transfer'
+    assert not legs[2][2], 'the arrival leg must be local'
+    # 470 km sits past EPISODE_ARRIVAL_ZOOM_START_FRACTION of the transfer leg,
+    # so the arrival blend is active.
+    return raw_camera_sample(
+        cumulative, xs, ys, lats, lons, 470.0, 'close_up', legs, local_framing='balanced',
+    )[3]
+
+
+def test_short_arrival_legs_are_not_flattened_to_one_span():
+    """The arrival blend must follow the real leg length.
+
+    A floor above ordinary city distances would clamp both of these to the same
+    value and erase the difference, which is what MIN_CONTEXT_KM = 15.0 did while
+    TimelinePainter.kt used 0.001.
+    """
+    tight = arrival_span(3.0)
+    loose = arrival_span(12.0)
+
+    assert tight < loose
+
+
+def test_log_floor_stays_below_real_leg_lengths():
+    """LOG_FLOOR_KM only guards log(0); it must never shape framing."""
+    assert visualizer.LOG_FLOOR_KM == 0.001
+    assert visualizer.LOG_FLOOR_KM < min(
+        movement['minimum_context_km'] for movement in visualizer.CAMERA_MOVEMENTS.values()
+    )

--- a/tests/test_map_tiles.py
+++ b/tests/test_map_tiles.py
@@ -1,0 +1,118 @@
+import io
+
+import pytest
+from PIL import Image
+
+import visualizer
+from visualizer import MapTileUnavailableError, fetch_tile_img
+
+
+@pytest.fixture(autouse=True)
+def clear_tile_state():
+    """The tile cache and failure set live for the process, so reset them per test."""
+    visualizer.TILE_CACHE.clear()
+    visualizer.FAILED_TILES.clear()
+    yield
+    visualizer.TILE_CACHE.clear()
+    visualizer.FAILED_TILES.clear()
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def png_bytes(color=(1, 2, 3)):
+    buffer = io.BytesIO()
+    Image.new('RGB', (256, 256), color).save(buffer, format='PNG')
+    return buffer.getvalue()
+
+
+def test_tile_request_carries_a_timeout(monkeypatch):
+    seen = []
+
+    def urlopen(request, timeout=None):
+        seen.append(timeout)
+        return FakeResponse(png_bytes())
+
+    monkeypatch.setattr(visualizer.urllib.request, 'urlopen', urlopen)
+
+    fetch_tile_img(1, 2, 3)
+
+    assert seen == [visualizer.TILE_FETCH_TIMEOUT_SECONDS]
+
+
+def test_successful_tile_is_served_from_cache(monkeypatch):
+    calls = []
+
+    def urlopen(request, timeout=None):
+        calls.append(request.full_url)
+        return FakeResponse(png_bytes())
+
+    monkeypatch.setattr(visualizer.urllib.request, 'urlopen', urlopen)
+
+    first = fetch_tile_img(1, 2, 3)
+    second = fetch_tile_img(1, 2, 3)
+
+    assert len(calls) == 1
+    assert first is second
+
+
+def test_transient_failure_is_retried(monkeypatch):
+    attempts = []
+
+    def urlopen(request, timeout=None):
+        attempts.append(request.full_url)
+        if len(attempts) == 1:
+            raise OSError('transient')
+        return FakeResponse(png_bytes())
+
+    monkeypatch.setattr(visualizer.urllib.request, 'urlopen', urlopen)
+
+    fetch_tile_img(4, 5, 6)
+
+    assert len(attempts) == visualizer.TILE_FETCH_ATTEMPTS
+    assert (4, 5, 6) not in visualizer.FAILED_TILES
+
+
+def test_failed_tile_is_not_requested_again(monkeypatch):
+    """A frame loop asks for the same tile repeatedly; a known miss must not retry."""
+    calls = []
+
+    def urlopen(request, timeout=None):
+        calls.append(request.full_url)
+        raise OSError('offline')
+
+    monkeypatch.setattr(visualizer.urllib.request, 'urlopen', urlopen)
+
+    placeholder = fetch_tile_img(7, 8, 9)
+    for _ in range(50):
+        assert fetch_tile_img(7, 8, 9) is placeholder
+
+    assert len(calls) == visualizer.TILE_FETCH_ATTEMPTS
+
+
+def test_too_many_missing_tiles_stops_the_export(monkeypatch):
+    def urlopen(request, timeout=None):
+        raise OSError('offline')
+
+    monkeypatch.setattr(visualizer.urllib.request, 'urlopen', urlopen)
+
+    for index in range(visualizer.MAX_FAILED_TILES):
+        fetch_tile_img(index, 0, 5)
+
+    with pytest.raises(MapTileUnavailableError, match='map tiles'):
+        fetch_tile_img(visualizer.MAX_FAILED_TILES, 0, 5)
+
+
+def test_missing_tile_error_is_a_cli_error():
+    assert issubclass(MapTileUnavailableError, visualizer.TimelineCliError)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,9 +1,22 @@
 import base64
 from visualizer import (
+    DEFAULT_DURATION,
+    MAX_DURATION_SECONDS,
+    MIN_DURATION_SECONDS,
+    PRESET_FORMAT,
+    PRESET_LEGACY_FORMAT,
     PresetValues,
     decode_preset,
     encode_preset,
 )
+
+
+def _token(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_raw(token: str) -> bytes:
+    return base64.urlsafe_b64decode(token + "=" * ((4 - len(token) % 4) % 4))
 
 
 def test_preset_codec_roundtrip():
@@ -13,9 +26,10 @@ def test_preset_codec_roundtrip():
         trip_detection="sensitive",
         local_framing="close",
         long_trip_compression="stronger",
+        duration_seconds=120,
     )
     token = encode_preset(values)
-    assert len(token) <= 16
+    assert len(token) <= 24
     decoded = decode_preset(token)
     assert decoded is not None
     assert decoded.camera_movement == "close_up"
@@ -23,6 +37,7 @@ def test_preset_codec_roundtrip():
     assert decoded.trip_detection == "sensitive"
     assert decoded.local_framing == "close"
     assert decoded.long_trip_compression == "stronger"
+    assert decoded.duration_seconds == 120
 
 
 def test_preset_codec_all_options_roundtrip():
@@ -64,5 +79,69 @@ def test_invalid_tokens_rejected():
     assert decode_preset("") is None
     assert decode_preset("not!urlsafe") is None
     assert decode_preset("a" * 20) is None
-    unsupported = base64.urlsafe_b64encode(bytes([0xA2, 0, 0])).decode("ascii").rstrip("=")
+    assert decode_preset("a" * 25) is None
+
+
+def test_unsupported_format_byte_rejected():
+    """A format byte this build does not know is refused. 0xA2 and 0xA1 are both known."""
+    unsupported = _token(bytes([0xA3, 0, 0, 30, 0]))
     assert decode_preset(unsupported) is None
+
+
+def test_truncated_current_format_rejected():
+    """0xA2 promises a duration in bytes 3 and 4, so a three-byte payload is malformed."""
+    assert decode_preset(_token(bytes([PRESET_FORMAT, 0, 0]))) is None
+
+
+def test_decodes_android_token_with_duration():
+    """Cross-platform vector: the byte layout PresetCodec.kt emits must decode here.
+
+    PresetCodec.encode packs camera | aspect << 2 | trip << 4 | framing << 6 into byte 1,
+    the pacing ordinal into byte 2, and the duration little-endian into bytes 3 and 4.
+    """
+    packed = 3 | (1 << 2) | (2 << 4) | (2 << 6)
+    android_token = _token(bytes([PRESET_FORMAT, packed, 3, 45 & 0xFF, 45 >> 8]))
+    decoded = decode_preset(android_token)
+    assert decoded is not None
+    assert decoded.camera_movement == "close_up"
+    assert decoded.aspect_ratio == "portrait"
+    assert decoded.trip_detection == "sensitive"
+    assert decoded.local_framing == "close"
+    assert decoded.long_trip_compression == "stronger"
+    assert decoded.duration_seconds == 45
+
+
+def test_encoded_token_uses_current_format():
+    raw = _decode_raw(encode_preset(PresetValues()))
+    assert raw[0] == PRESET_FORMAT
+    assert len(raw) == 5
+
+
+def test_legacy_token_defaults_duration():
+    """The three-byte 0xA1 layout predates the duration field."""
+    legacy = _token(bytes([PRESET_LEGACY_FORMAT, 0, 0]))
+    decoded = decode_preset(legacy)
+    assert decoded is not None
+    assert decoded.duration_seconds == DEFAULT_DURATION
+
+
+def test_duration_outside_supported_range_rejected():
+    for seconds in (MIN_DURATION_SECONDS - 1, MAX_DURATION_SECONDS + 1, 0, 0xFFFF):
+        token = _token(bytes([PRESET_FORMAT, 0, 0, seconds & 0xFF, (seconds >> 8) & 0xFF]))
+        assert decode_preset(token) is None, seconds
+
+
+def test_duration_range_boundaries_accepted():
+    for seconds in (MIN_DURATION_SECONDS, MAX_DURATION_SECONDS):
+        token = _token(bytes([PRESET_FORMAT, 0, 0, seconds & 0xFF, (seconds >> 8) & 0xFF]))
+        decoded = decode_preset(token)
+        assert decoded is not None, seconds
+        assert decoded.duration_seconds == seconds
+
+
+def test_every_duration_in_range_round_trips():
+    for seconds in range(MIN_DURATION_SECONDS, MAX_DURATION_SECONDS + 1):
+        values = PresetValues(duration_seconds=seconds)
+        decoded = decode_preset(encode_preset(values))
+        assert decoded is not None, seconds
+        assert decoded.duration_seconds == seconds

--- a/visualizer.py
+++ b/visualizer.py
@@ -21,6 +21,7 @@ import bisect
 import io
 import json
 import math
+import re
 import statistics
 import sys
 import urllib.request
@@ -46,6 +47,8 @@ except ImportError as e:
 # --- CONFIGURATION DEFAULTS ---
 DEFAULT_FPS = 30
 DEFAULT_DURATION = 30
+MIN_DURATION_SECONDS = 10
+MAX_DURATION_SECONDS = 300
 DEFAULT_TAIL_KM = 500
 THEME_COLOR = '#e90064'
 HEAD_COLOR = '#24191d'
@@ -118,6 +121,16 @@ TRIP_DETECTION_ENUM = ['conservative', 'balanced', 'sensitive']
 LOCAL_FRAMING_ENUM = ['off', 'balanced', 'close']
 LONG_TRIP_COMPRESSION_ENUM = ['off', 'balanced', 'strong', 'stronger']
 
+# Preset token wire format, mirroring PresetCodec.kt. 0xA2 carries the video
+# duration in bytes 3 and 4; 0xA1 is the older three-byte layout that predates
+# the duration field and decodes to DEFAULT_DURATION.
+PRESET_FORMAT = 0xA2
+PRESET_LEGACY_FORMAT = 0xA1
+PRESET_MIN_BYTES = 3
+PRESET_MAX_BYTES = 8
+PRESET_MAX_TOKEN_LENGTH = 24
+PRESET_TOKEN_PATTERN = re.compile(r'^[A-Za-z0-9_-]+$')
+
 TRANSFER_PADDING = 2.8
 CAMERA_TRACK_SAMPLES = 480
 CAMERA_DEAD_ZONE_HALF = 0.20
@@ -144,18 +157,20 @@ class PresetValues:
         trip_detection: str = "balanced",
         local_framing: str = "balanced",
         long_trip_compression: str = "balanced",
+        duration_seconds: int = DEFAULT_DURATION,
     ):
         self.camera_movement = camera_movement
         self.aspect_ratio = aspect_ratio
         self.trip_detection = trip_detection
         self.local_framing = local_framing
         self.long_trip_compression = long_trip_compression
+        self.duration_seconds = duration_seconds
 
     def __repr__(self) -> str:
         return (
             f"PresetValues(camera={self.camera_movement}, aspect={self.aspect_ratio}, "
             f"trip={self.trip_detection}, framing={self.local_framing}, "
-            f"pacing={self.long_trip_compression})"
+            f"pacing={self.long_trip_compression}, duration={self.duration_seconds}s)"
         )
 
 
@@ -166,13 +181,22 @@ def encode_preset(values: PresetValues) -> str:
     framing_ord = LOCAL_FRAMING_ENUM.index(values.local_framing)
     comp_ord = LONG_TRIP_COMPRESSION_ENUM.index(values.long_trip_compression)
     packed = cam_ord | (aspect_ord << 2) | (trip_ord << 4) | (framing_ord << 6)
-    raw_bytes = bytes([0xA1, packed, comp_ord])
+    duration = values.duration_seconds
+    raw_bytes = bytes([
+        PRESET_FORMAT,
+        packed,
+        comp_ord,
+        duration & 0xFF,
+        (duration >> 8) & 0xFF,
+    ])
     return base64.urlsafe_b64encode(raw_bytes).decode('ascii').rstrip('=')
 
 
 def decode_preset(token: str) -> Optional[PresetValues]:
     token = token.strip()
-    if not token or len(token) > 16:
+    if not token or len(token) > PRESET_MAX_TOKEN_LENGTH:
+        return None
+    if not PRESET_TOKEN_PATTERN.match(token):
         return None
     pad_len = (4 - len(token) % 4) % 4
     padded = token + ('=' * pad_len)
@@ -180,9 +204,10 @@ def decode_preset(token: str) -> Optional[PresetValues]:
         raw_bytes = base64.urlsafe_b64decode(padded)
     except Exception:
         return None
-    if len(raw_bytes) < 3 or len(raw_bytes) > 8:
+    if len(raw_bytes) < PRESET_MIN_BYTES or len(raw_bytes) > PRESET_MAX_BYTES:
         return None
-    if raw_bytes[0] != 0xA1:
+    preset_format = raw_bytes[0]
+    if preset_format not in (PRESET_FORMAT, PRESET_LEGACY_FORMAT):
         return None
     packed = raw_bytes[1]
     cam_idx = packed & 0b11
@@ -198,12 +223,21 @@ def decode_preset(token: str) -> Optional[PresetValues]:
         or comp_idx >= len(LONG_TRIP_COMPRESSION_ENUM)
     ):
         return None
+    if preset_format == PRESET_FORMAT:
+        if len(raw_bytes) < 5:
+            return None
+        duration_seconds = raw_bytes[3] | (raw_bytes[4] << 8)
+        if not MIN_DURATION_SECONDS <= duration_seconds <= MAX_DURATION_SECONDS:
+            return None
+    else:
+        duration_seconds = DEFAULT_DURATION
     return PresetValues(
         camera_movement=CAMERA_MOVEMENT_ENUM[cam_idx],
         aspect_ratio=ASPECT_RATIO_ENUM[aspect_idx],
         trip_detection=TRIP_DETECTION_ENUM[trip_idx],
         local_framing=LOCAL_FRAMING_ENUM[framing_idx],
         long_trip_compression=LONG_TRIP_COMPRESSION_ENUM[comp_idx],
+        duration_seconds=duration_seconds,
     )
 
 
@@ -1061,6 +1095,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             args.trip_detection = preset_values.trip_detection
             args.local_framing = preset_values.local_framing
             args.long_trip_compression = preset_values.long_trip_compression
+            args.duration = preset_values.duration_seconds
             print(f"Applied preset token '{args.preset}': {preset_values}")
         else:
             print(f"Warning: Invalid preset token '{args.preset}', using command-line arguments.", file=sys.stderr)

--- a/visualizer.py
+++ b/visualizer.py
@@ -97,7 +97,6 @@ CAMERA_MOVEMENTS = {
 
 COMPRESSION_EXPONENTS = {
     'off': 1.00,
-    'gentle': 0.92,
     'balanced': 0.85,
     'strong': 0.75,
     'stronger': 0.65,
@@ -1049,7 +1048,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument('--camera-movement', '-c', choices=CAMERA_MOVEMENTS.keys(), default='steady',
                         help="Camera behavior: fixed, steady, dynamic, or close_up")
     parser.add_argument('--long-trip-compression', '-p', choices=COMPRESSION_EXPONENTS.keys(), default='balanced',
-                        help="Timing compression: off, gentle, balanced, strong, or stronger")
+                        help="Timing compression: off, balanced, strong, or stronger")
     parser.add_argument('--trip-detection', choices=TRIP_DETECTION_MULTIPLIERS.keys(), default='balanced',
                         help="Trip detection sensitivity: conservative, balanced, sensitive")
     parser.add_argument('--local-framing', choices=LOCAL_FRAMING_SETTINGS.keys(), default='balanced',

--- a/visualizer.py
+++ b/visualizer.py
@@ -57,6 +57,11 @@ TEXT_PRIMARY_COLOR = '#24191d'
 TEXT_SECONDARY_COLOR = '#5c4b52'
 MAP_ATTRIBUTION = '© OpenStreetMap contributors  © CARTO'
 TILE_URL = "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+TILE_FETCH_TIMEOUT_SECONDS = 10
+TILE_FETCH_ATTEMPTS = 2
+# Isolated misses degrade to a blank tile, but a map this broken means the
+# network is down and the video would be mostly empty, so stop instead.
+MAX_FAILED_TILES = 8
 
 OUTRO_SECONDS = 1.5
 OUTRO_TRANSITION_SECONDS = 1.0
@@ -77,6 +82,10 @@ class NoDataFoundError(TimelineCliError):
 
 class FfmpegUnavailableError(TimelineCliError):
     """Raised when Matplotlib cannot find a configured ffmpeg executable."""
+
+
+class MapTileUnavailableError(TimelineCliError):
+    """Raised when too many map tiles fail to load to render an accurate map."""
 
 
 # Camera behavior matches the Android renderer defaults and options.
@@ -541,22 +550,42 @@ def tile_to_bounds_meters(xtile: int, ytile: int, zoom: int) -> Tuple[float, flo
 
 
 TILE_CACHE: Dict[Tuple[int, int, int], Image.Image] = {}
+FAILED_TILES: set = set()
 
 
 def fetch_tile_img(x: int, y: int, z: int) -> Image.Image:
+    """Return one map tile, reusing the process-lifetime cache.
+
+    A tile that cannot be fetched is cached as a blank placeholder so the frame
+    loop reuses it instead of repeating a request that already failed. Once more
+    than MAX_FAILED_TILES distinct tiles are missing, the map is too incomplete
+    to be worth encoding and the export stops.
+    """
     key = (x, y, z)
-    if key in TILE_CACHE:
-        return TILE_CACHE[key]
+    cached = TILE_CACHE.get(key)
+    if cached is not None:
+        return cached
+
     url = TILE_URL.format(z=z, x=x, y=y)
-    try:
-        req = urllib.request.Request(url, headers={'User-Agent': "Mozilla/5.0"})
-        with urllib.request.urlopen(req) as response:
-            img = Image.open(io.BytesIO(response.read())).convert('RGB')
-            TILE_CACHE[key] = img
-            return img
-    except Exception:
-        fallback = Image.new('RGB', (256, 256), (240, 240, 240))
-        return fallback
+    for attempt in range(TILE_FETCH_ATTEMPTS):
+        try:
+            req = urllib.request.Request(url, headers={'User-Agent': "Mozilla/5.0"})
+            with urllib.request.urlopen(req, timeout=TILE_FETCH_TIMEOUT_SECONDS) as response:
+                img = Image.open(io.BytesIO(response.read())).convert('RGB')
+                TILE_CACHE[key] = img
+                return img
+        except Exception:
+            continue
+
+    FAILED_TILES.add(key)
+    if len(FAILED_TILES) > MAX_FAILED_TILES:
+        raise MapTileUnavailableError(
+            f"Could not load {len(FAILED_TILES)} map tiles from the tile server. "
+            "Check the network connection and try again.",
+        )
+    fallback = Image.new('RGB', (256, 256), (240, 240, 240))
+    TILE_CACHE[key] = fallback
+    return fallback
 
 
 def get_map_image(
@@ -1307,7 +1336,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     ani = animation.FuncAnimation(fig, update, frames=len(frame_data), blit=False)
 
     print(f"Saving to {args.output}...")
-    ani.save(args.output, writer='ffmpeg', fps=fps, dpi=100)
+    try:
+        ani.save(args.output, writer='ffmpeg', fps=fps, dpi=100)
+    except TimelineCliError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
     print("Done!")
     return 0
 

--- a/visualizer.py
+++ b/visualizer.py
@@ -1041,7 +1041,7 @@ def calculate_overview_viewport(
 def resolve_title_template(
     template: str, year_label: str = "", name: str = "", fallback: str = "My Trips"
 ) -> str:
-    resolved = template.replace("{year}", year_label).replace("{name}", name.strip()).trim() if hasattr(template, "trim") else template.replace("{year}", year_label).replace("{name}", name.strip()).strip()
+    resolved = template.replace("{year}", year_label).replace("{name}", name.strip()).strip()
     return resolved if resolved else fallback
 
 

--- a/visualizer.py
+++ b/visualizer.py
@@ -138,7 +138,12 @@ MIN_TRANSFER_THRESHOLD_KM = 60.0
 MAX_TRANSFER_THRESHOLD_KM = 120.0
 TRANSFER_TO_TYPICAL_RATIO = 3.0
 DEVIATION_MULTIPLIER = 6.0
-MIN_CONTEXT_KM = 15.0
+
+# Numeric floor for the transfer-arrival logarithmic blend below, matching
+# MIN_CONTEXT_KM in TimelinePainter.kt. It only exists to keep log() away from
+# zero and must stay far smaller than any real leg length. The per-movement
+# framing minimums live in CAMERA_MOVEMENTS['...']['minimum_context_km'].
+LOG_FLOOR_KM = 0.001
 
 # Web Mercator Constants
 R_EARTH = 6378137.0
@@ -883,8 +888,8 @@ def raw_camera_sample(
         leg_len = leg[1] - leg[0]
         if transfer_arrival_blend > 0:
             arrival_ctx = min(proportional_context, (next_local_leg[1] - next_local_leg[0]) if next_local_leg else proportional_context)
-            arrival_ctx = max(MIN_CONTEXT_KM, arrival_ctx)
-            context = math.exp(lerp(math.log(max(MIN_CONTEXT_KM, leg_len)), math.log(arrival_ctx), transfer_arrival_blend))
+            arrival_ctx = max(LOG_FLOOR_KM, arrival_ctx)
+            context = math.exp(lerp(math.log(max(LOG_FLOOR_KM, leg_len)), math.log(arrival_ctx), transfer_arrival_blend))
             padding = lerp(TRANSFER_PADDING, movement['padding'] * framing['padding_multiplier'], transfer_arrival_blend)
         else:
             context = leg_len


### PR DESCRIPTION
## Summary

`visualizer.py` reimplements the Android renderer's algorithms by hand, and parts
of it have drifted from `app/` since they were ported. Two of those gaps change
what the CLI produces, and one lets a broken connection stall or quietly damage an
export.

Nothing under `app/` or `web/` is touched.

## Preset links from the Android app were rejected

`PresetCodec.kt` emits format byte `0xA2` with the video duration in bytes 3 and 4
and keeps `0xA1` as a legacy layout. `decode_preset` only accepted `0xA1`, so a
link shared from the app was refused and the CLI continued with its own defaults
after a stderr warning. The video still rendered, with the wrong settings.

```
Android token 'olABHgA'   before: decode_preset -> None
                           after: PresetValues(camera=fixed, ..., duration=30s)
```

`decode_preset` now accepts both formats, reads the duration from `0xA2`, rejects
one outside the supported 10-300 second range, and `main` applies it. The token
length limit moves from 16 to 24 and the token is validated against the same
pattern `PresetCodec` uses.

**This changes an existing assertion.** `test_invalid_tokens_rejected` asserted
that a `0xA2` token must decode to `None`, which pinned the incompatibility in
place — the CI job would have blocked this fix. That case is now split into an
unknown `0xA3` format byte and a truncated `0xA2` payload, and a new test builds a
token directly from the byte layout `PresetCodec.encode` produces, so a future
format change on either side fails here.

## Short arrival legs were framed differently from Android

The transfer-arrival blend clamps its logarithmic interpolation with a floor that
exists only to keep `log()` away from zero. `TimelinePainter.kt` uses `0.001`; the
CLI used `15.0`, which is larger than most city legs, so every arrival leg shorter
than that collapsed to identical framing while Android used the real leg length.

The value matched when the CLI was ported in 3a0004d. v2.3.0 (ebddcd3) reworked
the Android camera and set `0.001`; that commit touched 28 files and none of them
were `visualizer.py`. Renamed to `LOG_FLOOR_KM` so it is no longer confused with
the per-movement `minimum_context_km` values, which are a different concern.

The regression test compares two arrival legs that are both shorter than the old
floor, so it fails if a floor above ordinary leg lengths comes back.

## A failing tile server stalled or silently degraded an export

`fetch_tile_img` called `urlopen` with no timeout, so an unresponsive server
blocked the render indefinitely. A failed tile returned a placeholder without
caching it, and the frame loop rebuilds the tile grid every fourth frame, so one
unreachable tile was re-requested for the length of the export.

```
same failed tile requested 50 times   before: 50 network requests
                                       after:  0 network requests
```

Each request now has a ten second timeout and one retry, the placeholder is
cached, and more than eight distinct missing tiles raises the new
`MapTileUnavailableError` through the existing `TimelineCliError` exit path. This
follows what Android already does since 2.2.7.

## `gentle` pacing could not be encoded

`COMPRESSION_EXPONENTS` held five values while `LONG_TRIP_COMPRESSION_ENUM`, which
assigns the ordinals a preset token encodes, held four. `--long-trip-compression`
took its choices from the longer list, so `gentle` was selectable and documented in
`--help` but had no ordinal, and `encode_preset` raised `ValueError` for it.

Android retired the same setting — `CameraSettingsPreferences` migrates a stored
`GENTLE` to `BALANCED` — so it is dropped here too.

## Dead code in the title template

`resolve_title_template` chose between `.trim()` and `.strip()` on
`hasattr(template, "trim")`. Python strings have no `trim`, so the guard was always
false and that half could never run; removing it keeps the behavior on one line
instead of a 190 character ternary.

## Testing

`python -m pytest` — 69 passed, up from 53. Each commit was tested on its own, so
the tree passes at every step.

Not covered: `ffmpeg` was unavailable in my environment, so the end-to-end check
stops just before encoding. The pipeline was exercised through parse, outlier
filter, leg detection, journey timing and camera track on `seoul-bohol-sample`,
`outlier-sample`, `takeout-sample` and `android-ios-sample`. The Android and web
suites were not run; no files they cover are changed.

## Notes

The changelog entries here follow the project's practice of recording a change
alongside it. A companion PR restores the missing 2.3.0-2.4.1 history; the two
touch adjacent lines in the Unreleased block, so whichever merges second needs a
one-line rebase. Happy to do that.

The wider pattern behind the first two items is that the same algorithms exist in
three hand-written copies with nothing that detects divergence. `test-fixtures/`
already holds shared JSON that Android and one Python test read, so a golden-output
comparison across the three would catch this class of drift. Out of scope here, but
worth considering.
