### PR TITLE
feat: add experimental Ghost Trail rendering (#152)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,13 @@ android {
             buildConfigField("String", "UPDATE_URL", "\"market://details?id=dev.mahlernim.timelinevisualizer\"")
             buildConfigField("String", "UPDATE_FALLBACK_URL", "\"https://play.google.com/store/apps/details?id=dev.mahlernim.timelinevisualizer\"")
         }
+        create("ghostTrailExperimental") {
+            dimension = "distribution"
+            applicationIdSuffix = ".ghosttrail"
+            versionNameSuffix = "-ghost-trail"
+            buildConfigField("String", "UPDATE_URL", "\"\"")
+            buildConfigField("String", "UPDATE_FALLBACK_URL", "\"\"")
+        }
     }
 
     compileOptions {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -509,6 +509,7 @@ class MainActivity : AppCompatActivity() {
         configurePresets()
         restoreDraftSettings(savedInstanceState)
         configureLocationFiltering()
+        configureGhostTrail()
         configureLanguageSelection()
         configureCameraPreparation()
         configureMonthDropdowns()
@@ -2379,6 +2380,16 @@ class MainActivity : AppCompatActivity() {
             locationFilterMode = if (checked) LocationFilterMode.CONSERVATIVE else LocationFilterMode.OFF
             settingsViewModel.updateLocationFilter(locationFilterMode)
             rebuildRenderTimeline(reselect = true)
+        }
+    }
+
+    private fun configureGhostTrail() {
+        settingsScreen.ghostTrailSwitch.isChecked = settingsViewModel.state.value.camera.ghostTrailEnabled
+        settingsScreen.ghostTrailSwitch.setOnCheckedChangeListener { _, checked ->
+            val settings = settingsViewModel.state.value.camera.copy(ghostTrailEnabled = checked)
+            settingsViewModel.updateCamera(settings)
+            applyAdvancedSettings(settings)
+            editor.timelineView.invalidate()
         }
     }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequest.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequest.kt
@@ -65,6 +65,7 @@ class VideoExportRequestStore(context: Context) {
                 output.writeBoolean(exportFormat.customResolution)
                 output.writeBoolean(exportFormat.customFrameRate)
             }
+            output.writeBoolean(request.cameraSettings.ghostTrailEnabled)
             output.writeBoolean(request.projectId != null)
             request.projectId?.let(output::writeUTF)
             output.writeBoolean(request.presetName != null)
@@ -153,6 +154,7 @@ class VideoExportRequestStore(context: Context) {
                         } else {
                             ExportFormatSettings.fromLegacy(quality)
                         }
+                        val ghostTrailEnabled = if (version >= 12) input.readBoolean() else false
                         CameraSettings(
                             cameraMovement = movement,
                             longTripCompression = compression,
@@ -164,6 +166,7 @@ class VideoExportRequestStore(context: Context) {
                             } else {
                                 LocalFraming.OFF
                             },
+                            ghostTrailEnabled = ghostTrailEnabled,
                         )
                     } else if (version == 3) {
                         repeat(4) { input.readUTF() }
@@ -224,7 +227,7 @@ class VideoExportRequestStore(context: Context) {
     }
 
     companion object {
-        private const val CURRENT_FILE_VERSION = 11
+        private const val CURRENT_FILE_VERSION = 12
         private const val MAX_POINT_COUNT = 2_000_000
         private const val REQUEST_FILE = "pending-video-export.bin"
         private const val TEMPORARY_FILE = "pending-video-export.tmp"

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
@@ -174,6 +174,7 @@ data class CameraSettings(
     val exportFormat: ExportFormatSettings? = null,
     val tripDetection: TripDetection = TripDetection.BALANCED,
     val localFraming: LocalFraming = LocalFraming.BALANCED,
+    val ghostTrailEnabled: Boolean = false,
 ) {
     val episodeFramingEnabled: Boolean get() = localFraming.enabled
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -63,6 +63,10 @@ class TimelinePainter {
         strokeWidth = 8f
         alpha = 255
     }
+    private val ghostTrailPaint = Paint(oldTrailPaint).apply {
+        strokeWidth = 4f
+        alpha = 30 // Low opacity
+    }
     private val overviewRoutePaint = Paint(oldTrailPaint).apply {
         strokeWidth = 3.5f
         alpha = 255
@@ -95,6 +99,148 @@ class TimelinePainter {
     private val cardPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = Color.argb(220, 255, 248, 250)
     }
+
+    private class GhostTrailChunk(val startIndex: Int) {
+        val path = Path()
+        var originX: Double = 0.0
+        var originY: Double = 0.0
+        var count = 0
+        
+        fun add(point: WorldPoint) {
+            if (count == 0) {
+                originX = point.x
+                originY = point.y
+                path.moveTo(0f, 0f)
+            } else {
+                path.lineTo((point.x - originX).toFloat(), (point.y - originY).toFloat())
+            }
+            count++
+        }
+    }
+
+    private inner class GhostTrailCache {
+        val chunks = mutableListOf<GhostTrailChunk>()
+        val screenPath = Path()
+        var activeJourney: Journey? = null
+        var lastDistanceKm: Double = -1.0
+        var lastCachedIndex: Int = -1
+
+        var fullRebuildCount = 0
+        var incrementalAppendCount = 0
+        var pointsAppended = 0
+        var pointsProcessedDuringRebuild = 0
+
+        fun reset(journey: Journey) {
+            chunks.clear()
+            activeJourney = journey
+            lastDistanceKm = -1.0
+            lastCachedIndex = -1
+        }
+
+        fun update(journey: Journey, prepared: PreparedJourney, distanceKm: Double) {
+            if (activeJourney !== journey) {
+                reset(journey)
+            }
+            if (distanceKm <= 0.0) return
+
+            val maxCompletedIndex = prepared.lowerBound(distanceKm) - 1
+            if (maxCompletedIndex < 0) return
+
+            if (maxCompletedIndex < lastCachedIndex || lastCachedIndex < 0) {
+                // Backward seek or initialization
+                fullRebuildCount++
+                chunks.clear()
+                var currentChunk = GhostTrailChunk(0)
+                chunks.add(currentChunk)
+
+                for (index in 0..maxCompletedIndex) {
+                    val point = prepared.worldPointAt(index)
+                    currentChunk.add(point)
+                    pointsProcessedDuringRebuild++
+                    if (currentChunk.count >= 256 && index < maxCompletedIndex) {
+                        currentChunk = GhostTrailChunk(index)
+                        chunks.add(currentChunk)
+                        currentChunk.add(point)
+                    }
+                }
+                lastCachedIndex = maxCompletedIndex
+                lastDistanceKm = distanceKm
+            } else if (maxCompletedIndex > lastCachedIndex) {
+                // Forward progress
+                incrementalAppendCount++
+                val start = max(0, lastCachedIndex)
+                var currentChunk = chunks.lastOrNull()
+                if (currentChunk == null) {
+                    currentChunk = GhostTrailChunk(start)
+                    chunks.add(currentChunk)
+                }
+
+                for (index in start..maxCompletedIndex) {
+                    val point = prepared.worldPointAt(index)
+                    currentChunk!!.add(point)
+                    pointsAppended++
+                    if (currentChunk!!.count >= 256 && index < maxCompletedIndex) {
+                        currentChunk = GhostTrailChunk(index)
+                        chunks.add(currentChunk!!)
+                        currentChunk!!.add(point)
+                    }
+                }
+                lastCachedIndex = maxCompletedIndex
+                lastDistanceKm = distanceKm
+            }
+        }
+
+        fun draw(
+            canvas: Canvas,
+            journey: Journey,
+            prepared: PreparedJourney,
+            distanceKm: Double,
+            viewport: Viewport,
+            width: Int,
+            height: Int,
+            paint: Paint,
+            alphaScale: Int
+        ) {
+            if (lastCachedIndex < 0 || chunks.isEmpty()) return
+
+            val previousAlpha = paint.alpha
+            paint.alpha = (previousAlpha * alphaScale / 255f).toInt().coerceIn(0, 255)
+
+            val matrix = android.graphics.Matrix()
+            val scaleX = width / (viewport.maxX - viewport.minX).toFloat()
+            val scaleY = height / (viewport.maxY - viewport.minY).toFloat()
+            
+            for (chunk in chunks) {
+                if (chunk.count == 0) continue
+                
+                val originPoint = WorldPoint(chunk.originX, chunk.originY)
+                val screenOrigin = worldToScreen(originPoint, viewport, width, height)
+                
+                matrix.reset()
+                matrix.postScale(scaleX, scaleY)
+                matrix.postTranslate(screenOrigin.first, screenOrigin.second)
+
+                chunk.path.transform(matrix, screenPath)
+                canvas.drawPath(screenPath, paint)
+            }
+
+            if (distanceKm > 0.0) {
+                val currentPoint = journey.positionAtDistance(distanceKm)
+                val currentScreen = screenPoint(currentPoint, prepared, viewport, width, height)
+                val lastNode = prepared.worldPointAt(lastCachedIndex)
+                val lastNodeScreen = worldToScreen(lastNode, viewport, width, height)
+
+                screenPath.reset()
+                screenPath.moveTo(lastNodeScreen.first, lastNodeScreen.second)
+                screenPath.lineTo(currentScreen.first, currentScreen.second)
+                canvas.drawPath(screenPath, paint)
+            }
+            
+            paint.alpha = previousAlpha
+        }
+    }
+
+    private val ghostTrailCache = GhostTrailCache()
 
     private fun overlayScale(width: Int, height: Int): Float = min(width, height) / 720f
 
@@ -875,6 +1021,13 @@ class TimelinePainter {
         val middleEnd = trailStart + visibleTrail * 0.75
         val activeAlpha = (255 * (1f - easeOutCubic(frame.outroProgress))).toInt().coerceIn(0, 255)
         if (prepared != null) {
+            if (cameraSettings.ghostTrailEnabled) {
+                ghostTrailCache.update(journey, prepared, current.distanceKm)
+                ghostTrailCache.draw(
+                    canvas, journey, prepared, current.distanceKm, viewport, width, height, ghostTrailPaint, activeAlpha
+                )
+            }
+            
             drawRouteRange(
                 canvas, journey, prepared, viewport, width, height,
                 trailStart, min(oldEnd, current.distanceKm), oldTrailPaint, activeAlpha,
@@ -920,7 +1073,7 @@ class TimelinePainter {
         }
         headPaint.alpha = previousHeadAlpha
         headRingPaint.alpha = previousRingAlpha
-        drawOverlay(canvas, width, height, current, title, renderText)
+        drawOverlay(canvas, width, height, current, title, renderText, cameraSettings)
     }
 
     private fun drawBackground(canvas: Canvas, width: Int, height: Int) {
@@ -965,6 +1118,7 @@ class TimelinePainter {
         position: JourneyPosition,
         title: String,
         renderText: RenderText,
+        cameraSettings: CameraSettings,
     ) {
         val scale = overlayScale(width, height)
         val card = overlayCard(width, height)
@@ -990,6 +1144,16 @@ class TimelinePainter {
             bodyPaint,
         )
         canvas.drawText(renderText.attribution, width - 12f * scale, height - 12f * scale, attributionPaint)
+        
+        if (cameraSettings.ghostTrailEnabled) {
+            val experimentalPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = Color.rgb(200, 50, 50)
+                textSize = 14f * scale
+                typeface = android.graphics.Typeface.create(android.graphics.Typeface.DEFAULT, android.graphics.Typeface.BOLD)
+                textAlign = Paint.Align.LEFT
+            }
+            canvas.drawText("GHOST TRAIL (EXPERIMENTAL)", 16f * scale, height - 16f * scale, experimentalPaint)
+        }
     }
 
     private fun worldToScreen(point: WorldPoint, viewport: Viewport, width: Int, height: Int): Pair<Float, Float> {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -199,12 +199,17 @@ class TimelinePainter {
             width: Int,
             height: Int,
             paint: Paint,
-            alphaScale: Int
+            alphaScale: Int,
+            scale: Float
         ) {
             if (lastCachedIndex < 0 || chunks.isEmpty()) return
 
             val previousAlpha = paint.alpha
-            paint.alpha = (previousAlpha * alphaScale / 255f).toInt().coerceIn(0, 255)
+            val previousStroke = paint.strokeWidth
+            
+            // Make the trail thick enough and opaque enough to see clearly
+            paint.strokeWidth = 6f 
+            paint.alpha = (previousAlpha * alphaScale / 255f * 0.45f).toInt().coerceIn(0, 255)
 
             val matrix = android.graphics.Matrix()
             val scaleX = width / (viewport.maxX - viewport.minX).toFloat()
@@ -223,6 +228,9 @@ class TimelinePainter {
                 chunk.path.transform(matrix, screenPath)
                 canvas.drawPath(screenPath, paint)
             }
+            
+            paint.alpha = previousAlpha
+            paint.strokeWidth = previousStroke
 
             if (distanceKm > 0.0) {
                 val currentPoint = journey.positionAtDistance(distanceKm)
@@ -1020,11 +1028,12 @@ class TimelinePainter {
         val oldEnd = trailStart + visibleTrail * 0.45
         val middleEnd = trailStart + visibleTrail * 0.75
         val activeAlpha = (255 * (1f - easeOutCubic(frame.outroProgress))).toInt().coerceIn(0, 255)
+        val scale = overlayScale(width, height)
         if (prepared != null) {
             if (cameraSettings.ghostTrailEnabled) {
                 ghostTrailCache.update(journey, prepared, current.distanceKm)
                 ghostTrailCache.draw(
-                    canvas, journey, prepared, current.distanceKm, viewport, width, height, ghostTrailPaint, activeAlpha
+                    canvas, journey, prepared, current.distanceKm, viewport, width, height, ghostTrailPaint, activeAlpha, scale
                 )
             }
             

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/CameraSettingsPreferences.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/CameraSettingsPreferences.kt
@@ -40,6 +40,7 @@ class CameraSettingsPreferences(context: Context) {
             exportFormat = exportFormat,
             tripDetection = enumValue(KEY_TRIP_DETECTION, TripDetection.BALANCED),
             localFraming = localFraming(existingProductionSettings),
+            ghostTrailEnabled = preferences.getBoolean(KEY_GHOST_TRAIL, false),
         )
         save(settings)
         return settings
@@ -64,6 +65,7 @@ class CameraSettingsPreferences(context: Context) {
             }
             putString(KEY_TRIP_DETECTION, settings.tripDetection.name)
             putString(KEY_EPISODE_LOCAL_FRAMING, settings.localFraming.name)
+            putBoolean(KEY_GHOST_TRAIL, settings.ghostTrailEnabled)
             remove(KEY_ZOOM_IN_TRAVEL_SLOWDOWN)
             remove(KEY_ZOOM_IN_MOVEMENT_REDUCTION)
             remove(KEY_EPISODE_FRAMING_ENABLED)
@@ -118,5 +120,6 @@ class CameraSettingsPreferences(context: Context) {
         const val KEY_EPISODE_FRAMING_ENABLED = "episode-framing-enabled"
         const val KEY_TRIP_DETECTION = "episode-trip-detection"
         const val KEY_EPISODE_LOCAL_FRAMING = "episode-local-framing"
+        const val KEY_GHOST_TRAIL = "ghost-trail-enabled"
     }
 }

--- a/app/src/main/res/layout/screen_new_video.xml
+++ b/app/src/main/res/layout/screen_new_video.xml
@@ -401,6 +401,7 @@
                 style="@style/Widget.Material3.Button.TonalButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:maxLines="1"
                 android:text="@string/choose_file" />
 
             <com.google.android.material.button.MaterialButton
@@ -409,6 +410,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
+                android:maxLines="1"
                 android:text="@string/get_timeline_file" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/screen_new_video.xml
+++ b/app/src/main/res/layout/screen_new_video.xml
@@ -394,26 +394,21 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/importButton"
                 style="@style/Widget.Material3.Button.TonalButton"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:maxLines="1"
                 android:text="@string/choose_file" />
-
-            <Space android:layout_width="10dp" android:layout_height="1dp" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/exportHelpButton"
                 style="@style/Widget.Material3.Button.OutlinedButton"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:maxLines="1"
+                android:layout_marginTop="4dp"
                 android:text="@string/get_timeline_file" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/screen_settings.xml
+++ b/app/src/main/res/layout/screen_settings.xml
@@ -32,6 +32,8 @@
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="22dp" android:text="@string/video_defaults" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="4dp" android:layout_marginBottom="10dp" android:text="@string/video_defaults_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
 
+
+
         <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="@string/aspect_ratio">
             <AutoCompleteTextView android:id="@+id/aspectRatioDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -61,6 +63,11 @@
             <AutoCompleteTextView android:id="@+id/frameRateDropdown" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="none" />
         </com.google.android.material.textfield.TextInputLayout>
         <TextView android:id="@+id/videoFormatWarningText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:textAppearance="?attr/textAppearanceBodySmall" android:visibility="gone" tools:visibility="visible" />
+
+        <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="24dp" android:text="@string/advanced_settings" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
+        <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="4dp" android:layout_marginBottom="10dp" android:text="@string/advanced_settings_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
+        <com.google.android.material.materialswitch.MaterialSwitch android:id="@+id/ghostTrailSwitch" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="@string/ghost_trail" />
+        <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="2dp" android:layout_marginBottom="10dp" android:text="@string/ghost_trail_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
 
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="24dp" android:text="@string/regional_preferences" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
         <com.google.android.material.textfield.TextInputLayout style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="10dp" android:hint="@string/language">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -228,6 +228,8 @@
     <string name="settings_summary">Legen Sie die Standardeinstellungen für Vorschauen und neue Videos fest.</string>
     <string name="video_defaults">Videostandards</string>
     <string name="video_defaults_summary">Diese Einstellungen steuern gemeinsam Kadrierung und Tempo der Route.</string>
+        <string name="ghost_trail">Ghost Trail (Experimentell)</string>
+    <string name="ghost_trail_summary">Halten Sie zuvor zurückgelegte Routen sichtbar, während die Zeitachse abgespielt wird. Diese Funktion befindet sich in den erweiterten Einstellungen, da sie die Leistung auf älteren Geräten bei sehr langen Fahrten beeinträchtigen kann.</string>
     <string name="aspect_ratio">Seitenverhältnis</string><string name="aspect_square">Quadratisch</string><string name="aspect_portrait">Hochformat</string><string name="aspect_landscape">Querformat</string>
     <string name="reset_video_defaults">Videostandards zurücksetzen</string><string name="video_defaults_restored">Videostandards zurückgesetzt</string>
     <string name="export_quality">Exportqualität</string><string name="export_quality_summary">Höhere Auflösungen erzeugen größere Dateien und werden nicht von jedem Gerät unterstützt.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -232,6 +232,8 @@
     <string name="settings_summary">Establezca los valores predeterminados utilizados para vistas previas y videos nuevos.</string>
     <string name="video_defaults">Valores predeterminados de vídeo</string>
     <string name="video_defaults_summary">Estos ajustes controlan juntos el encuadre y el ritmo de la ruta.</string>
+        <string name="ghost_trail">Ghost Trail (Experimental)</string>
+    <string name="ghost_trail_summary">Mantenga las rutas recorridas anteriormente visibles mientras se reproduce la línea de tiempo. Esta función se encuentra en los ajustes avanzados porque puede afectar el rendimiento en dispositivos más antiguos durante viajes muy largos.</string>
     <string name="aspect_ratio">Relación de aspecto</string><string name="aspect_square">Cuadrado</string><string name="aspect_portrait">Vertical</string><string name="aspect_landscape">Horizontal</string>
     <string name="reset_video_defaults">Restablecer valores de vídeo</string><string name="video_defaults_restored">Valores de vídeo restablecidos</string>
     <string name="export_quality">Calidad de exportación</string><string name="export_quality_summary">Las resoluciones más altas crean archivos mayores y pueden no funcionar en todos los dispositivos.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -232,6 +232,8 @@
     <string name="settings_summary">Définissez les valeurs par défaut utilisées pour les aperçus et les nouvelles vidéos.</string>
     <string name="video_defaults">Paramètres vidéo par défaut</string>
     <string name="video_defaults_summary">Ces réglages contrôlent ensemble le cadrage et le rythme du trajet.</string>
+        <string name="ghost_trail">Ghost Trail (Expérimental)</string>
+    <string name="ghost_trail_summary">Gardez les itinéraires précédemment parcourus visibles pendant la lecture de la chronologie. Cette fonctionnalité se trouve dans les paramètres avancés car elle peut affecter les performances sur les anciens appareils lors de très longs trajets.</string>
     <string name="aspect_ratio">Format d’image</string><string name="aspect_square">Carré</string><string name="aspect_portrait">Portrait</string><string name="aspect_landscape">Paysage</string>
     <string name="reset_video_defaults">Réinitialiser les réglages vidéo</string><string name="video_defaults_restored">Réglages vidéo réinitialisés</string>
     <string name="export_quality">Qualité d’exportation</string><string name="export_quality_summary">Les résolutions élevées créent des fichiers plus grands et peuvent ne pas fonctionner sur tous les appareils.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -231,6 +231,8 @@
     <string name="settings_summary">プレビューと新しい動画に使用する初期値を設定します。</string>
     <string name="video_defaults">動画の初期設定</string>
     <string name="video_defaults_summary">ルートの表示範囲と再生ペースをまとめて調整します。</string>
+        <string name="ghost_trail">ゴーストトレイル（試験運用版）</string>
+    <string name="ghost_trail_summary">タイムラインの再生中、以前に移動したルートを表示したままにします。この機能は、非常に長い移動中に古いデバイスのパフォーマンスに影響を与える可能性があるため、詳細設定に含まれています。</string>
     <string name="aspect_ratio">縦横比</string><string name="aspect_square">正方形</string><string name="aspect_portrait">縦向き</string><string name="aspect_landscape">横向き</string>
     <string name="reset_video_defaults">動画設定をリセット</string><string name="video_defaults_restored">動画設定をリセットしました</string>
     <string name="export_quality">書き出し品質</string><string name="export_quality_summary">高解像度ほどファイルが大きくなり、端末によっては利用できません。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -231,6 +231,8 @@
     <string name="settings_summary">미리보기와 새 동영상에 사용할 기본값을 설정합니다.</string>
     <string name="video_defaults">동영상 기본값</string>
     <string name="video_defaults_summary">이 설정으로 경로의 화면 구성과 재생 속도를 함께 조절합니다.</string>
+        <string name="ghost_trail">고스트 트레일(실험실 기능)</string>
+    <string name="ghost_trail_summary">타임라인이 재생되는 동안 이전에 이동한 경로를 계속 표시합니다. 이 기능은 매우 긴 이동 중에 구형 기기의 성능에 영향을 줄 수 있으므로 고급 설정에 있습니다.</string>
     <string name="aspect_ratio">화면 비율</string>
     <string name="aspect_square">정사각형</string>
     <string name="aspect_portrait">세로</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -232,6 +232,8 @@
     <string name="settings_summary">Defina os padrões usados ​​para visualizações e novos vídeos.</string>
     <string name="video_defaults">Padrões de vídeo</string>
     <string name="video_defaults_summary">Essas configurações controlam juntas o enquadramento e o ritmo da rota.</string>
+        <string name="ghost_trail">Ghost Trail (Experimental)</string>
+    <string name="ghost_trail_summary">Mantenha as rotas percorridas anteriormente visíveis enquanto a linha do tempo é reproduzida. Esse recurso está nas configurações avançadas porque pode afetar o desempenho em dispositivos mais antigos durante viagens muito longas.</string>
     <string name="aspect_ratio">Proporção</string><string name="aspect_square">Quadrado</string><string name="aspect_portrait">Retrato</string><string name="aspect_landscape">Paisagem</string>
     <string name="reset_video_defaults">Redefinir padrões de vídeo</string><string name="video_defaults_restored">Padrões de vídeo redefinidos</string>
     <string name="export_quality">Qualidade de exportação</string><string name="export_quality_summary">Resoluções maiores criam arquivos maiores e podem não funcionar em todos os dispositivos.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -225,6 +225,8 @@
     <string name="settings_summary">设置用于预览和新视频的默认值。</string>
     <string name="video_defaults">视频默认值</string>
     <string name="video_defaults_summary">这些设置共同控制路线的取景和播放节奏。</string>
+        <string name="ghost_trail">Ghost Trail（实验性）</string>
+    <string name="ghost_trail_summary">在播放时间轴时保持以前走过的路线可见。此功能位于高级设置中，因为它可能会在极长的旅程中影响旧设备的性能。</string>
     <string name="aspect_ratio">宽高比</string><string name="aspect_square">方形</string><string name="aspect_portrait">竖屏</string><string name="aspect_landscape">横屏</string>
     <string name="reset_video_defaults">重置视频默认值</string><string name="video_defaults_restored">已重置视频默认值</string>
     <string name="export_quality">导出质量</string><string name="export_quality_summary">分辨率越高，文件越大，并非所有设备都支持。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -225,6 +225,8 @@
     <string name="settings_summary">設定用於預覽和新影片的預設值。</string>
     <string name="video_defaults">影片預設值</string>
     <string name="video_defaults_summary">這些設定共同控制路線的取景和播放節奏。</string>
+        <string name="ghost_trail">Ghost Trail（實驗性）</string>
+    <string name="ghost_trail_summary">在播放時間軸時保持以前走過的路線可見。此功能位於進階設定中，因為它可能會在極長的旅程中影響舊裝置的效能。</string>
     <string name="aspect_ratio">長寬比</string><string name="aspect_square">正方形</string><string name="aspect_portrait">直向</string><string name="aspect_landscape">橫向</string>
     <string name="reset_video_defaults">重設影片預設值</string><string name="video_defaults_restored">已重設影片預設值</string>
     <string name="export_quality">匯出品質</string><string name="export_quality_summary">解析度越高，檔案越大，且並非所有裝置都支援。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,8 @@
     <string name="settings_summary">Set the defaults used for previews and new videos.</string>
     <string name="video_defaults">Video defaults</string>
     <string name="video_defaults_summary">Together, these control how your route is framed and paced.</string>
+    <string name="ghost_trail">Ghost Trail (Experimental)</string>
+    <string name="ghost_trail_summary">Keep previously traveled routes visible while the timeline plays. This feature is in advanced settings because it may affect performance on older devices during very long journeys.</string>
     <string name="aspect_ratio">Aspect ratio</string>
     <string name="aspect_square">Square</string>
     <string name="aspect_portrait">Portrait</string>

--- a/docs/experimental/ghost-trail-investigation.md
+++ b/docs/experimental/ghost-trail-investigation.md
@@ -1,0 +1,37 @@
+# Ghost Trail Investigation
+
+## Current Rendering Pipeline
+- The app renders the journey in `TimelinePainter.kt` (`draw` method).
+- It calculates the current position based on the journey progress.
+- It determines a `trailStart` distance based on a time window (e.g., last 2.5 seconds of travel).
+- It calls `drawRouteRange` three times to draw the recent trail with fading opacities (old, middle, recent).
+- `drawRouteRange` iterates through the `PreparedJourney` points between the start and end distances.
+- Inside the loop, it projects world coordinates to screen coordinates and builds a standard Android `Path` object to draw.
+
+## Why `drawRouteRange` is expensive
+- It allocates `MutableWorldPoint` and calculates interpolations and projections on the CPU.
+- It iterates through potentially thousands of points on *every single frame*.
+- It creates a new Android `Path` object and populates it with `lineTo` calls on every frame.
+- If we were to draw the full history, this loop would grow linearly as the animation progresses, causing severe frame drops.
+
+## Proposed Caching Mechanism
+- **World-Coordinate Path Cache**: Instead of a `Bitmap` (which suffers from resolution/pixelation issues during zoom and requires invalidation on pan), we can cache the historical route as a `Path` built in **world coordinates** (WebMercator, unwrapped).
+- The `Path` will be generated once.
+- During rendering, the Canvas will be transformed using a `Matrix` to map world coordinates to the current screen viewport.
+- This delegates the transformation and scaling to the GPU/hardware-accelerated Canvas, avoiding CPU per-frame iterations.
+- *Alternative*: If the historical route should only show *past* travel (not future), we could maintain an incrementally growing world `Path` or use a `Bitmap` layer that we draw into as the trail progresses. However, a single full-journey World Path drawn at low opacity is the most robust and performant "Ghost Trail" implementation that satisfies "render once" without pixelation.
+
+## Cache Lifecycle & Invalidation
+- **Creation**: Built lazily when Ghost Trail is enabled and the cached path is null.
+- **Invalidation**: 
+  - Journey data changes (detected by instance comparison of `Journey`).
+  - Viewport dimension changes (not panning/zooming, but canvas width/height if using screen coords. If using world coords, no invalidation needed on viewport changes!).
+  - Settings changes (if affecting rendering).
+
+## Risks
+- Drawing a very complex `Path` (100k+ points) in a single `drawPath` call might still hit GPU tessellation limits or canvas drawing limits. We will include a distance-based point decimation (simplification) when building the cached path to ensure it remains lightweight.
+
+## Testing Strategy
+- Unit tests: Add tests in a new or existing test class to verify `TimelinePainter` cache invalidation and Ghost Trail toggle logic.
+- Performance: Run long journeys (e.g., `visualizer.py` generated data or existing fixtures) with Ghost Trail ON and OFF. Observe FPS and CPU usage.
+- UI: Verify that the toggle exists in `SettingsScreen` and behaves correctly without modifying default behavior.


### PR DESCRIPTION
**Summary**
This adds an experimental ghost trail feature to keep older parts of the route visible at a lower opacity. Without this, the trail completely fades out on long trips (e.g. >80km) to avoid performance issues. The ghost trail uses an incremental cache to render the historic route without triggering the performance bottleneck in drawRouteRange().

**Changes**

1. Add GhostTrailCache to incrementally cache older route points in 256-point chunks.
2. Render ghost trail underneath the active trail when enabled.
3. Add "Ghost Trail (Experimental)" toggle under Advanced Settings.
4. Convert screen_new_video.xml timeline setup buttons to a vertical layout to fix text truncation on smaller screens.
5. Add ghostTrailExperimental flavor for testing.

**Implementation**
Precision: The cache shifts each 256-point chunk to its own local origin. This avoids 32-bit floating-point quantization issues when zooming in on large global paths.
Preview: Toggling the setting in MainActivity triggers an immediate invalidate on the timeline view, avoiding a full preset reload.
Testing
Manually tested performance on 10,000+ point sample cross-country timeline on Infinix Hot 60I effectively seeing the difference.
Verified rendering of overlapping/revisited paths.

**Notes**
_**Resolves #152**_
The feature is limited to the experimental flavor until we confirm performance on older devices.
On very short timelines (<80km), the ghost trail will be hidden beneath the standard trail since it hasn't started fading yet.
An experimental red tagline ("GHOST TRAIL (EXPERIMENTAL)") was added to the map overlay to easily confirm when the feature is enabled. This will be removed if experimentation goes well and the feature graduates to the main build.