### PR TITLE
Add one-time support link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [mahlernim]

--- a/README.md
+++ b/README.md
@@ -204,4 +204,11 @@ Basemap attribution is displayed in every preview and exported video:
 © [OpenStreetMap contributors](https://www.openstreetmap.org/copyright) and
 © [CARTO](https://carto.com/attributions).
 
+## Support
+
+If Timeline Visualizer was useful to you, you can leave an optional
+[one-time contribution](https://github.com/sponsors/mahlernim?frequency=one-time).
+Support is appreciated but never required and does not include paid features,
+priority support, or a commitment to future development.
+
 Licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- enable the repository Sponsor button through GitHub Sponsors
- add a restrained README link to the one-time support page
- clarify that support is optional and does not include rewards or future-development commitments

## Validation

- git diff --check
- verified the public Sponsors page is active with a $5 minimum, $10 suggested amount, one $5 one-time tier, and no monthly tiers