### PR TITLE
Prepare 3.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - Add distance-unit selection to the web app.
 - Document the web app's distance units and close-up mode.
 
+## 3.0.6
+
+- Use semantic activity episodes to recognize long transfers while retaining detailed route points for marker and trail geometry.
+- Hold the Close-up transfer view through arrival, then close progressively during protected local movement.
+- Preserve semantic camera context across interrupted and resumed video exports while remaining compatible with older pending exports.
+- Set Android version code 48 and version name 3.0.6.
+
 ## 3.0.5
 
 - Constrain the Detect trips date picker to the available Timeline range.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 47
-        versionName = "3.0.5"
+        versionCode = 48
+        versionName = "3.0.6"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/release-notes-v3.0.6.md
+++ b/docs/release-notes-v3.0.6.md
@@ -1,0 +1,80 @@
+# Timeline Visualizer 3.0.6
+
+This release improves Close-up framing in Travel Journal videos.
+
+- Long-distance travel stays visible through arrival.
+- The camera then moves closer during local movement, giving arrival details more time without making the marker rush.
+
+Your Travel Journal, Timeline file, and saved videos are unchanged.
+
+## 한국어
+
+이번 릴리스에서는 여행 기록 동영상의 클로즈업 구도를 개선했습니다.
+
+- 장거리 이동은 도착할 때까지 넓은 화면으로 보여 줍니다.
+- 도착 후 현지 이동 중에 카메라가 가까워져 도착지의 세부 이동을 더 여유 있게 보여 줍니다.
+
+여행 기록과 Timeline 파일, 저장된 동영상은 변경되지 않습니다.
+
+## 日本語
+
+このリリースでは、旅行記録動画のクローズアップ構図を改善しました。
+
+- 長距離移動は到着まで広い範囲を表示します。
+- 到着後の現地移動中にカメラが近づき、マーカーを急がせずに到着地の詳細を長く表示します。
+
+旅行記録、Timeline ファイル、保存済み動画は変更されません。
+
+## 简体中文
+
+此版本改进了旅行日志视频的特写取景。
+
+- 长途移动在到达前始终保持较宽的视野。
+- 到达后，镜头会在本地移动期间逐渐拉近，让到达地细节有更多展示时间，同时避免标记移动过快。
+
+你的旅行日志、Timeline 文件和已保存的视频不会改变。
+
+## 繁體中文
+
+此版本改善了旅行日誌影片的特寫取景。
+
+- 長途移動在抵達前會一直保持較寬的視野。
+- 抵達後，鏡頭會在當地移動期間逐漸拉近，讓抵達地細節有更多展示時間，同時避免標記移動過快。
+
+你的旅行日誌、Timeline 檔案和已儲存的影片不會改變。
+
+## Español
+
+Esta versión mejora el encuadre de primer plano en los vídeos del diario de viaje.
+
+- Los trayectos largos permanecen visibles hasta la llegada.
+- Después, la cámara se acerca durante el movimiento local para mostrar los detalles de la llegada durante más tiempo sin acelerar el marcador.
+
+Su diario de viaje, archivo Timeline y vídeos guardados no cambian.
+
+## Français
+
+Cette version améliore le cadrage rapproché des vidéos du carnet de voyage.
+
+- Les longs trajets restent visibles jusqu'à l'arrivée.
+- La caméra se rapproche ensuite pendant les déplacements locaux afin de montrer plus longtemps les détails de l'arrivée sans accélérer le marqueur.
+
+Votre carnet de voyage, fichier Timeline et vidéos enregistrées restent inchangés.
+
+## Deutsch
+
+Diese Version verbessert den Nahaufnahme-Bildausschnitt in Reisetagebuch-Videos.
+
+- Lange Reisen bleiben bis zur Ankunft vollständig sichtbar.
+- Danach fährt die Kamera während der lokalen Bewegung näher heran. So bleiben Details am Ziel länger sichtbar, ohne dass sich die Markierung zu schnell bewegt.
+
+Reisetagebuch, Timeline-Datei und gespeicherte Videos bleiben unverändert.
+
+## Português (Brasil)
+
+Esta versão melhora o enquadramento aproximado nos vídeos do diário de viagem.
+
+- Viagens longas permanecem visíveis até a chegada.
+- Depois, a câmera se aproxima durante o movimento local para mostrar os detalhes da chegada por mais tempo sem acelerar o marcador.
+
+Seu diário de viagem, arquivo Timeline e vídeos salvos não mudam.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.5` and version code `47`
+- Version name `3.0.6` and version code `48`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 47' in build_file
-    assert 'versionName = "3.0.5"' in build_file
+    assert 'versionCode = 48' in build_file
+    assert 'versionName = "3.0.6"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
## Summary

- set the production version to 3.0.6 with Play version code 48
- document the semantic Close-up arrival framing improvement in the changelog
- add concise release notes for all nine supported store languages
- align the Play submission checklist and packaging assertions

## Validation

- Play Console confirms version code 48 is unused and greater than every uploaded bundle
- `python -m pytest tests -q` (75 passed)
- `gradlew.bat test lint assembleGithubRelease bundlePlayRelease --stacktrace`

Relates to #203