### PR TITLE
Prepare 3.0.4 release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 45
-        versionName = "3.0.3"
+        versionCode = 46
+        versionName = "3.0.4"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/release-notes-v3.0.4.md
+++ b/docs/release-notes-v3.0.4.md
@@ -1,0 +1,89 @@
+# Timeline Visualizer 3.0.4
+
+This release improves video creation and playback controls.
+
+- Export videos at 120 FPS when supported by your device.
+- Keep the preview playback control away from the map marker.
+- Stop showing the journey preparation indicator after preparation finishes.
+
+Your Travel Journal, Timeline file, and saved videos are unchanged.
+
+## 한국어
+
+동영상 생성과 재생 조작을 개선했습니다.
+
+- 기기에서 지원하는 경우 120 FPS로 동영상을 내보낼 수 있습니다.
+- 미리보기 재생 버튼이 지도 마커를 가리지 않습니다.
+- 준비가 끝나면 여행 준비 표시가 사라집니다.
+
+여행 기록과 Timeline 파일, 저장된 동영상은 변경되지 않습니다.
+
+## 日本語
+
+動画作成と再生操作を改善しました。
+
+- 端末が対応している場合、120 FPS で動画を書き出せます。
+- プレビューの再生ボタンが地図のマーカーを隠さなくなりました。
+- 準備が完了すると、移動履歴の準備表示が消えます。
+
+旅行記録、Timeline ファイル、保存済み動画は変更されません。
+
+## 简体中文
+
+此版本改进了视频创建和播放控件。
+
+- 设备支持时可用 120 FPS 导出视频。
+- 预览播放按钮不再遮挡地图标记。
+- 准备完成后，行程准备提示会消失。
+
+你的旅行记录、Timeline 文件和已保存的视频不会改变。
+
+## 繁體中文
+
+此版本改善了影片建立和播放控制項。
+
+- 裝置支援時可用 120 FPS 匯出影片。
+- 預覽播放按鈕不再遮擋地圖標記。
+- 準備完成後，旅程準備提示會消失。
+
+你的旅行記錄、Timeline 檔案和已儲存的影片不會改變。
+
+## Español
+
+Esta versión mejora la creación de vídeos y los controles de reproducción.
+
+- Puede exportar vídeos a 120 FPS si el dispositivo lo admite.
+- El control de reproducción de la vista previa ya no tapa el marcador del mapa.
+- El indicador de preparación desaparece cuando finaliza el proceso.
+
+Su diario de viaje, archivo Timeline y vídeos guardados no cambian.
+
+## Français
+
+Cette version améliore la création des vidéos et les commandes de lecture.
+
+- Vous pouvez exporter des vidéos à 120 FPS si votre appareil le permet.
+- La commande de lecture de l'aperçu ne masque plus le marqueur de la carte.
+- L'indicateur de préparation disparaît lorsque le traitement est terminé.
+
+Votre carnet de voyage, fichier Timeline et vidéos enregistrées restent inchangés.
+
+## Deutsch
+
+Diese Version verbessert die Videoerstellung und die Wiedergabesteuerung.
+
+- Videos können mit 120 FPS exportiert werden, wenn das Gerät dies unterstützt.
+- Die Wiedergabesteuerung der Vorschau verdeckt den Kartenmarker nicht mehr.
+- Die Vorbereitungsanzeige verschwindet, sobald die Verarbeitung abgeschlossen ist.
+
+Reisetagebuch, Timeline-Datei und gespeicherte Videos bleiben unverändert.
+
+## Português (Brasil)
+
+Esta versão melhora a criação de vídeos e os controles de reprodução.
+
+- Você pode exportar vídeos a 120 FPS quando o dispositivo oferecer suporte.
+- O controle de reprodução da prévia não cobre mais o marcador do mapa.
+- O indicador de preparação desaparece quando o processamento termina.
+
+Seu diário de viagem, arquivo Timeline e vídeos salvos não mudam.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.3` and version code `45`
+- Version name `3.0.4` and version code `46`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 45' in build_file
-    assert 'versionName = "3.0.3"' in build_file
+    assert 'versionCode = 46' in build_file
+    assert 'versionName = "3.0.4"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
Summary

- Bump the production version to 3.0.4 with version code 46.
- Add localized notes for the 120 FPS option, preview playback control placement, and preparation indicator fix.
- Update packaging assertions and the Play submission checklist.

Validation

- Packaging tests pass.