### PR TITLE
Add simplified route detail for long histories

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -118,6 +118,7 @@ import dev.mahlernim.timelinevisualizer.journal.route.JournalRoute
 import dev.mahlernim.timelinevisualizer.journal.route.JournalRouteService
 import dev.mahlernim.timelinevisualizer.journal.route.JournalRoutePreparationStage
 import dev.mahlernim.timelinevisualizer.journal.route.RouteSource
+import dev.mahlernim.timelinevisualizer.journal.route.RouteDetail
 import dev.mahlernim.timelinevisualizer.journal.route.connectedTimelines
 import dev.mahlernim.timelinevisualizer.journal.route.journeyForDateRange
 import dev.mahlernim.timelinevisualizer.journal.route.journeyForRange
@@ -152,6 +153,7 @@ import dev.mahlernim.timelinevisualizer.ui.AppLanguage
 import dev.mahlernim.timelinevisualizer.ui.LocationFilterPreferences
 import dev.mahlernim.timelinevisualizer.ui.SelectionArrayAdapter
 import dev.mahlernim.timelinevisualizer.ui.SettingsViewModel
+import dev.mahlernim.timelinevisualizer.ui.TimelineDisplayPreferences
 import dev.mahlernim.timelinevisualizer.videos.GeneratedMediaRepository
 import dev.mahlernim.timelinevisualizer.videos.VideoMedia
 import dev.mahlernim.timelinevisualizer.videos.VideoRecord
@@ -247,6 +249,7 @@ class MainActivity : AppCompatActivity() {
                     CameraSettingsPreferences(applicationContext),
                     DistanceUnitPreferences(applicationContext),
                     LocationFilterPreferences(applicationContext),
+                    TimelineDisplayPreferences(applicationContext),
                 )
             }
         }
