### PR TITLE
Improve semantic close-up camera framing

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequest.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequest.kt
@@ -3,6 +3,7 @@ package dev.mahlernim.timelinevisualizer.export
 import android.content.Context
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
+import dev.mahlernim.timelinevisualizer.model.JourneySemanticEpisode
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
 import dev.mahlernim.timelinevisualizer.render.RenderText
 import dev.mahlernim.timelinevisualizer.render.CameraSettings
@@ -81,6 +82,17 @@ class VideoExportRequestStore(context: Context) {
             request.journey.breakBeforePointIndices.forEach(output::writeInt)
             output.writeInt(request.journey.inferredTransferBeforePointIndices.size)
             request.journey.inferredTransferBeforePointIndices.forEach(output::writeInt)
+            output.writeInt(request.journey.semanticEpisodes.size)
+            request.journey.semanticEpisodes.forEach { episode ->
+                output.writeDouble(episode.startKm)
+                output.writeDouble(episode.endKm)
+                output.writeLong(episode.origin.instant.toEpochMilli())
+                output.writeDouble(episode.origin.latitude)
+                output.writeDouble(episode.origin.longitude)
+                output.writeLong(episode.destination.instant.toEpochMilli())
+                output.writeDouble(episode.destination.latitude)
+                output.writeDouble(episode.destination.longitude)
+            }
         }
         if (!temporaryFile.renameTo(requestFile)) {
             temporaryFile.copyTo(requestFile, overwrite = true)
@@ -215,6 +227,27 @@ class VideoExportRequestStore(context: Context) {
                 } else {
                     emptyList()
                 }
+                val semanticEpisodes = if (version >= 15) {
+                    val episodeCount = input.readInt().coerceIn(0, MAX_SEMANTIC_EPISODE_COUNT)
+                    List(episodeCount) {
+                        JourneySemanticEpisode(
+                            startKm = input.readDouble(),
+                            endKm = input.readDouble(),
+                            origin = GeoPoint(
+                                instant = Instant.ofEpochMilli(input.readLong()),
+                                latitude = input.readDouble(),
+                                longitude = input.readDouble(),
+                            ),
+                            destination = GeoPoint(
+                                instant = Instant.ofEpochMilli(input.readLong()),
+                                latitude = input.readDouble(),
+                                longitude = input.readDouble(),
+                            ),
+                        )
+                    }
+                } else {
+                    emptyList()
+                }
                 VideoExportRequest(
                     outputUri = outputUri,
                     journey = Journey.fromBreakIndices(
@@ -225,6 +258,7 @@ class VideoExportRequestStore(context: Context) {
                         ),
                         breakBeforePointIndices,
                         inferredTransferBeforePointIndices,
+                        semanticEpisodes,
                     ),
                     title = title,
                     durationSeconds = durationSeconds,
@@ -245,8 +279,9 @@ class VideoExportRequestStore(context: Context) {
     }
 
     companion object {
-        private const val CURRENT_FILE_VERSION = 14
+        private const val CURRENT_FILE_VERSION = 15
         private const val MAX_POINT_COUNT = 2_000_000
+        private const val MAX_SEMANTIC_EPISODE_COUNT = 100_000
         private const val REQUEST_FILE = "pending-video-export.bin"
         private const val TEMPORARY_FILE = "pending-video-export.tmp"
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/JournalDao.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/JournalDao.kt
@@ -201,6 +201,32 @@ interface JournalDao {
             ON import_batches.id = semantic_snapshots.importBatchId
         WHERE import_batches.journalId = :journalId
           AND import_batches.status = 'COMMITTED'
+          AND semantic_segments.kind IN ('ACTIVITY', 'ACTIVITY_AND_VISIT')
+          AND semantic_segments.endEpochMillis >= :startEpochMillis
+          AND semantic_segments.startEpochMillis < :endExclusiveEpochMillis
+        ORDER BY semantic_snapshots.capturedAtEpochMillis DESC,
+                 semantic_snapshots.id DESC,
+                 semantic_segments.sourceOrdinal ASC
+        """,
+    )
+    suspend fun activeSemanticActivitySegmentsNewestFirst(
+        journalId: String,
+        startEpochMillis: Long,
+        endExclusiveEpochMillis: Long,
+    ): List<ActiveSemanticSegment>
+
+    @Query(
+        """
+        SELECT semantic_segments.*,
+               import_batches.parserVersion AS parserVersion,
+               semantic_snapshots.capturedAtEpochMillis AS snapshotCapturedAtEpochMillis
+        FROM semantic_segments
+        INNER JOIN semantic_snapshots
+            ON semantic_snapshots.id = semantic_segments.snapshotId
+        INNER JOIN import_batches
+            ON import_batches.id = semantic_snapshots.importBatchId
+        WHERE import_batches.journalId = :journalId
+          AND import_batches.status = 'COMMITTED'
           AND semantic_snapshots.id IN (:snapshotIds)
         ORDER BY semantic_snapshots.capturedAtEpochMillis DESC,
                  semantic_snapshots.id DESC,

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/JournalRepository.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/JournalRepository.kt
@@ -197,6 +197,15 @@ class JournalRepository(
         return dao.activeSemanticSegmentsNewestFirst(journalId, startEpochMillis, endExclusiveEpochMillis)
     }
 
+    suspend fun activeSemanticActivitySegments(
+        journalId: String,
+        startEpochMillis: Long,
+        endExclusiveEpochMillis: Long,
+    ): List<ActiveSemanticSegment> {
+        require(endExclusiveEpochMillis > startEpochMillis) { "The route range must not be empty" }
+        return dao.activeSemanticActivitySegmentsNewestFirst(journalId, startEpochMillis, endExclusiveEpochMillis)
+    }
+
     suspend fun activeSemanticSegmentsForSnapshots(
         journalId: String,
         snapshotIds: Collection<String>,

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/route/JournalJourneySelection.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/route/JournalJourneySelection.kt
@@ -2,6 +2,7 @@ package dev.mahlernim.timelinevisualizer.journal.route
 
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
+import dev.mahlernim.timelinevisualizer.model.JourneySemanticEpisode
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
 import java.time.LocalDate
 import java.time.YearMonth
@@ -58,7 +59,45 @@ private fun JournalRoute.journeyFromSpans(
         }
     }
     if (current.isNotEmpty()) sections.add(current)
-    return Journey.fromSections(sections, period, inferredTransferBeforePointIndices)
+    val journey = Journey.fromSections(sections, period, inferredTransferBeforePointIndices)
+    if (journey.points.size < 2 || cameraEpisodes.isEmpty()) return journey
+
+    val projectedEpisodes = cameraEpisodes.mapNotNull { episode ->
+        val startIndex = journey.points.lowerBound(episode.start)
+        val endIndex = journey.points.upperBound(episode.end) - 1
+        if (startIndex !in journey.points.indices || endIndex <= startIndex) return@mapNotNull null
+        if (journey.breakBeforePointIndices.any { it in (startIndex + 1)..endIndex }) return@mapNotNull null
+        val startKm = journey.cumulativeDistanceKm[startIndex]
+        val endKm = journey.cumulativeDistanceKm[endIndex]
+        if (endKm <= startKm) return@mapNotNull null
+        JourneySemanticEpisode(
+            startKm = startKm,
+            endKm = endKm,
+            origin = episode.origin,
+            destination = episode.destination,
+        )
+    }.sortedBy(JourneySemanticEpisode::startKm)
+    return journey.copy(semanticEpisodes = projectedEpisodes)
+}
+
+private fun List<GeoPoint>.lowerBound(instant: java.time.Instant): Int {
+    var low = 0
+    var high = size
+    while (low < high) {
+        val middle = (low + high) ushr 1
+        if (this[middle].instant < instant) low = middle + 1 else high = middle
+    }
+    return low
+}
+
+private fun List<GeoPoint>.upperBound(instant: java.time.Instant): Int {
+    var low = 0
+    var high = size
+    while (low < high) {
+        val middle = (low + high) ushr 1
+        if (this[middle].instant <= instant) low = middle + 1 else high = middle
+    }
+    return low
 }
 
 private fun pointKey(point: GeoPoint): Triple<Long, Long, Long> = Triple(

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/route/JournalRouteService.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/journal/route/JournalRouteService.kt
@@ -22,7 +22,20 @@ data class JournalRoute(
     val detailedInputCount: Int,
     val detailedUsableCount: Int,
     val semanticUsableCount: Int,
+    val cameraEpisodes: List<SemanticCameraEpisode> = emptyList(),
 )
+
+/** Global activity context retained separately from the detailed route geometry. */
+data class SemanticCameraEpisode(
+    val start: Instant,
+    val end: Instant,
+    val origin: GeoPoint,
+    val destination: GeoPoint,
+) {
+    init {
+        require(end >= start)
+    }
+}
 
 enum class RouteDetail {
     DETAILED,
@@ -58,14 +71,19 @@ class JournalRouteService(
         val usesCanonicalSettings = maximumAccuracyMeters == RawSignalProcessor.DEFAULT_MAXIMUM_ACCURACY_METERS &&
             discontinuity == JournalRouteFusion.DEFAULT_DISCONTINUITY && routeDetail == RouteDetail.DETAILED
         if (!usesCanonicalSettings) {
-            return reconstructWithContext(
+            return attachCameraEpisodes(
                 journalId,
                 start,
                 endExclusive,
-                maximumAccuracyMeters,
-                discontinuity,
-                routeDetail,
-                onPreparationStage,
+                reconstructWithContext(
+                    journalId,
+                    start,
+                    endExclusive,
+                    maximumAccuracyMeters,
+                    discontinuity,
+                    routeDetail,
+                    onPreparationStage,
+                ),
             )
         }
 
@@ -120,7 +138,12 @@ class JournalRouteService(
             previous != null && cachedRangeContainsRequest && cacheMatchesAlgorithm &&
             (cacheIsCurrent || dirtyDoesNotAffectRequest)
         ) {
-            return previous.clippedTo(start, endExclusive)
+            return attachCameraEpisodes(
+                journalId,
+                start,
+                endExclusive,
+                previous.clippedTo(start, endExclusive),
+            )
         }
 
         val rebuilt = if (
@@ -193,7 +216,47 @@ class JournalRouteService(
             )
             if (!stored) throw StaleJournalRouteBuildException()
         }
-        return rebuilt.clippedTo(start, endExclusive)
+        return attachCameraEpisodes(
+            journalId,
+            start,
+            endExclusive,
+            rebuilt.clippedTo(start, endExclusive),
+        )
+    }
+
+    private suspend fun attachCameraEpisodes(
+        journalId: String,
+        start: Instant,
+        endExclusive: Instant,
+        route: JournalRoute,
+    ): JournalRoute {
+        val rows = repository.activeSemanticActivitySegments(
+            journalId,
+            start.toEpochMilli(),
+            endExclusive.toEpochMilli(),
+        )
+        if (rows.isEmpty()) return route
+
+        val coveredByNewerSnapshots = MergedMillisIntervals()
+        val episodes = mutableListOf<SemanticCameraEpisode>()
+        rows.groupBy { it.snapshotCapturedAtEpochMillis to it.snapshotId }.forEach { (_, snapshotRows) ->
+            val records = snapshotRecords(snapshotRows).filter { record ->
+                record.kind == STRUCTURED_ACTIVITY_KIND || record.kind == STRUCTURED_ACTIVITY_AND_VISIT_KIND
+            }
+            records.forEach recordLoop@ { record ->
+                if (coveredByNewerSnapshots.overlaps(record.interval)) return@recordLoop
+                val origin = record.points.firstOrNull() ?: return@recordLoop
+                val destination = record.points.lastOrNull() ?: return@recordLoop
+                episodes += SemanticCameraEpisode(
+                    start = Instant.ofEpochMilli(record.startEpochMillis),
+                    end = Instant.ofEpochMilli(record.endEpochMillis),
+                    origin = origin,
+                    destination = destination,
+                )
+            }
+            coveredByNewerSnapshots.addAll(records.map(StoredSemanticRecord::interval))
+        }
+        return route.copy(cameraEpisodes = episodes.sortedBy(SemanticCameraEpisode::start))
     }
 
     private suspend fun reconstructWithContext(
@@ -824,6 +887,8 @@ class JournalRouteService(
         const val LEGACY_FLATTENED_PARSER_VERSION = 1
         const val LEGACY_PATH_KIND = "TIMELINE_PATH"
         const val STRUCTURED_PATH_KIND = "PATH"
+        const val STRUCTURED_ACTIVITY_KIND = "ACTIVITY"
+        const val STRUCTURED_ACTIVITY_AND_VISIT_KIND = "ACTIVITY_AND_VISIT"
         const val MINIMUM_STRONG_CONFLICTS = 2
         const val STRONG_CONFLICT_DISTANCE_METERS = 5_000.0
         const val MINIMUM_DIRECTIONAL_ANCHOR_DISTANCE_METERS = 1_000.0

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/model/TimelineModels.kt
@@ -248,12 +248,29 @@ data class JourneyLeg(
     val lengthKm: Double get() = endKm - startKm
 }
 
+/**
+ * A semantic activity projected onto the detailed journey distance axis.
+ *
+ * The activity endpoints provide global trip context while the points between [startKm] and
+ * [endKm] remain the authoritative local geometry followed by the marker and route trail.
+ */
+data class JourneySemanticEpisode(
+    val startKm: Double,
+    val endKm: Double,
+    val origin: GeoPoint,
+    val destination: GeoPoint,
+) {
+    val lengthKm: Double get() = endKm - startKm
+    val displacementKm: Double get() = haversineKm(origin, destination)
+}
+
 data class Journey(
     val period: TimelinePeriod,
     val points: List<GeoPoint>,
     val cumulativeDistanceKm: DoubleArray,
     val breakBeforePointIndices: List<Int> = emptyList(),
     val inferredTransferBeforePointIndices: List<Int> = emptyList(),
+    val semanticEpisodes: List<JourneySemanticEpisode> = emptyList(),
 ) {
     private val breakIndexSet = breakBeforePointIndices.toSet()
     private val inferredTransferIndexSet = inferredTransferBeforePointIndices.toSet()
@@ -288,6 +305,10 @@ data class Journey(
         require(inferredTransferBeforePointIndices == inferredTransferBeforePointIndices.distinct().sorted())
         require(inferredTransferBeforePointIndices.all { it in 1..points.lastIndex })
         require(inferredTransferBeforePointIndices.none(breakIndexSet::contains))
+        require(semanticEpisodes.all { episode ->
+            episode.startKm >= 0.0 && episode.endKm > episode.startKm && episode.endKm <= totalDistanceKm
+        })
+        require(semanticEpisodes.zipWithNext().all { (before, after) -> before.startKm <= after.startKm })
     }
 
     fun isConnectedToPrevious(pointIndex: Int): Boolean =
@@ -402,22 +423,40 @@ data class Journey(
     private fun buildLegs(thresholdKm: Double): List<JourneyLeg> {
         if (points.size < 2 || totalDistanceKm <= 0.0) return emptyList()
         val cutoff = thresholdKm.coerceAtLeast(1.0)
-        var transferCount = 0
+        val transferRanges = ArrayList<TransferRange>()
         for (index in 1..points.lastIndex) {
-            if (cumulativeDistanceKm[index] - cumulativeDistanceKm[index - 1] >= cutoff) transferCount += 1
+            val startKm = cumulativeDistanceKm[index - 1]
+            val endKm = cumulativeDistanceKm[index]
+            if (index in inferredTransferIndexSet || endKm - startKm >= cutoff) {
+                transferRanges += TransferRange(startKm, endKm)
+            }
         }
-        val capacity = (transferCount.toLong() * 2L + 1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
-        val result = ArrayList<JourneyLeg>(capacity)
+        semanticEpisodes.forEach { episode ->
+            if (episode.displacementKm >= cutoff) {
+                transferRanges += TransferRange(episode.startKm, episode.endKm)
+            }
+        }
+        if (transferRanges.isEmpty()) return listOf(JourneyLeg(0.0, totalDistanceKm, false))
+
+        transferRanges.sortWith(compareBy<TransferRange> { it.startKm }.thenBy { it.endKm })
+        val merged = ArrayList<TransferRange>(transferRanges.size)
+        transferRanges.forEach { next ->
+            val previous = merged.lastOrNull()
+            if (previous == null || next.startKm > previous.endKm) {
+                merged += next
+            } else if (next.endKm > previous.endKm) {
+                merged[merged.lastIndex] = previous.copy(endKm = next.endKm)
+            }
+        }
+
+        val result = ArrayList<JourneyLeg>(merged.size * 2 + 1)
         var localStartKm = 0.0
-        for (index in 1..points.lastIndex) {
-            val transferStartKm = cumulativeDistanceKm[index - 1]
-            val transferEndKm = cumulativeDistanceKm[index]
-            if (index !in inferredTransferIndexSet && transferEndKm - transferStartKm < cutoff) continue
-            if (transferStartKm > localStartKm) result.add(JourneyLeg(localStartKm, transferStartKm, false))
-            result.add(JourneyLeg(transferStartKm, transferEndKm, true))
-            localStartKm = transferEndKm
+        merged.forEach { transfer ->
+            if (transfer.startKm > localStartKm) result += JourneyLeg(localStartKm, transfer.startKm, false)
+            result += JourneyLeg(transfer.startKm, transfer.endKm, true)
+            localStartKm = transfer.endKm
         }
-        if (totalDistanceKm > localStartKm) result.add(JourneyLeg(localStartKm, totalDistanceKm, false))
+        if (totalDistanceKm > localStartKm) result += JourneyLeg(localStartKm, totalDistanceKm, false)
         return result
     }
 
@@ -450,11 +489,13 @@ data class Journey(
             period: TimelinePeriod,
             breakBeforePointIndices: List<Int>,
             inferredTransferBeforePointIndices: List<Int> = emptyList(),
+            semanticEpisodes: List<JourneySemanticEpisode> = emptyList(),
         ): Journey = fromFlattened(
             points,
             period,
             breakBeforePointIndices,
             inferredTransferBeforePointIndices,
+            semanticEpisodes,
         )
 
         private fun fromFlattened(
@@ -462,6 +503,7 @@ data class Journey(
             period: TimelinePeriod,
             breakBeforePointIndices: List<Int>,
             inferredTransferBeforePointIndices: List<Int> = emptyList(),
+            semanticEpisodes: List<JourneySemanticEpisode> = emptyList(),
         ): Journey {
             val breaks = breakBeforePointIndices.distinct().sorted()
             require(breaks.all { it in 1..points.lastIndex })
@@ -477,7 +519,7 @@ data class Journey(
                     haversineKm(points[index - 1], points[index])
                 }
             }
-            return Journey(period, points, distances, breaks, inferredTransfers)
+            return Journey(period, points, distances, breaks, inferredTransfers, semanticEpisodes)
         }
 
         internal fun interpolate(a: GeoPoint, b: GeoPoint, fraction: Double): GeoPoint {
@@ -525,6 +567,8 @@ data class Journey(
                 sorted[middle]
             }
         }
+
+        private data class TransferRange(val startKm: Double, val endKm: Double)
     }
 }
 

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -249,8 +249,13 @@ class TimelinePainter {
         val movement = cameraSettings.cameraMovement
         val proportionalContextKm = (journey.totalDistanceKm * movement.contextFraction)
             .coerceIn(movement.minimumContextKm, movement.maximumContextKm)
-        val tail = journey.positionAtDistance(max(0.0, current.distanceKm - proportionalContextKm)).point
-        val lookahead = journey.positionAtDistance(min(journey.totalDistanceKm, current.distanceKm + proportionalContextKm)).point
+        val episodeLegs = cameraEpisodeLegs(journey, cameraSettings)
+        val leg = journey.legAt(current.distanceKm, episodeLegs).takeIf { movement.legAware }
+        val contextKm = if (leg?.isTransfer == true) leg.lengthKm else proportionalContextKm
+        val rangeStartKm = leg?.startKm ?: 0.0
+        val rangeEndKm = leg?.endKm ?: journey.totalDistanceKm
+        val tail = journey.positionAtDistance(max(rangeStartKm, current.distanceKm - contextKm)).point
+        val lookahead = journey.positionAtDistance(min(rangeEndKm, current.distanceKm + contextKm)).point
         val center = WebMercator.project(current.point)
         val before = WebMercator.project(tail)
         val after = WebMercator.project(lookahead)
@@ -289,13 +294,11 @@ class TimelinePainter {
         val leg = journey.legAt(current.distanceKm, episodeLegs).takeIf { movement.legAware }
         val legIndex = leg?.let(episodeLegs::indexOf) ?: -1
         val nextLocalLeg = episodeLegs.getOrNull(legIndex + 1)?.takeIf { !it.isTransfer }
-        val closeUpArrivalAllowed = movement != CameraMovement.CLOSE_UP ||
-            nextLocalLeg?.let { isMeaningfulCloseUpArrival(journey, it) } == true
         val transferArrivalBlend = if (
             cameraSettings.episodeFramingEnabled &&
+            movement != CameraMovement.CLOSE_UP &&
             leg?.isTransfer == true &&
             nextLocalLeg != null &&
-            closeUpArrivalAllowed &&
             leg.lengthKm > 0.0
         ) {
             smoothstep(
@@ -712,12 +715,14 @@ class TimelinePainter {
             val plan = closeUpPlans.firstOrNull {
                 currentDistanceKm >= it.transferLeg.startKm && currentDistanceKm <= it.localLeg.endKm
             } ?: return 0.0
-            if (currentDistanceKm < plan.localLeg.startKm) {
-                val width = plan.arrivalProgress - plan.approachStartProgress
-                if (width <= 0f) return 0.0
-                return smoothstep(((progress - plan.approachStartProgress) / width).toDouble())
+            if (currentDistanceKm < plan.localLeg.startKm) return 0.0
+            val width = plan.closeInEndProgress - plan.arrivalProgress
+            val closeIn = if (width <= 0f) {
+                1.0
+            } else {
+                smoothstep(((progress - plan.arrivalProgress) / width).toDouble())
             }
-            return localArrivalSettleIntensity(journey, currentDistanceKm, plan.localLeg)
+            return closeIn * localArrivalSettleIntensity(journey, currentDistanceKm, plan.localLeg)
         }
         val leg = journey.legAt(currentDistanceKm, legs)
         val legIndex = legs.indexOf(leg)
@@ -833,6 +838,49 @@ class TimelinePainter {
         if (!cameraSettings.episodeFramingEnabled || !cameraSettings.cameraMovement.legAware) return base
         val distanceKm = playbackPosition(journey, actualProgress, cameraSettings).distanceKm
         val leg = journey.legAt(distanceKm, episodeLegs)
+        val closeUpPlan = closeUpPlans.firstOrNull {
+            distanceKm >= it.transferLeg.startKm && distanceKm <= it.localLeg.endKm
+        }
+        if (cameraSettings.cameraMovement == CameraMovement.CLOSE_UP && closeUpPlan != null) {
+            val alignedViewport = rawViewport(
+                journey,
+                actualProgress,
+                width,
+                height,
+                cameraSettings,
+                episodeLegsOverride = episodeLegs,
+            )
+            val alignedSpanY = (alignedViewport.maxY - alignedViewport.minY)
+                .coerceAtLeast(cameraSettings.cameraMovement.minimumViewportSpan)
+            if (leg.isTransfer) {
+                val spanY = max(base.spanY, alignedSpanY)
+                return base.copy(spanY = spanY, zoom = tileZoom(width, aspect, spanY))
+            }
+            if (actualProgress <= closeUpPlan.closeInEndProgress) {
+                val transferDistanceKm = closeUpPlan.transferLeg.startKm + closeUpPlan.transferLeg.lengthKm * 0.5
+                val transferViewport = rawViewport(
+                    journey,
+                    actualProgress,
+                    width,
+                    height,
+                    cameraSettings,
+                    episodeLegsOverride = episodeLegs,
+                    distanceOverrideKm = transferDistanceKm,
+                )
+                val transferSpanY = (transferViewport.maxY - transferViewport.minY)
+                    .coerceAtLeast(alignedSpanY)
+                val widthProgress = closeUpPlan.closeInEndProgress - closeUpPlan.arrivalProgress
+                val closeIn = if (widthProgress <= 0f) {
+                    1.0
+                } else {
+                    smoothstep(
+                        ((actualProgress - closeUpPlan.arrivalProgress) / widthProgress).toDouble(),
+                    )
+                }
+                val spanY = kotlin.math.exp(lerp(ln(transferSpanY), ln(alignedSpanY), closeIn))
+                return base.copy(spanY = spanY, zoom = tileZoom(width, aspect, spanY))
+            }
+        }
         val alignment = if (leg.isTransfer) {
             episodeArrivalZoomIntensity(journey, actualProgress, cameraSettings, episodeLegs, closeUpPlans)
         } else {
@@ -941,18 +989,18 @@ class TimelinePainter {
         val localIndex = episodeLegs.indexOf(episode.localLeg)
         val transfer = episodeLegs.getOrNull(localIndex - 1)?.takeIf { it.isTransfer }
             ?: return@mapNotNull null
-        val transferStartProgress = timing.progressAtDistance(transfer.startKm)
         val arrivalProgress = timing.progressAtDistance(episode.localLeg.startKm)
-        val transferProgress = (arrivalProgress - transferStartProgress).coerceAtLeast(0f)
-        val approachProgress = min(
-            episode.minimumProgressFraction.toFloat(),
-            transferProgress * CLOSE_UP_MAX_APPROACH_TRANSFER_FRACTION,
+        val localEndProgress = timing.progressAtDistance(episode.localLeg.endKm)
+        val localProgress = (localEndProgress - arrivalProgress).coerceAtLeast(0f)
+        val closeInProgress = min(
+            CLOSE_UP_POST_ARRIVAL_MAX_PROGRESS,
+            localProgress * CLOSE_UP_POST_ARRIVAL_SHARE,
         )
         CloseUpArrivalPlan(
             transferLeg = transfer,
             localLeg = episode.localLeg,
-            approachStartProgress = (arrivalProgress - approachProgress).coerceAtLeast(transferStartProgress),
             arrivalProgress = arrivalProgress,
+            closeInEndProgress = (arrivalProgress + closeInProgress).coerceAtMost(localEndProgress),
         )
     }
 
@@ -1562,8 +1610,8 @@ class TimelinePainter {
     private data class CloseUpArrivalPlan(
         val transferLeg: JourneyLeg,
         val localLeg: JourneyLeg,
-        val approachStartProgress: Float,
         val arrivalProgress: Float,
+        val closeInEndProgress: Float,
     )
 
     internal data class RouteBounds(
@@ -1654,9 +1702,10 @@ class TimelinePainter {
         private const val EPISODE_ARRIVAL_HOLD_SAMPLES = 2.0
         private const val EPISODE_ARRIVAL_SETTLE_MAX_KM = 25.0
         private const val CLOSE_UP_MIN_LOCAL_DURATION_MILLIS = 60L * 60L * 1_000L
-        private const val CLOSE_UP_TOTAL_PROGRESS_BUDGET = 0.08
-        private const val CLOSE_UP_MAX_PROGRESS_PER_ARRIVAL = 0.03
-        private const val CLOSE_UP_MAX_APPROACH_TRANSFER_FRACTION = 0.35f
+        private const val CLOSE_UP_TOTAL_PROGRESS_BUDGET = 0.16
+        private const val CLOSE_UP_MAX_PROGRESS_PER_ARRIVAL = 0.08
+        private const val CLOSE_UP_POST_ARRIVAL_SHARE = 0.50f
+        private const val CLOSE_UP_POST_ARRIVAL_MAX_PROGRESS = 0.04f
         private const val CLOSE_UP_ANCHOR_INSET_FRACTION = 0.10
         private const val CLOSE_UP_ANCHOR_INSET_MAX_KM = 0.25
         private const val MIN_CONTEXT_KM = 0.001

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequestStoreTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/VideoExportRequestStoreTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
+import dev.mahlernim.timelinevisualizer.model.JourneySemanticEpisode
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
 import dev.mahlernim.timelinevisualizer.render.RenderText
 import dev.mahlernim.timelinevisualizer.render.CameraSettings
@@ -152,6 +153,33 @@ class VideoExportRequestStoreTest {
         assertEquals(listOf(1), restored.journey.inferredTransferBeforePointIndices)
         assertEquals(request.journey.totalDistanceKm, restored.journey.totalDistanceKm, 0.001)
         assertEquals(request.journey.knownDistanceKm, restored.journey.knownDistanceKm, 0.001)
+    }
+
+    @Test
+    fun semanticCameraEpisodesSurvivePendingExportRestart() {
+        val points = listOf(
+            GeoPoint(Instant.parse("2026-01-01T00:00:00Z"), 37.5, 127.0),
+            GeoPoint(Instant.parse("2026-01-01T04:00:00Z"), 35.7, 139.8),
+            GeoPoint(Instant.parse("2026-01-01T05:00:00Z"), 35.71, 139.81),
+        )
+        val base = Journey.from(points, 2026)
+        val episode = JourneySemanticEpisode(
+            startKm = 0.0,
+            endKm = base.cumulativeDistanceKm[1],
+            origin = points[0],
+            destination = points[1],
+        )
+        val request = VideoExportRequest(
+            outputUri = "content://documents/semantic-camera.mp4",
+            journey = base.copy(semanticEpisodes = listOf(episode)),
+            title = "Semantic camera",
+            durationSeconds = 30,
+            dataSource = VideoDataSource.JOURNAL,
+        )
+
+        store.save(request)
+
+        assertEquals(listOf(episode), store.load()!!.journey.semanticEpisodes)
     }
 
     @Test

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/journal/route/JournalJourneySelectionTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/journal/route/JournalJourneySelectionTest.kt
@@ -91,6 +91,88 @@ class JournalJourneySelectionTest {
         assertEquals(0.0, journey.knownDistanceKm, 0.0)
     }
 
+    @Test
+    fun semanticActivityProjectsOntoDetailedGeometryAsOneCameraEpisode() {
+        val points = (0..120).map { index -> point(index.toLong(), index / 10.0) }
+        val route = JournalRoute(
+            timeline = Timeline(points),
+            spans = listOf(span(RouteSource.DETAILED, *points.toTypedArray())),
+            detailedInputCount = points.size,
+            detailedUsableCount = points.size,
+            semanticUsableCount = 2,
+            cameraEpisodes = listOf(
+                SemanticCameraEpisode(
+                    start = points.first().instant,
+                    end = points.last().instant,
+                    origin = points.first(),
+                    destination = points.last(),
+                ),
+            ),
+        )
+
+        val journey = route.journeyForRange(TimelinePeriod.sameYear(2026), ZoneOffset.UTC)
+
+        assertEquals(1, journey.semanticEpisodes.size)
+        assertTrue(journey.semanticEpisodes.single().displacementKm > 1_000.0)
+        assertEquals(listOf(true), journey.legs.map { it.isTransfer })
+    }
+
+    @Test
+    fun semanticActivityCrossingAnExplicitGapFallsBackToGeometricLegs() {
+        val before = listOf(point(0, 0.0), point(10, 0.1))
+        val after = listOf(point(60, 20.0), point(70, 20.1))
+        val route = JournalRoute(
+            timeline = Timeline(before + after),
+            spans = listOf(
+                span(RouteSource.DETAILED, *before.toTypedArray()),
+                RouteSpan(instant(10), instant(60), RouteSource.GAP, emptyList()),
+                span(RouteSource.DETAILED, *after.toTypedArray()),
+            ),
+            detailedInputCount = 4,
+            detailedUsableCount = 4,
+            semanticUsableCount = 2,
+            cameraEpisodes = listOf(
+                SemanticCameraEpisode(
+                    start = before.first().instant,
+                    end = after.last().instant,
+                    origin = before.first(),
+                    destination = after.last(),
+                ),
+            ),
+        )
+
+        val journey = route.journeyForRange(TimelinePeriod.sameYear(2026), ZoneOffset.UTC)
+
+        assertTrue(journey.semanticEpisodes.isEmpty())
+        assertEquals(listOf(2), journey.breakBeforePointIndices)
+        assertFalse(journey.isConnectedToPrevious(2))
+    }
+
+    @Test
+    fun zeroDurationSemanticActivityIsIgnored() {
+        val points = listOf(point(0, 0.0), point(10, 0.1), point(20, 0.2))
+        val route = JournalRoute(
+            timeline = Timeline(points),
+            spans = listOf(span(RouteSource.DETAILED, *points.toTypedArray())),
+            detailedInputCount = points.size,
+            detailedUsableCount = points.size,
+            semanticUsableCount = 1,
+            cameraEpisodes = listOf(
+                SemanticCameraEpisode(
+                    start = points[1].instant,
+                    end = points[1].instant,
+                    origin = points[1],
+                    destination = points[1],
+                ),
+            ),
+        )
+
+        val journey = route.journeyForRange(TimelinePeriod.sameYear(2026), ZoneOffset.UTC)
+
+        assertTrue(journey.semanticEpisodes.isEmpty())
+        assertEquals(listOf(false), journey.legs.map { it.isTransfer })
+    }
+
     private fun span(source: RouteSource, vararg points: GeoPoint) = RouteSpan(
         start = points.first().instant,
         end = points.last().instant,

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import dev.mahlernim.timelinevisualizer.R
 import dev.mahlernim.timelinevisualizer.model.GeoPoint
 import dev.mahlernim.timelinevisualizer.model.Journey
+import dev.mahlernim.timelinevisualizer.model.JourneySemanticEpisode
 import dev.mahlernim.timelinevisualizer.model.WebMercator
 import java.time.Instant
 import dev.mahlernim.timelinevisualizer.model.TimelinePeriod
@@ -251,7 +252,7 @@ class TimelinePainterTest {
     }
 
     @Test
-    fun episodeArrivalZoomStartsBeforeLandingAndSettlesImmediately() {
+    fun closeUpHoldsTheTransferViewThenClosesDuringProtectedLocalTime() {
         val journey = roundTripJourney()
         val inboundTransfer = journey.legs[1]
         val destination = journey.legs[2]
@@ -270,25 +271,30 @@ class TimelinePainterTest {
 
         val earlyFlightSpan = trackSpanAt(inboundTransfer.startKm + inboundTransfer.lengthKm * 0.70)
         val finalFlightSpan = trackSpanAt(inboundTransfer.startKm + inboundTransfer.lengthKm * 0.95)
-        val justArrivedDistance = destination.startKm + min(1.0, destination.lengthKm * 0.05)
-        val arrivalSpan = trackSpanAt(justArrivedDistance)
-        val arrivalTarget = painter.rawViewportForTest(
-            journey,
-            (justArrivedDistance / journey.totalDistanceKm).toFloat(),
-            SIZE,
-            SIZE,
-            settings,
-            useRangeIndex = true,
-        ).let { it.maxY - it.minY }
+        val arrivalProgress = track.timing.progressAtDistance(destination.startKm)
+        val localEndProgress = track.timing.progressAtDistance(destination.endKm)
+        val localProgress = localEndProgress - arrivalProgress
+        val arrivalSpan = track.viewportAt(arrivalProgress).let { it.maxY - it.minY }
+        val closingSpan = track.viewportAt(arrivalProgress + localProgress * 0.25f).let { it.maxY - it.minY }
+        val settledSpan = track.viewportAt(arrivalProgress + localProgress * 0.60f).let { it.maxY - it.minY }
 
         assertTrue(
-            "Final-flight span $finalFlightSpan did not begin closing from $earlyFlightSpan",
-            finalFlightSpan < earlyFlightSpan * 0.70,
+            "Final-flight span $finalFlightSpan closed early from $earlyFlightSpan",
+            finalFlightSpan >= earlyFlightSpan * 0.85,
         )
         assertTrue(
-            "Arrival span $arrivalSpan still lagged behind its local target $arrivalTarget",
-            arrivalSpan <= arrivalTarget * 1.60,
+            "Arrival span $arrivalSpan did not retain the final-flight view $finalFlightSpan",
+            arrivalSpan >= finalFlightSpan * 0.80,
         )
+        assertTrue(
+            "Camera did not begin closing after arrival: $arrivalSpan to $closingSpan",
+            closingSpan < arrivalSpan * 0.80,
+        )
+        assertTrue(
+            "Camera did not reach the local view: $closingSpan to $settledSpan",
+            settledSpan < closingSpan * 0.75,
+        )
+        assertTrue("Protected local share was $localProgress", localProgress >= 0.079f)
     }
 
     @Test
@@ -314,9 +320,9 @@ class TimelinePainterTest {
         }
         val meaningfulShares = listOf(shares[0], shares[2])
 
-        meaningfulShares.forEach { share -> assertTrue("Meaningful arrival share was $share", share >= 0.029f) }
+        meaningfulShares.forEach { share -> assertTrue("Meaningful arrival share was $share", share >= 0.079f) }
         assertTrue("Brief stop unexpectedly received the arrival budget: $shares", shares[1] < 0.02f)
-        assertTrue("Arrival budget exceeded its global bound: $shares", meaningfulShares.sum() <= 0.061f)
+        assertTrue("Arrival budget exceeded its global bound: $shares", meaningfulShares.sum() <= 0.161f)
 
         listOf(localArrivals[0], localArrivals[2]).forEach { leg ->
             val start = timing.progressAtDistance(leg.startKm)
@@ -374,6 +380,54 @@ class TimelinePainterTest {
 
         assertEquals(0, balancedTransfers)
         assertEquals(2, sensitiveTransfers)
+    }
+
+    @Test
+    fun semanticLongTripStaysWideThenTightensForDestinationDetail() {
+        val points = (0..100).map { index ->
+            timedPoint(index, 0.02 * kotlin.math.sin(index / 5.0), index * 0.05)
+        } + (101..115).map { index ->
+            timedPoint(index, (index - 100) * 0.0005, 5.0 + (index - 100) * 0.0005)
+        }
+        val base = Journey.from(points, 2025)
+        val semantic = base.copy(
+            semanticEpisodes = listOf(
+                JourneySemanticEpisode(
+                    startKm = 0.0,
+                    endKm = base.cumulativeDistanceKm[100],
+                    origin = points.first(),
+                    destination = points[100],
+                ),
+            ),
+        )
+        val settings = CameraSettings(
+            cameraMovement = CameraMovement.CLOSE_UP,
+            longTripCompression = LongTripCompression.OFF,
+            localFraming = LocalFraming.BALANCED,
+        )
+        val legs = semantic.legsForThreshold(
+            semantic.transferThresholdKm * settings.tripDetection.thresholdMultiplier,
+        )
+        val transfer = legs.first()
+        val local = legs.last()
+        val painter = TimelinePainter()
+        fun spanAt(distanceKm: Double): Double {
+            val viewport = painter.rawViewportForTest(
+                semantic,
+                (distanceKm / semantic.totalDistanceKm).toFloat(),
+                SIZE,
+                SIZE,
+                settings,
+                useRangeIndex = true,
+            )
+            return viewport.maxY - viewport.minY
+        }
+
+        val tripSpan = spanAt(transfer.startKm + transfer.lengthKm * 0.50)
+        val destinationSpan = spanAt(local.startKm + local.lengthKm * 0.50)
+
+        assertEquals(listOf(true, false), legs.map { it.isTransfer })
+        assertTrue("Semantic trip span $tripSpan did not stay wider than destination span $destinationSpan", tripSpan > destinationSpan * 8)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- retain semantic activity context separately from detailed marker and trail geometry
- hold the Close-up transfer corridor through arrival, then close during protected local movement
- preserve semantic context across pending export restart while retaining compatibility with request versions 1 through 14
- preserve Fixed, Wide, and existing non-Close-up Balanced behavior

## Testing

- `python -m pytest tests -q` (75 passed)
- `gradlew.bat test lint assembleGithubRelease bundlePlayRelease --stacktrace`
- private real-route comparison using the successful Journal Lab 22 flight example, with no personal Timeline or Journal data committed

Relates to #203