### PR TITLE
Add language selection to onboarding

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -1017,6 +1017,7 @@ class MainActivity : AppCompatActivity() {
         onboarding.onboardingSkipButton.setOnClickListener {
             onboarding.onboardingPager.currentItem = pages.lastIndex
         }
+        onboarding.onboardingLanguageButton.setOnClickListener { showOnboardingLanguagePicker() }
         onboarding.onboardingChooseFileButton.setOnClickListener {
             journalOnboardingStore.complete()
             showJournalSetup(returnToCreate = false)
@@ -1068,6 +1069,8 @@ class MainActivity : AppCompatActivity() {
         onboarding.onboardingBackButton.visibility =
             if (onboardingPage > 0 || onboardingReplay) View.VISIBLE else View.INVISIBLE
         onboarding.onboardingSkipButton.visibility = if (isFinal) View.INVISIBLE else View.VISIBLE
+        onboarding.onboardingLanguageButton.visibility = if (onboardingPage == 0) View.VISIBLE else View.GONE
+        updateOnboardingLanguageLabel()
         onboarding.onboardingNavigationActions.visibility = if (isFinal) View.GONE else View.VISIBLE
         onboarding.onboardingFinalActions.visibility = if (isFinal) View.VISIBLE else View.GONE
         val announcement = getString(
@@ -3697,7 +3700,16 @@ class MainActivity : AppCompatActivity() {
         Resources.getSystem().configuration.locales[0] ?: Locale.getDefault(Locale.Category.FORMAT)
 
     private fun configureLanguageSelection() {
-        val labels = listOf(
+        val labels = languageLabels()
+        val dropdown = settingsScreen.languageDropdown
+        dropdown.setAdapter(SelectionArrayAdapter(this, labels))
+        makeDropdownOpenReliably(dropdown)
+        updateLanguageSelectionLabel()
+        dropdown.post(::updateLanguageSelectionLabel)
+        dropdown.setOnItemClickListener { _, _, position, _ -> applyLanguageSelection(position) }
+    }
+
+    private fun languageLabels(): List<String> = listOf(
             getString(R.string.language_system_default),
             getString(R.string.language_name_en),
             getString(R.string.language_name_ko),
@@ -3709,17 +3721,30 @@ class MainActivity : AppCompatActivity() {
             getString(R.string.language_name_de),
             getString(R.string.language_name_pt_br),
         )
-        val dropdown = settingsScreen.languageDropdown
-        dropdown.setAdapter(SelectionArrayAdapter(this, labels))
-        makeDropdownOpenReliably(dropdown)
-        updateLanguageSelectionLabel()
-        dropdown.post(::updateLanguageSelectionLabel)
-        dropdown.setOnItemClickListener { _, _, position, _ ->
-            val locales = AppLanguage.localesForSelection(position)
-            if (AppCompatDelegate.getApplicationLocales() != locales) {
-                AppCompatDelegate.setApplicationLocales(locales)
-            }
+
+    private fun applyLanguageSelection(position: Int) {
+        val locales = AppLanguage.localesForSelection(position)
+        if (AppCompatDelegate.getApplicationLocales() != locales) {
+            AppCompatDelegate.setApplicationLocales(locales)
         }
+    }
+
+    private fun showOnboardingLanguagePicker() {
+        val labels = languageLabels().toTypedArray()
+        val selected = AppLanguage.selectionIndex(currentApplicationLanguageTags())
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.language)
+            .setSingleChoiceItems(labels, selected) { dialog, position ->
+                dialog.dismiss()
+                applyLanguageSelection(position)
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun updateOnboardingLanguageLabel() {
+        val selected = AppLanguage.selectionIndex(currentApplicationLanguageTags())
+        onboarding.onboardingLanguageButton.text = languageLabels()[selected]
     }
 
     private fun updateLanguageSelectionLabel() {

--- a/app/src/main/res/layout/screen_journal_onboarding.xml
+++ b/app/src/main/res/layout/screen_journal_onboarding.xml
@@ -34,6 +34,16 @@
             android:text="@string/onboarding_skip" />
     </LinearLayout>
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/onboardingLanguageButton"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginEnd="20dp"
+        android:minHeight="48dp"
+        android:text="@string/language" />
+
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/onboardingPager"
         android:layout_width="match_parent"

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/JournalOnboardingUiTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/JournalOnboardingUiTest.kt
@@ -60,6 +60,11 @@ class JournalOnboardingUiTest {
         assertEquals(0.24f, activity.findViewById<View>(R.id.onboardingDotThree).alpha)
         assertEquals(View.INVISIBLE, activity.findViewById<View>(R.id.onboardingBackButton).visibility)
         assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.onboardingNextButton).visibility)
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.onboardingLanguageButton).visibility)
+        assertEquals(
+            activity.getString(R.string.language_system_default),
+            activity.findViewById<TextView>(R.id.onboardingLanguageButton).text,
+        )
         assertTrue(activity.findViewById<TextView>(R.id.onboardingPageTitle).isAccessibilityHeading)
     }
 
@@ -76,6 +81,7 @@ class JournalOnboardingUiTest {
 
         assertEquals(View.VISIBLE, recreated.findViewById<View>(R.id.journalOnboardingScreen).visibility)
         assertEquals(View.VISIBLE, recreated.findViewById<View>(R.id.onboardingBackButton).visibility)
+        assertEquals(View.GONE, recreated.findViewById<View>(R.id.onboardingLanguageButton).visibility)
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Add a language button to the first onboarding page
- Apply the selected language immediately
- Keep the selector off later onboarding pages

## Checks

- Unit tests
- Android lint
- Debug APK build

Closes #193