@@ -262,6 +265,7 @@ class MainActivity : AppCompatActivity() {
     private var distanceUnitPreference = DistanceUnitPreference.AUTOMATIC
     private var videoFormatSupported = true
     private var locationFilterMode = LocationFilterMode.CONSERVATIVE
+    private var simplifyRouteDetail = false
     private var routeDurationSeconds = VideoDuration.DEFAULT_SECONDS
     private val applyTitleChanges = Runnable { commitTitlePreferences() }
     private var videoRenderJob: Job? = null
@@ -627,6 +631,7 @@ class MainActivity : AppCompatActivity() {
         configurePresets()
         restoreDraftSettings(savedInstanceState)
         configureLocationFiltering()
+        configureTimelineDisplay()
         configureLanguageSelection()
         configureCameraPreparation()
         configureMonthDropdowns()
@@ -1980,6 +1985,7 @@ class MainActivity : AppCompatActivity() {
                 journalId = journalId,
                 start = start,
                 endExclusive = endExclusive,
+                routeDetail = if (simplifyRouteDetail) RouteDetail.SIMPLIFIED else RouteDetail.DETAILED,
                 onPreparationStage = { stage ->
                     withContext(Dispatchers.Main.immediate) {
                         if (requestId == journalRouteRequestId && activeJournalRouteRequest?.id == requestId) {
@@ -3607,12 +3613,26 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun configureLocationFiltering() {
-        locationFilterMode = settingsViewModel.state.value.locationFilter
-        settingsScreen.locationFilterSwitch.isChecked = locationFilterMode == LocationFilterMode.CONSERVATIVE
-        settingsScreen.locationFilterSwitch.setOnCheckedChangeListener { _, checked ->
-            locationFilterMode = if (checked) LocationFilterMode.CONSERVATIVE else LocationFilterMode.OFF
-            settingsViewModel.updateLocationFilter(locationFilterMode)
-            rebuildRenderTimeline(reselect = true)
+        locationFilterMode = LocationFilterMode.CONSERVATIVE
+    }
+
+    private fun configureTimelineDisplay() {
+        simplifyRouteDetail = settingsViewModel.state.value.simplifyRouteDetail
+        settingsScreen.simplifyRouteDetailSwitch.isChecked = simplifyRouteDetail
+        settingsScreen.simplifyRouteDetailSwitch.setOnCheckedChangeListener { _, checked ->
+            if (simplifyRouteDetail == checked) return@setOnCheckedChangeListener
+            simplifyRouteDetail = checked
+            settingsViewModel.updateSimplifyRouteDetail(checked)
+            if (!BuildConfig.IS_JOURNAL_LAB) return@setOnCheckedChangeListener
+            invalidateJournalRouteRequest()
+            activeJournalRoute = null
+            activeJournalRouteStart = null
+            activeJournalRouteEndExclusive = null
+            currentProjectDates()?.let { (start, end) ->
+                loadJournalRouteForRange(start, end) { outcome ->
+                    if (outcome == JournalRouteLoadOutcome.READY) selectRange()
+                }
+            }
         }
     }
 
@@ -4362,7 +4382,7 @@ class MainActivity : AppCompatActivity() {
         settingsScreen.videoQualityDropdown.isEnabled = !exporting
         settingsScreen.frameRateDropdown.isEnabled = !exporting
         settingsScreen.resetAdvancedSettingsButton.isEnabled = !exporting
-        settingsScreen.locationFilterSwitch.isEnabled = !exporting
+        settingsScreen.simplifyRouteDetailSwitch.isEnabled = !exporting
         renderPresetSelection()
         if (exporting) editor.videoReadyGroup.visibility = View.GONE
         if (!exporting) updateCameraPreparationUi()

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/route/JournalRouteService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/route/JournalRouteService.kt
@@ -24,6 +24,11 @@ data class JournalRoute(
     val semanticUsableCount: Int,
 )
 
+enum class RouteDetail {
+    DETAILED,
+    SIMPLIFIED,
+}
+
 /** The Journal changed while a derived route was being persisted, so this result is stale. */
 class StaleJournalRouteBuildException : CancellationException(
     "The Journal changed while its route was being prepared",
@@ -46,11 +51,12 @@ class JournalRouteService(
         endExclusive: Instant,
         maximumAccuracyMeters: Double? = RawSignalProcessor.DEFAULT_MAXIMUM_ACCURACY_METERS,
         discontinuity: Duration = JournalRouteFusion.DEFAULT_DISCONTINUITY,
+        routeDetail: RouteDetail = RouteDetail.DETAILED,
         onPreparationStage: suspend (JournalRoutePreparationStage) -> Unit = {},
     ): JournalRoute {
         require(endExclusive > start) { "The route range must not be empty" }
         val usesCanonicalSettings = maximumAccuracyMeters == RawSignalProcessor.DEFAULT_MAXIMUM_ACCURACY_METERS &&
-            discontinuity == JournalRouteFusion.DEFAULT_DISCONTINUITY
+            discontinuity == JournalRouteFusion.DEFAULT_DISCONTINUITY && routeDetail == RouteDetail.DETAILED
         if (!usesCanonicalSettings) {
             return reconstructWithContext(
                 journalId,
@@ -58,6 +64,7 @@ class JournalRouteService(
                 endExclusive,
                 maximumAccuracyMeters,
                 discontinuity,
+                routeDetail,
                 onPreparationStage,
             )
         }
@@ -137,6 +144,7 @@ class JournalRouteService(
                 boundedRefreshEnd,
                 maximumAccuracyMeters,
                 discontinuity,
+                routeDetail,
                 onPreparationStage,
             )
             previous.replacingWindow(boundedRefreshStart, boundedRefreshEnd, replacement)
@@ -161,6 +169,7 @@ class JournalRouteService(
                 rebuildEnd,
                 maximumAccuracyMeters,
                 discontinuity,
+                routeDetail,
                 onPreparationStage,
             )
         }
@@ -193,6 +202,7 @@ class JournalRouteService(
         endExclusive: Instant,
         maximumAccuracyMeters: Double?,
         discontinuity: Duration,
+        routeDetail: RouteDetail,
         onPreparationStage: suspend (JournalRoutePreparationStage) -> Unit,
     ): JournalRoute {
         val contextMillis = discontinuity.toMillis()
@@ -204,6 +214,7 @@ class JournalRouteService(
             queryEnd,
             maximumAccuracyMeters,
             discontinuity,
+            routeDetail,
             onPreparationStage,
         ).clippedTo(start, endExclusive)
     }
@@ -214,6 +225,7 @@ class JournalRouteService(
         endExclusive: Instant,
         maximumAccuracyMeters: Double?,
         discontinuity: Duration,
+        routeDetail: RouteDetail,
         onPreparationStage: suspend (JournalRoutePreparationStage) -> Unit,
     ): JournalRoute {
         val startMillis = start.toEpochMilli()
@@ -240,7 +252,7 @@ class JournalRouteService(
         )
         val spans = JournalRouteFusion.fuseSemanticPaths(
             semanticPaths = semanticPaths,
-            detailedPoints = detailed,
+            detailedPoints = if (routeDetail == RouteDetail.DETAILED || semanticPaths.isEmpty()) detailed else emptyList(),
             discontinuity = discontinuity,
         )
         val flattened = spans.asSequence()

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModel.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModel.kt
@@ -12,18 +12,21 @@ data class SettingsState(
     val camera: CameraSettings,
     val distanceUnit: DistanceUnitPreference,
     val locationFilter: LocationFilterMode,
+    val simplifyRouteDetail: Boolean,
 )
 
 class SettingsViewModel(
     private val cameraPreferences: CameraSettingsPreferences,
     private val distanceUnitPreferences: DistanceUnitPreferences,
     private val locationFilterPreferences: LocationFilterPreferences,
+    private val timelineDisplayPreferences: TimelineDisplayPreferences,
 ) : ViewModel() {
     private val mutableState = MutableStateFlow(
         SettingsState(
             camera = cameraPreferences.load(),
             distanceUnit = distanceUnitPreferences.load(),
             locationFilter = locationFilterPreferences.load(),
+            simplifyRouteDetail = timelineDisplayPreferences.simplifyRouteDetail(),
         ),
     )
     val state: StateFlow<SettingsState> = mutableState.asStateFlow()
@@ -47,5 +50,10 @@ class SettingsViewModel(
     fun updateLocationFilter(mode: LocationFilterMode) {
         locationFilterPreferences.save(mode)
         mutableState.value = mutableState.value.copy(locationFilter = mode)
+    }
+
+    fun updateSimplifyRouteDetail(enabled: Boolean) {
+        timelineDisplayPreferences.setSimplifyRouteDetail(enabled)
+        mutableState.value = mutableState.value.copy(simplifyRouteDetail = enabled)
     }
 }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineDisplayPreferences.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/TimelineDisplayPreferences.kt
@@ -1,0 +1,21 @@
+package dev.mahlernim.timelinevisualizer.ui
+
+import android.content.Context
+import androidx.core.content.edit
+
+class TimelineDisplayPreferences(context: Context) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    fun simplifyRouteDetail(): Boolean = preferences.getBoolean(KEY_SIMPLIFY_ROUTE_DETAIL, false)
+
+    fun setSimplifyRouteDetail(enabled: Boolean) {
+        preferences.edit { putBoolean(KEY_SIMPLIFY_ROUTE_DETAIL, enabled) }
+    }
+
+    fun clear() = preferences.edit { clear() }
+
+    private companion object {
+        const val PREFERENCES_NAME = "timeline-display-settings"
+        const val KEY_SIMPLIFY_ROUTE_DETAIL = "simplify-route-detail"
+    }
+}

--- a/app/src/main/res/layout/screen_settings.xml
+++ b/app/src/main/res/layout/screen_settings.xml
@@ -157,8 +157,8 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="24dp" android:text="@string/timeline_data" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
-        <com.google.android.material.materialswitch.MaterialSwitch android:id="@+id/locationFilterSwitch" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:text="@string/remove_impossible_jumps" />
-        <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="2dp" android:text="@string/remove_impossible_jumps_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
+        <com.google.android.material.materialswitch.MaterialSwitch android:id="@+id/simplifyRouteDetailSwitch" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:text="@string/simplify_route_detail" />
+        <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="2dp" android:text="@string/simplify_route_detail_summary" android:textAppearance="?attr/textAppearanceBodySmall" />
 
         <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="24dp" android:text="@string/about_and_privacy" android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold" />
         <TextView android:id="@+id/versionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:gravity="center_horizontal" android:textAppearance="?attr/textAppearanceBodyMedium" tools:text="Version 2.3.0 (33)" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -559,4 +559,6 @@
     <string name="onboarding_v11_start_body">Exportieren Sie eine aktuelle Timeline.json-Datei aus Google Maps und wählen Sie sie hier aus. Bei umfangreichem Verlauf kann das erste Mal etwas länger dauern. Spätere Importe ergänzen dasselbe Reisetagebuch um neue Details.</string>
     <string name="settings_why_import_title">Warum eine aktualisierte Datei importieren?</string>
     <string name="settings_why_import_detail">Aktuelle Timeline-Exporte können detaillierte Routen enthalten, die in einem späteren Export fehlen. Wenn Sie alle paar Wochen eine aktualisierte Datei importieren, bewahrt Ihr Reisetagebuch jeden neuen detaillierten Abschnitt auf diesem Gerät.</string>
+    <string name="simplify_route_detail">Routendetails vereinfachen</string>
+    <string name="simplify_route_detail_summary">Verwendet zusammengefasste Timeline-Aktivitäten für eine übersichtlichere Route in Videos über lange Zeiträume. Wenn die Option deaktiviert ist, wird die detaillierteste verfügbare Route verwendet.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -561,4 +561,6 @@
     <string name="onboarding_v11_start_body">Exporta un archivo Timeline.json actualizado desde Google Maps y elígelo aquí. Con historiales grandes, la primera vez puede tardar un poco más. Las importaciones futuras añaden nuevos detalles al mismo diario.</string>
     <string name="settings_why_import_title">¿Por qué importar un archivo actualizado?</string>
     <string name="settings_why_import_detail">Las exportaciones recientes de Timeline pueden incluir rutas detalladas que quizá no aparezcan en una exportación posterior. Importar un archivo actualizado cada pocas semanas permite que tu diario de viaje conserve en este dispositivo cada nuevo tramo detallado.</string>
+    <string name="simplify_route_detail">Simplificar el detalle de la ruta</string>
+    <string name="simplify_route_detail_summary">Usa la actividad resumida de Timeline para crear una ruta más clara en vídeos de periodos largos. Si está desactivado, se usa la ruta más detallada disponible.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -561,4 +561,6 @@
     <string name="onboarding_v11_start_body">Exportez un fichier Timeline.json à jour depuis Google Maps, puis choisissez-le ici. Avec un historique volumineux, la première fois peut prendre un peu plus de temps. Les imports suivants ajoutent de nouveaux détails au même carnet.</string>
     <string name="settings_why_import_title">Pourquoi importer un fichier à jour ?</string>
     <string name="settings_why_import_detail">Les exports Timeline récents peuvent contenir des itinéraires détaillés absents d\'un export ultérieur. En important un fichier à jour toutes les quelques semaines, votre carnet de voyage conserve sur cet appareil chaque nouvelle portion détaillée.</string>
+    <string name="simplify_route_detail">Simplifier le détail du trajet</string>
+    <string name="simplify_route_detail_summary">Utilise l’activité Timeline résumée pour créer un trajet plus clair dans les vidéos couvrant une longue période. Si cette option est désactivée, le trajet le plus détaillé disponible est utilisé.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -558,4 +558,6 @@
     <string name="onboarding_v11_start_body">Google マップから最新の Timeline.json をエクスポートし、ここで選択してください。履歴が大きい場合、初回は少し時間がかかることがあります。次回以降の読み込みでは、同じ記録に新しい詳細が追加されます。</string>
     <string name="settings_why_import_title">なぜ新しいファイルを読み込むのですか</string>
     <string name="settings_why_import_detail">最近の Timeline のエクスポートには、後のエクスポートには現れない詳細なルートが含まれていることがあります。数週間ごとに新しいファイルを読み込むと、新たな詳細区間をこの端末の旅の記録に残せます。</string>
+    <string name="simplify_route_detail">ルートの詳細を簡略化</string>
+    <string name="simplify_route_detail_summary">長期間の動画では、要約された Timeline アクティビティを使って見やすいルートを作成します。オフの場合は、利用可能な最も詳細なルートを使います。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -572,4 +572,6 @@
     <string name="onboarding_v11_start_body">Google 지도에서 최신 Timeline.json 파일을 내보낸 뒤 여기에서 선택하세요. 기록이 많으면 처음에는 시간이 조금 더 걸릴 수 있습니다. 이후 가져오기는 같은 여행 기록에 새로운 정보를 더합니다.</string>
     <string name="settings_why_import_title">왜 최신 파일을 가져와야 하나요?</string>
     <string name="settings_why_import_detail">최근에 내보낸 Timeline에는 나중에 내보낸 파일에는 없을 수 있는 상세 경로가 담겨 있습니다. 몇 주에 한 번씩 최신 파일을 가져오면 새로 생긴 상세 구간을 이 기기의 여행 기록에 계속 보관할 수 있습니다.</string>
+    <string name="simplify_route_detail">경로 세부 정보 단순화</string>
+    <string name="simplify_route_detail_summary">긴 기간의 동영상에서 요약된 Timeline 활동을 사용해 경로를 더 간결하게 표시합니다. 끄면 사용 가능한 가장 자세한 경로를 사용합니다.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -561,4 +561,6 @@
     <string name="onboarding_v11_start_body">Exporte um arquivo Timeline.json atualizado do Google Maps e escolha-o aqui. Com históricos grandes, a primeira vez pode demorar um pouco mais. As próximas importações adicionam novos detalhes ao mesmo diário.</string>
     <string name="settings_why_import_title">Por que importar um arquivo atualizado?</string>
     <string name="settings_why_import_detail">Exportações recentes da Timeline podem conter rotas detalhadas que talvez não apareçam em uma exportação posterior. Importar um arquivo atualizado a cada poucas semanas permite que seu diário de viagem preserve neste aparelho cada novo trecho detalhado.</string>
+    <string name="simplify_route_detail">Simplificar detalhes da rota</string>
+    <string name="simplify_route_detail_summary">Usa a atividade resumida da Timeline para criar uma rota mais clara em vídeos de períodos longos. Quando desativado, usa a rota mais detalhada disponível.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -551,4 +551,6 @@
     <string name="onboarding_v11_start_body">先从 Google 地图导出最新的 Timeline.json 文件，然后在这里选择它。历史记录较多时，首次处理可能稍慢。以后每次导入都会为同一份旅行记录添加新的细节。</string>
     <string name="settings_why_import_title">为什么要导入更新的文件？</string>
     <string name="settings_why_import_detail">较新的时间轴导出文件可能包含之后的导出文件中不再出现的详细路线。每隔几周导入一次更新的文件，就能把每段新的详细路线保留在本机的旅行记录中。</string>
+    <string name="simplify_route_detail">简化路线细节</string>
+    <string name="simplify_route_detail_summary">在长时间跨度的视频中使用摘要后的 Timeline 活动来生成更清晰的路线。关闭时使用可用的最详细路线。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -551,4 +551,6 @@
     <string name="onboarding_v11_start_body">先從 Google 地圖匯出最新的 Timeline.json 檔案，然後在這裡選擇。記錄較多時，首次處理可能稍久。日後每次匯入都會為同一份旅行記錄加入新的細節。</string>
     <string name="settings_why_import_title">為什麼要匯入更新的檔案？</string>
     <string name="settings_why_import_detail">較新的時間軸匯出檔案可能包含之後的匯出檔案中不再出現的詳細路線。每隔幾週匯入一次更新的檔案，就能把每段新的詳細路線保留在這部裝置的旅行記錄中。</string>
+    <string name="simplify_route_detail">簡化路線細節</string>
+    <string name="simplify_route_detail_summary">在長時間範圍的影片中使用摘要後的 Timeline 活動來產生更清晰的路線。關閉時使用可用的最詳細路線。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -622,4 +622,6 @@
     <string name="get_updated_timeline_file">Get updated Timeline file</string>
     <string name="journal_route_load_failed">Your Journal is safe, but its routes could not be prepared. Please try again.</string>
     <string name="save_as_preset">Save as preset</string>
+    <string name="simplify_route_detail">Simplify route detail</string>
+    <string name="simplify_route_detail_summary">Use summarized Timeline activity for a cleaner route in long-history videos. When off, the most detailed available route is used.</string>
 </resources>

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -596,8 +596,8 @@ class MainActivityTest {
             activity.findViewById<AutoCompleteTextView>(R.id.distanceUnitDropdown).text.toString(),
         )
         assertTrue(
-            activity.findViewById<com.google.android.material.materialswitch.MaterialSwitch>(
-                R.id.locationFilterSwitch,
+            !activity.findViewById<com.google.android.material.materialswitch.MaterialSwitch>(
+                R.id.simplifyRouteDetailSwitch,
             ).isChecked,
         )
         assertEquals(
@@ -689,33 +689,6 @@ class MainActivityTest {
             activity.findViewById<TimelineView>(R.id.timelineView).previewAspectRatio,
             0.001f,
         )
-    }
-
-    @Test
-    fun changingLocationFilterImmediatelyRestoresIgnoredPoints() {
-        assumeFalse(BuildConfig.IS_JOURNAL_LAB)
-        acceptPrivacyDisclosure()
-        val source = Uri.fromFile(repoRoot().resolve("test-fixtures/outlier-sample.json"))
-        val activity = launchActivity(Intent(Intent.ACTION_VIEW, source))
-        waitUntil { activity.findViewById<View>(R.id.editorGroup).visibility == View.VISIBLE }
-
-        val summary = activity.findViewById<TextView>(R.id.periodSummaryText)
-        assertTrue(
-            summary.text.contains(
-                activity.resources.getQuantityString(R.plurals.location_outliers_ignored, 1, 1),
-            ),
-        )
-
-        activity.findViewById<View>(R.id.navigationSettings).performClick()
-        activity.findViewById<View>(R.id.locationFilterSwitch).performClick()
-        activity.findViewById<View>(R.id.navigationCreate).performClick()
-
-        assertTrue(
-            !summary.text.contains(
-                activity.resources.getQuantityString(R.plurals.location_outliers_ignored, 1, 1),
-            ),
-        )
-        assertTrue(summary.text.contains("3"))
     }
 
     @Test

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/journal/route/JournalRouteServiceTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/journal/route/JournalRouteServiceTest.kt
@@ -76,6 +76,51 @@ class JournalRouteServiceTest {
     }
 
     @Test
+    fun simplifiedRouteUsesSemanticHistoryInsteadOfOverlappingDetailedPoints() = runBlocking {
+        repository.import(
+            JOURNAL_ID,
+            importInput(
+                hash = "simplified",
+                importedAt = minute(100),
+                observations = listOf(observation(0, 1.0), observation(10, 1.1)),
+                semantic = listOf(semantic(0, 60, listOf(point(0, 9.0), point(30, 9.3), point(60, 9.6)))),
+            ),
+        )
+
+        val route = service.route(
+            JOURNAL_ID,
+            BASE,
+            BASE.plus(Duration.ofMinutes(61)),
+            routeDetail = RouteDetail.SIMPLIFIED,
+        )
+
+        assertEquals(listOf(RouteSource.SEMANTIC_PATH), route.spans.map(RouteSpan::source))
+        assertEquals(listOf(9.0, 9.3, 9.6), route.timeline.points.map(GeoPoint::latitude))
+    }
+
+    @Test
+    fun simplifiedRouteFallsBackToDetailedHistoryWhenSemanticHistoryIsMissing() = runBlocking {
+        repository.import(
+            JOURNAL_ID,
+            importInput(
+                hash = "detailed-fallback",
+                importedAt = minute(100),
+                observations = listOf(observation(0, 1.0), observation(10, 1.1)),
+            ),
+        )
+
+        val route = service.route(
+            JOURNAL_ID,
+            BASE,
+            BASE.plus(Duration.ofMinutes(11)),
+            routeDetail = RouteDetail.SIMPLIFIED,
+        )
+
+        assertEquals(listOf(RouteSource.DETAILED), route.spans.map(RouteSpan::source))
+        assertEquals(listOf(1.0, 1.1), route.timeline.points.map(GeoPoint::latitude))
+    }
+
+    @Test
     fun detailedDiscontinuityWithoutSemanticCoverageBecomesAnInferredTransfer() = runBlocking {
         repository.import(
             JOURNAL_ID,

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/SettingsViewModelTest.kt
@@ -22,6 +22,7 @@ class SettingsViewModelTest {
     private lateinit var cameraPreferences: CameraSettingsPreferences
     private lateinit var distancePreferences: DistanceUnitPreferences
     private lateinit var filterPreferences: LocationFilterPreferences
+    private lateinit var timelineDisplayPreferences: TimelineDisplayPreferences
 
     @Before
     fun setUp() {
@@ -29,6 +30,7 @@ class SettingsViewModelTest {
         cameraPreferences = CameraSettingsPreferences(context)
         distancePreferences = DistanceUnitPreferences(context)
         filterPreferences = LocationFilterPreferences(context)
+        timelineDisplayPreferences = TimelineDisplayPreferences(context)
         clearPreferences()
     }
 
@@ -47,11 +49,13 @@ class SettingsViewModelTest {
         viewModel.updateCamera(camera)
         viewModel.updateDistanceUnit(DistanceUnitPreference.MILES)
         viewModel.updateLocationFilter(LocationFilterMode.OFF)
+        viewModel.updateSimplifyRouteDetail(true)
 
-        assertEquals(SettingsState(camera, DistanceUnitPreference.MILES, LocationFilterMode.OFF), viewModel.state.value)
+        assertEquals(SettingsState(camera, DistanceUnitPreference.MILES, LocationFilterMode.OFF, true), viewModel.state.value)
         assertEquals(camera, cameraPreferences.load())
         assertEquals(DistanceUnitPreference.MILES, distancePreferences.load())
         assertEquals(LocationFilterMode.OFF, filterPreferences.load())
+        assertEquals(true, timelineDisplayPreferences.simplifyRouteDetail())
     }
 
     @Test
@@ -68,11 +72,17 @@ class SettingsViewModelTest {
         assertEquals(LocationFilterMode.OFF, viewModel.state.value.locationFilter)
     }
 
-    private fun viewModel() = SettingsViewModel(cameraPreferences, distancePreferences, filterPreferences)
+    private fun viewModel() = SettingsViewModel(
+        cameraPreferences,
+        distancePreferences,
+        filterPreferences,
+        timelineDisplayPreferences,
+    )
 
     private fun clearPreferences() {
         cameraPreferences.reset()
         distancePreferences.clear()
         filterPreferences.reset()
+        timelineDisplayPreferences.clear()
     }
 }


### PR DESCRIPTION
## Summary

- add an off-by-default Simplify route detail switch
- use semantic Timeline history for simplified videos
- keep detailed routes as the default and fallback
- keep impossible-jump filtering automatic

## Testing

- `testGithubDebugUnitTest`
- `lintGithubDebug`
- `assembleGithubDebug`

Closes #192