### PR TITLE
Remove consecutive impossible raw-signal readings (#185)

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/data/RawSignalProcessor.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/data/RawSignalProcessor.kt
@@ -4,6 +4,7 @@ import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.haversineKm
 import java.time.Duration
 import kotlin.math.max
+import kotlin.math.min
 
 data class RawSignalProcessingResult(
     val points: List<GeoPoint>,
@@ -43,19 +44,44 @@ object RawSignalProcessor {
         if (points.size < 3) return points
         val kept = ArrayList<RawSignalPoint>(points.size)
         kept += points.first()
-        for (index in 1 until points.lastIndex) {
-            val before = kept.last()
-            val candidate = points[index]
-            val after = points[index + 1]
-            if (!isShortImpossibleSpike(before, candidate, after)) kept += candidate
+        var index = 1
+        while (index < points.lastIndex) {
+            val runEnd = impossibleRunEnd(points, kept.last(), index)
+            if (runEnd == null) {
+                kept += points[index]
+                index += 1
+            } else {
+                index = runEnd + 1
+            }
         }
         kept += points.last()
         return kept
     }
 
-    private fun isShortImpossibleSpike(
+    /**
+     * Returns the last index of the impossible excursion starting at [start], or null when the
+     * point at [start] rejoins the track plausibly. Longer runs are tried first so a cluster of
+     * consecutive readings at the same wrong location is removed as a whole; checking only the
+     * single-point window leaves every member of such a cluster in place, because neither the
+     * first nor the last one rejoins near [before].
+     */
+    private fun impossibleRunEnd(
+        points: List<RawSignalPoint>,
         before: RawSignalPoint,
-        candidate: RawSignalPoint,
+        start: Int,
+    ): Int? {
+        val latestEnd = min(start + MAX_SPIKE_RUN_POINTS - 1, points.lastIndex - 1)
+        for (end in latestEnd downTo start) {
+            if (isImpossibleExcursion(before, points, start, end, points[end + 1])) return end
+        }
+        return null
+    }
+
+    private fun isImpossibleExcursion(
+        before: RawSignalPoint,
+        points: List<RawSignalPoint>,
+        start: Int,
+        end: Int,
         after: RawSignalPoint,
     ): Boolean {
         val window = Duration.between(before.point.instant, after.point.instant)
@@ -65,15 +91,26 @@ object RawSignalProcessor {
             (before.accuracyMeters + after.accuracyMeters) * ACCURACY_REJOIN_MULTIPLIER / 1_000.0,
         )
         if (haversineKm(before.point, after.point) > rejoinToleranceKm) return false
-        val ingressKm = haversineKm(before.point, candidate.point)
-        val egressKm = haversineKm(candidate.point, after.point)
-        val minimumSpikeKm = max(
-            MIN_SPIKE_DISTANCE_KM,
-            candidate.accuracyMeters * ACCURACY_SPIKE_MULTIPLIER / 1_000.0,
-        )
-        if (ingressKm < minimumSpikeKm || egressKm < minimumSpikeKm) return false
-        return speedKmPerHour(before.point, candidate.point, ingressKm) > MAX_PLAUSIBLE_GROUND_SPEED_KMH &&
-            speedKmPerHour(candidate.point, after.point, egressKm) > MAX_PLAUSIBLE_GROUND_SPEED_KMH
+
+        val first = points[start]
+        val last = points[end]
+        val ingressKm = haversineKm(before.point, first.point)
+        val egressKm = haversineKm(last.point, after.point)
+        if (speedKmPerHour(before.point, first.point, ingressKm) <= MAX_PLAUSIBLE_GROUND_SPEED_KMH) return false
+        if (speedKmPerHour(last.point, after.point, egressKm) <= MAX_PLAUSIBLE_GROUND_SPEED_KMH) return false
+
+        val anchor = first.point
+        for (index in start..end) {
+            val candidate = points[index]
+            val minimumSpikeKm = max(
+                MIN_SPIKE_DISTANCE_KM,
+                candidate.accuracyMeters * ACCURACY_SPIKE_MULTIPLIER / 1_000.0,
+            )
+            if (haversineKm(before.point, candidate.point) < minimumSpikeKm) return false
+            if (haversineKm(candidate.point, after.point) < minimumSpikeKm) return false
+            if (haversineKm(anchor, candidate.point) > MAX_SPIKE_CLUSTER_SPAN_KM) return false
+        }
+        return true
     }
 
     private fun collapseUncertainMovement(points: List<RawSignalPoint>): List<RawSignalPoint> {
@@ -113,6 +150,8 @@ object RawSignalProcessor {
     private const val ACCURACY_REJOIN_MULTIPLIER = 2.0
     private const val ACCURACY_SPIKE_MULTIPLIER = 5.0
     private const val MAX_PLAUSIBLE_GROUND_SPEED_KMH = 250.0
+    private const val MAX_SPIKE_RUN_POINTS = 5
+    private const val MAX_SPIKE_CLUSTER_SPAN_KM = 50.0
     private val MAX_SPIKE_WINDOW: Duration = Duration.ofMinutes(20)
     private val MAX_STATIONARY_WINDOW: Duration = Duration.ofMinutes(10)
     private val DISCONTINUITY_GAP: Duration = Duration.ofMinutes(30)

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/data/RawSignalProcessorTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/data/RawSignalProcessorTest.kt
@@ -2,6 +2,7 @@ package dev.mahlernim.timelinevisualizer.data
 
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
 
@@ -50,6 +51,74 @@ class RawSignalProcessorTest {
 
         assertEquals(2, result.points.size)
         assertEquals(1, result.discontinuityCount)
+    }
+
+    @Test
+    fun removesTwoConsecutiveReadingsAtTheSameImpossibleLocation() {
+        val result = RawSignalProcessor.process(
+            listOf(
+                raw("2026-01-01T00:00:00Z", 37.0, 127.0, 10.0),
+                raw("2026-01-01T00:01:00Z", 38.0, 128.0, 10.0),
+                raw("2026-01-01T00:02:00Z", 38.0, 128.0, 10.0),
+                raw("2026-01-01T00:03:00Z", 37.0001, 127.0001, 10.0),
+                raw("2026-01-01T01:00:00Z", 37.1, 127.1, 10.0),
+            ),
+        )
+
+        assertEquals(2, result.points.size)
+        assertEquals(3, result.noiseRejectedCount)
+        assertEquals(37.0, result.points.first().latitude, 0.00001)
+        assertEquals(37.1, result.points.last().latitude, 0.00001)
+    }
+
+    @Test
+    fun removesADriftingClusterOfConsecutiveImpossibleReadings() {
+        val result = RawSignalProcessor.process(
+            listOf(
+                raw("2026-01-01T00:00:00Z", 37.0, 127.0, 10.0),
+                raw("2026-01-01T00:01:00Z", 38.0, 128.0, 10.0),
+                raw("2026-01-01T00:02:00Z", 38.05, 128.05, 10.0),
+                raw("2026-01-01T00:03:00Z", 38.02, 128.03, 10.0),
+                raw("2026-01-01T00:04:00Z", 37.0001, 127.0001, 10.0),
+                raw("2026-01-01T01:00:00Z", 37.1, 127.1, 10.0),
+            ),
+        )
+
+        assertEquals(2, result.points.size)
+        assertEquals(4, result.noiseRejectedCount)
+        assertEquals(37.1, result.points.last().latitude, 0.00001)
+    }
+
+    @Test
+    fun keepsAnExcursionLongerThanTheRunCapRatherThanGuessing() {
+        val excursion = (1..6).map { minute ->
+            raw("2026-01-01T00:0$minute:00Z", 38.0, 128.0, 10.0)
+        }
+        val source = listOf(raw("2026-01-01T00:00:00Z", 37.0, 127.0, 10.0)) +
+            excursion +
+            listOf(
+                raw("2026-01-01T00:07:00Z", 37.0001, 127.0001, 10.0),
+                raw("2026-01-01T01:00:00Z", 37.1, 127.1, 10.0),
+            )
+
+        val result = RawSignalProcessor.process(source)
+
+        assertTrue(result.points.size > 2)
+    }
+
+    @Test
+    fun keepsSustainedTravelThatNeverRejoinsItsStartingPoint() {
+        val result = RawSignalProcessor.process(
+            listOf(
+                raw("2026-01-01T00:00:00Z", 37.0, 127.0, 10.0),
+                raw("2026-01-01T00:20:00Z", 37.3, 127.3, 10.0),
+                raw("2026-01-01T00:40:00Z", 37.6, 127.6, 10.0),
+                raw("2026-01-01T01:00:00Z", 37.9, 127.9, 10.0),
+            ),
+        )
+
+        assertEquals(4, result.points.size)
+        assertEquals(0, result.noiseRejectedCount)
     }
 
     private fun raw(


### PR DESCRIPTION
Fixes #185.

## The gap

`removeShortImpossibleSpikes` inspected exactly one candidate between its neighbours, so a cluster of two or more consecutive readings at the same wrong location survived intact. Each member fails the rejoin test for a different reason:

- the **first** bad reading takes the **second** as its `after`, so `haversineKm(before, after)` is the full excursion distance and blows past the rejoin tolerance
- the **second** takes the **first** as its `before`, so it never departs from a plausible place

Neither is removed, and the video draws the excursion twice.

## The fix

Replaced the fixed three-point window with a sliding run, mirroring the structure `LocationOutlierFilter.suspiciousRunEnd` already uses on the semantic path: try the longest run first, fall back to shorter ones, skip the whole run when it qualifies.

**I kept the raw-signal thresholds rather than reusing `LocationOutlierFilter` (the report's Option A).** That filter is tuned for Timeline points — 1,300 km/h, a 500 km minimum hop, a 200 km rejoin — and it operates on `GeoPoint`, which drops the per-reading `accuracyMeters` that every threshold in `RawSignalProcessor` is derived from. Running it over raw signals would apply the wrong definition of "impossible" to much denser data. So this is Option B.

For a single-point run the checks reduce to exactly the previous ones, so existing behaviour is unchanged.

## Staying conservative

Two bounds keep the wider window safe:

- `MAX_SPIKE_RUN_POINTS = 5` — above the semantic filter's 3, because raw signals sample far more often, so a glitch cluster spans more readings
- `MAX_SPIKE_CLUSTER_SPAN_KM = 50.0` — the run must stay within 50 km of its first reading, so an excursion that keeps travelling is not mistaken for one glitch

Removal still requires departing **and** returning above 250 km/h and rejoining within the accuracy-derived tolerance. Real movement cannot satisfy that: it would mean leaving and returning to within ~200 m at over 250 km/h inside 20 minutes.

## Tests

Adds the consecutive-cluster coverage the report noted was missing:

| test | covers |
|---|---|
| `removesTwoConsecutiveReadingsAtTheSameImpossibleLocation` | the exact reported case |
| `removesADriftingClusterOfConsecutiveImpossibleReadings` | a cluster that drifts rather than repeating |
| `keepsAnExcursionLongerThanTheRunCapRatherThanGuessing` | past the cap, left alone |
| `keepsSustainedTravelThatNeverRejoinsItsStartingPoint` | no false positives on real travel |

The first two **fail against the previous implementation** and pass with this change; I verified by stashing the source and re-running. The other two pass either way — they guard against over-removal, which the old code also avoided.

`gradlew lintGithubDebug testGithubDebugUnitTest` passes.