### PR TITLE
Prepare 3.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - Add distance-unit selection to the web app.
 - Document the web app's distance units and close-up mode.
 
+## 3.0.5
+
+- Constrain the Detect trips date picker to the available Timeline range.
+- Keep the first and final available dates selectable while disabling adjacent unavailable dates.
+- Clamp outdated initial date selections before opening constrained date pickers.
+- Set Android version code 47 and version name 3.0.5.
+
 ## 3.0.2
 
 - Remove clusters of consecutive impossible raw-signal readings, which previously survived because the spike filter only ever inspected a single point between its neighbours.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 46
-        versionName = "3.0.4"
+        versionCode = 47
+        versionName = "3.0.5"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/release-notes-v3.0.5.md
+++ b/docs/release-notes-v3.0.5.md
@@ -1,0 +1,80 @@
+# Timeline Visualizer 3.0.5
+
+This release fixes date selection for trip detection.
+
+- The date picker now stays within the dates available in your Timeline.
+- The first and final available dates remain selectable.
+
+Your Travel Journal, Timeline file, and saved videos are unchanged.
+
+## 한국어
+
+이번 릴리스에서는 여행 감지를 위한 날짜 선택을 수정했습니다.
+
+- 날짜 선택 화면에서 Timeline에 실제로 있는 날짜 범위만 선택할 수 있습니다.
+- 사용 가능한 첫날과 마지막 날을 모두 선택할 수 있습니다.
+
+여행 기록과 Timeline 파일, 저장된 동영상은 변경되지 않습니다.
+
+## 日本語
+
+このリリースでは、旅行検出の日付選択を修正しました。
+
+- 日付選択画面で、Timeline に実際に含まれる期間だけを選択できます。
+- 利用可能な最初の日と最後の日の両方を選択できます。
+
+旅行記録、Timeline ファイル、保存済み動画は変更されません。
+
+## 简体中文
+
+此版本修复了行程检测的日期选择。
+
+- 日期选择器现在仅允许选择 Timeline 中实际存在的日期范围。
+- 可用范围的第一天和最后一天均可选择。
+
+你的旅行记录、Timeline 文件和已保存的视频不会改变。
+
+## 繁體中文
+
+此版本修正了旅程偵測的日期選擇。
+
+- 日期選擇器現在只允許選擇 Timeline 中實際存在的日期範圍。
+- 可用範圍的第一天和最後一天都可以選擇。
+
+你的旅行記錄、Timeline 檔案和已儲存的影片不會改變。
+
+## Español
+
+Esta versión corrige la selección de fechas para detectar viajes.
+
+- El selector ahora se limita a las fechas disponibles en su Timeline.
+- El primer y el último día disponibles se pueden seleccionar.
+
+Su diario de viaje, archivo Timeline y vídeos guardados no cambian.
+
+## Français
+
+Cette version corrige la sélection des dates pour la détection des voyages.
+
+- Le sélecteur se limite désormais aux dates disponibles dans votre Timeline.
+- Le premier et le dernier jour disponibles restent sélectionnables.
+
+Votre carnet de voyage, fichier Timeline et vidéos enregistrées restent inchangés.
+
+## Deutsch
+
+Diese Version korrigiert die Datumsauswahl für die Reiseerkennung.
+
+- Die Datumsauswahl ist jetzt auf die in Ihrer Timeline verfügbaren Tage begrenzt.
+- Der erste und der letzte verfügbare Tag bleiben auswählbar.
+
+Reisetagebuch, Timeline-Datei und gespeicherte Videos bleiben unverändert.
+
+## Português (Brasil)
+
+Esta versão corrige a seleção de datas para detectar viagens.
+
+- O seletor agora fica limitado às datas disponíveis na sua Timeline.
+- O primeiro e o último dia disponíveis continuam selecionáveis.
+
+Seu diário de viagem, arquivo Timeline e vídeos salvos não mudam.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.4` and version code `46`
+- Version name `3.0.5` and version code `47`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 46' in build_file
-    assert 'versionName = "3.0.4"' in build_file
+    assert 'versionCode = 47' in build_file
+    assert 'versionName = "3.0.5"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
## Summary

- release the inclusive Timeline date-picker fix from PR #181 as Android 3.0.5
- set Android version code 47 and version name 3.0.5
- add user-facing release notes in all nine supported locales

## Why a patch release

PR #181 corrects existing date-selection behavior without changing the product scope or data model. PR #206 affects only the Python CLI and web app, so it is not presented as an Android change. Open PRs #204 and #205 are intentionally excluded.

## Validation

- `git diff --check`
- `testGithubDebugUnitTest`
- `lintGithubDebug`
- `assembleGithubDebug`
- `bundlePlayDebug`