### PR TITLE
Add 120 fps export option

### DIFF
--- a/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/DeviceSmokeTest.kt
+++ b/app/src/androidTest/java/dev/mahlernim/timelinevisualizer/DeviceSmokeTest.kt
@@ -74,7 +74,7 @@ class DeviceSmokeTest {
                 add(R.id.cameraMovementDropdown to 4)
                 add(R.id.longTripDropdown to 4)
                 add(R.id.videoQualityDropdown to 6)
-                add(R.id.frameRateDropdown to 4)
+                add(R.id.frameRateDropdown to 5)
                 add(R.id.languageDropdown to 10)
                 add(R.id.tripDetectionDropdown to 3)
                 add(R.id.localFramingDropdown to 3)

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -1127,7 +1127,7 @@ class MainActivity : AppCompatActivity() {
             val format = working.activeVideoFormat
             resolutionLabels += getString(R.string.custom_resolution_selected, format.width, format.height)
         }
-        val presetFrameRates = listOf(24, 30, 60)
+        val presetFrameRates = listOf(24, 30, 60, 120)
         val frameRateLabels = presetFrameRates.map { getString(R.string.frame_rate_value, it) }.toMutableList()
         val currentFrameRateIndex = presetFrameRates.indexOf(working.effectiveExportFormat.frameRate)
         if (currentFrameRateIndex < 0 || working.effectiveExportFormat.customFrameRate) {
@@ -3205,7 +3205,7 @@ class MainActivity : AppCompatActivity() {
             R.string.resolution_1440,
             R.string.resolution_2160,
         ).map(::getString) + getString(R.string.custom_action)
-        val frameRateLabels = listOf(24, 30, 60).map { getString(R.string.frame_rate_value, it) } +
+        val frameRateLabels = listOf(24, 30, 60, 120).map { getString(R.string.frame_rate_value, it) } +
             getString(R.string.custom_action)
         val tripDetectionLabels = listOf(
             R.string.trip_detection_conservative,
@@ -3267,7 +3267,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
         settingsScreen.frameRateDropdown.setOnItemClickListener { _, _, position, _ ->
-            val presetRates = listOf(24, 30, 60)
+            val presetRates = listOf(24, 30, 60, 120)
             if (position == presetRates.size) {
                 showCustomFrameRateDialog()
             } else {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
@@ -93,7 +93,7 @@ data class ExportFormatSettings(
         const val MIN_SHORT_EDGE = 480
         const val MAX_SHORT_EDGE = 2160
         const val MIN_FRAME_RATE = 15
-        const val MAX_FRAME_RATE = 60
+        const val MAX_FRAME_RATE = 120
         const val DEFAULT_SHORT_EDGE = 480
         const val DEFAULT_FRAME_RATE = 30
 

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -625,22 +625,22 @@ class MainActivityTest {
     }
 
     @Test
-    fun settingsSelect2160pAnd60FramesPerSecondWithoutChangingAspect() {
+    fun settingsSelect2160pAnd120FramesPerSecondWithoutChangingAspect() {
         val activity = launchActivity()
         activity.findViewById<View>(R.id.navigationSettings).performClick()
         val resolution = activity.findViewById<AutoCompleteTextView>(R.id.videoQualityDropdown)
         val frameRate = activity.findViewById<AutoCompleteTextView>(R.id.frameRateDropdown)
 
         resolution.onItemClickListener?.onItemClick(null, null, 4, 4)
-        frameRate.onItemClickListener?.onItemClick(null, null, 2, 2)
+        frameRate.onItemClickListener?.onItemClick(null, null, 3, 3)
 
         assertEquals(
             activity.getString(R.string.preset_resolution_selected, 2160, 2160, 2160),
             resolution.text.toString(),
         )
-        assertEquals(activity.getString(R.string.frame_rate_value, 60), frameRate.text.toString())
+        assertEquals(activity.getString(R.string.frame_rate_value, 120), frameRate.text.toString())
         assertEquals(2160, CameraSettingsPreferences(context).load().activeVideoFormat.width)
-        assertEquals(60, CameraSettingsPreferences(context).load().activeVideoFormat.frameRate)
+        assertEquals(120, CameraSettingsPreferences(context).load().activeVideoFormat.frameRate)
     }
 
     @Test

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/VideoQualityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/VideoQualityTest.kt
@@ -33,8 +33,8 @@ class VideoQualityTest {
         assertEquals(2160, ExportFormatSettings.parseShortEdge("2160"))
         assertEquals(null, ExportFormatSettings.parseShortEdge("479"))
         assertEquals(15, ExportFormatSettings.parseFrameRate("15"))
-        assertEquals(60, ExportFormatSettings.parseFrameRate("60"))
-        assertEquals(null, ExportFormatSettings.parseFrameRate("61"))
+        assertEquals(120, ExportFormatSettings.parseFrameRate("120"))
+        assertEquals(null, ExportFormatSettings.parseFrameRate("121"))
     }
 
     @Test


### PR DESCRIPTION
## summary

- add 120 fps as an android export preset
- allow custom frame rates through 120 fps
- retain device encoder validation so unsupported combinations remain blocked
- keep existing defaults and saved settings unchanged

## validation

- `gradlew testGithubDebugUnitTest`
- `gradlew lintGithubDebug`

refs #41