### PR TITLE
Prepare 3.0.3 release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 44
-        versionName = "3.0.2"
+        versionCode = 45
+        versionName = "3.0.3"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/release-notes-v3.0.3.md
+++ b/docs/release-notes-v3.0.3.md
@@ -1,0 +1,98 @@
+# Timeline Visualizer 3.0.3
+
+This release adds more control over route rendering and makes first-time setup easier.
+
+- Simplify route detail for long histories by using summarized Timeline paths. Detailed routes remain the default.
+- Keep past routes visible while a video progresses. This optional feature uses an efficient cached trail based on Ahmad Kaleem Bhatti's contribution.
+- Choose the app language on the first onboarding screen.
+- Impossible jumps are filtered automatically.
+
+Your Travel Journal, Timeline file, and saved videos are unchanged.
+
+## 한국어
+
+경로 표현을 더 세밀하게 조절할 수 있고 첫 설정이 쉬워졌습니다.
+
+- 긴 기록에서는 요약된 Timeline 경로를 사용해 경로를 단순화할 수 있습니다. 기본값은 상세 경로입니다.
+- 동영상이 진행되는 동안 이전 경로를 계속 표시할 수 있습니다. Ahmad Kaleem Bhatti의 기여를 바탕으로 효율적인 캐시 방식을 사용합니다.
+- 첫 온보딩 화면에서 앱 언어를 선택할 수 있습니다.
+- 불가능한 위치 이동은 자동으로 제거됩니다.
+
+여행 기록과 Timeline 파일, 저장된 동영상은 변경되지 않습니다.
+
+## 日本語
+
+ルート表示の選択肢を増やし、初回設定を使いやすくしました。
+
+- 長期間の履歴では、要約された Timeline の経路を使ってルートを簡略化できます。詳細ルートが初期設定です。
+- 動画の進行中に過去のルートを残せます。この任意機能は Ahmad Kaleem Bhatti の貢献を基に効率的なキャッシュを使います。
+- 最初のオンボーディング画面でアプリの言語を選べます。
+- あり得ない移動は自動で除去されます。
+
+旅行記録、Timeline ファイル、保存済み動画は変更されません。
+
+## 简体中文
+
+此版本增加了路线显示选项，并简化首次设置。
+
+- 对于较长的历史记录，可使用 Timeline 摘要路径来简化路线。默认仍为详细路线。
+- 视频播放时可保留已走过的路线。此可选功能采用基于 Ahmad Kaleem Bhatti 贡献的高效缓存方式。
+- 可在首个引导页面选择应用语言。
+- 不可能的跳跃会自动过滤。
+
+你的旅行记录、Timeline 文件和已保存的视频不会改变。
+
+## 繁體中文
+
+此版本增加了路線顯示選項，並簡化首次設定。
+
+- 對於較長的歷史記錄，可使用 Timeline 摘要路徑來簡化路線。預設仍為詳細路線。
+- 影片播放時可保留已走過的路線。此選用功能採用基於 Ahmad Kaleem Bhatti 貢獻的高效快取方式。
+- 可在第一個引導頁面選擇應用程式語言。
+- 不可能的跳躍會自動過濾。
+
+你的旅行記錄、Timeline 檔案和已儲存的影片不會改變。
+
+## Español
+
+Esta versión ofrece más control sobre las rutas y facilita la configuración inicial.
+
+- Puede simplificar recorridos largos con las rutas resumidas de Timeline. La ruta detallada sigue siendo la opción predeterminada.
+- Puede mantener visibles las rutas anteriores mientras avanza el vídeo. Esta función opcional usa una caché eficiente basada en la contribución de Ahmad Kaleem Bhatti.
+- Puede elegir el idioma en la primera pantalla de introducción.
+- Los saltos imposibles se filtran automáticamente.
+
+Su diario de viaje, archivo Timeline y vídeos guardados no cambian.
+
+## Français
+
+Cette version améliore le contrôle du tracé et simplifie la première configuration.
+
+- Vous pouvez simplifier les longs historiques avec les trajets résumés de Timeline. Le tracé détaillé reste le réglage par défaut.
+- Vous pouvez garder les anciens trajets visibles pendant la vidéo. Cette option utilise un cache efficace fondé sur la contribution de Ahmad Kaleem Bhatti.
+- Vous pouvez choisir la langue sur le premier écran d'accueil.
+- Les déplacements impossibles sont filtrés automatiquement.
+
+Votre carnet de voyage, fichier Timeline et vidéos enregistrées restent inchangés.
+
+## Deutsch
+
+Diese Version bietet mehr Kontrolle über Routen und erleichtert die Ersteinrichtung.
+
+- Lange Verläufe lassen sich mit zusammengefassten Timeline-Pfaden vereinfachen. Detaillierte Routen bleiben die Voreinstellung.
+- Frühere Routen können während des Videos sichtbar bleiben. Diese optionale Funktion nutzt einen effizienten Cache auf Basis des Beitrags von Ahmad Kaleem Bhatti.
+- Die App-Sprache kann auf dem ersten Einführungsbildschirm gewählt werden.
+- Unmögliche Sprünge werden automatisch gefiltert.
+
+Reisetagebuch, Timeline-Datei und gespeicherte Videos bleiben unverändert.
+
+## Português (Brasil)
+
+Esta versão oferece mais controle sobre as rotas e facilita a configuração inicial.
+
+- Você pode simplificar históricos longos usando os trajetos resumidos do Timeline. A rota detalhada continua sendo o padrão.
+- Você pode manter rotas anteriores visíveis durante o vídeo. Este recurso opcional usa um cache eficiente baseado na contribuição de Ahmad Kaleem Bhatti.
+- Você pode escolher o idioma na primeira tela de introdução.
+- Saltos impossíveis são filtrados automaticamente.
+
+Seu diário de viagem, arquivo Timeline e vídeos salvos não mudam.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.2` and version code `44`
+- Version name `3.0.3` and version code `45`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 44' in build_file
-    assert 'versionName = "3.0.2"' in build_file
+    assert 'versionCode = 45' in build_file
+    assert 'versionName = "3.0.3"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
## What changed

- Set version 3.0.3 with version code 45
- Add localized release notes

## Release contents

- Simplified route detail
- Optional persistent past routes
- Language selection on the first onboarding screen