### PR TITLE
Fix recap preparation indicator

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -1245,7 +1245,10 @@ class MainActivity : AppCompatActivity() {
         val hasJournalMetadata = BuildConfig.IS_JOURNAL_LAB && activeJournalStatus != null
         editor.createTypeStepGroup.visibility = if (isType && (hasTimeline || hasJournalMetadata)) View.VISIBLE else View.GONE
         editor.journalRoutePreparingGroup.visibility = if (
-            hasJournalMetadata && journalRouteLoadJob?.isActive == true
+            hasJournalMetadata &&
+            isProject &&
+            journalRouteLoadJob?.isActive == true &&
+            !selectedJournalRangeReady()
         ) {
             View.VISIBLE
         } else {
@@ -1316,19 +1319,17 @@ class MainActivity : AppCompatActivity() {
     private fun updateWizardContinueAvailability() {
         if (!::editor.isInitialized) return
         val isProject = currentCreateStep == CreateStep.PROJECT
-        val selectedJournalRangeReady = if (BuildConfig.IS_JOURNAL_LAB && isProject) {
-            currentProjectDates()?.let { (start, end) ->
-                val zone = ZoneId.systemDefault()
-                journalRouteCovers(
-                    start.atStartOfDay(zone).toInstant(),
-                    end.plusDays(1).atStartOfDay(zone).toInstant(),
-                )
-            } == true
-        } else {
-            true
-        }
+        val selectedJournalRangeReady = !BuildConfig.IS_JOURNAL_LAB || !isProject || selectedJournalRangeReady()
         editor.wizardContinueButton.isEnabled = !(isProject && rawProjectRangeConflict) && selectedJournalRangeReady
     }
+
+    private fun selectedJournalRangeReady(): Boolean = currentProjectDates()?.let { (start, end) ->
+        val zone = ZoneId.systemDefault()
+        journalRouteCovers(
+            start.atStartOfDay(zone).toInstant(),
+            end.plusDays(1).atStartOfDay(zone).toInstant(),
+        )
+    } == true
 
     private fun renderCreateStepper() {
         val stage = currentCreateStage()

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/JournalLabUiTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/JournalLabUiTest.kt
@@ -279,6 +279,29 @@ class JournalLabUiTest {
     }
 
     @Test
+    fun firstImportRecapHidesPreparationIndicatorWhenTheRouteIsReady() {
+        val activity = launchActivity()
+        activity.importTimeline(Uri.fromFile(twoYearTimeline()))
+        waitUntil {
+            activity.journalMetadataReady() &&
+                activity.findViewById<View>(R.id.loadingGroup).visibility == View.GONE
+        }
+        ShadowDialog.getLatestDialog()?.dismiss()
+        activity.findViewById<View>(R.id.navigationCreate).performClick()
+        activity.findViewById<View>(R.id.recapVideoChoice).performClick()
+        val recapDialog = ShadowDialog.getLatestDialog() as androidx.appcompat.app.AlertDialog
+        recapDialog.listView.performItemClick(null, 0, 0L)
+
+        val continueButton = activity.findViewById<View>(R.id.wizardContinueButton)
+        waitUntil(continueButton::isEnabled)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.journalRoutePreparingGroup).visibility)
+
+        continueButton.performClick()
+        assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.styleStepGroup).visibility)
+        assertEquals(View.GONE, activity.findViewById<View>(R.id.journalRoutePreparingGroup).visibility)
+    }
+
+    @Test
     fun findTripsIsAvailableFromJournalMetadataBeforeGeometryLoads() {
         val database = JournalDatabase.open(context)
         runBlocking {


### PR DESCRIPTION
## Summary
- hide recap preparation when the selected route is ready
- keep the indicator on Step 1 only
- add first-import recap regression coverage

## Validation
- `testJournalLabDebugUnitTest --tests dev.mahlernim.timelinevisualizer.JournalLabUiTest`
- `lintJournalLabDebug`

Closes #199