### PR TITLE
Fix v3.0.0 release version verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
           package_name="$(sed -n "s/^package: name='\([^']*\)'.*/\1/p" <<< "$package_line")"
           version_code="$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<< "$package_line")"
           version_name="$(sed -n "s/.*versionName='\([^']*\)'.*/\1/p" <<< "$package_line")"
-          expected_version_code="$(sed -nE 's/^[[:space:]]*versionCode = ([0-9]+).*$/\1/p' app/build.gradle.kts)"
-          expected_version_name="$(sed -nE 's/^[[:space:]]*versionName = "([^"]+)".*$/\1/p' app/build.gradle.kts)"
+          expected_version_code="$(sed -nE 's/^[[:space:]]*versionCode = ([0-9]+).*$/\1/p' app/build.gradle.kts | head -n 1)"
+          expected_version_name="$(sed -nE 's/^[[:space:]]*versionName = "([^"]+)".*$/\1/p' app/build.gradle.kts | head -n 1)"
 
           test "$package_name" = "dev.mahlernim.timelinevisualizer"
           test "$version_code" = "$expected_version_code"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -35,6 +35,13 @@ def test_release_workflow_can_update_an_existing_release() -> None:
     assert 'gh release upload "$RELEASE_TAG" "$apk" "$apk.sha256" --clobber' in workflow
 
 
+def test_release_workflow_uses_production_version_when_flavors_override_it() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "expected_version_code=\"$(sed -nE 's/^[[:space:]]*versionCode = ([0-9]+).*$/\\1/p' app/build.gradle.kts | head -n 1)\"" in workflow
+    assert "expected_version_name=\"$(sed -nE 's/^[[:space:]]*versionName = \"([^\"]+)\".*$/\\1/p' app/build.gradle.kts | head -n 1)\"" in workflow
+
+
 def test_release_workflow_requires_the_carto_project_key() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Problem

The v3.0.0 release build contains both the production version and the retained Journal Lab flavor override. The release verifier collected both declarations and stopped after the signed APK and Play bundle were built.

## Outcome

Read the first version declaration from the default configuration when validating production artifacts. Keep the immutable v3.0.0 tag unchanged and use the existing-tag workflow rerun after this fix merges.

## Acceptance criteria

- Production APK verification resolves version code 42 and version name 3.0.0
- Flavor-specific version overrides do not affect production verification
- Existing-tag release reruns remain supported
- Regression coverage protects the version extraction