### PR TITLE
Prepare web app for future AdSense review

### DIFF
--- a/docs/privacy-web.md
+++ b/docs/privacy-web.md
@@ -1,6 +1,6 @@
 # Timeline Visualizer web app privacy
 
-**Effective date:** August 26, 2026
+**Effective date:** August 28, 2026
 
 **Developer:** MahlerLab
 
@@ -45,6 +45,29 @@ developer's behalf, truncates IP addresses when requests arrive, and stores the
 resulting request logs in the United States for 30 days. CARTO may also process
 this information under its privacy notice and data-processing agreement.
 
+## Advertising status and consent
+
+Production advertising is not currently active in the web app. The page does not
+load an AdSense advertising script or request an advertisement.
+
+The site is prepared for a possible future AdSense release. Before advertising is
+enabled, the site will use a Google-certified consent management platform where
+required. The consent message will explain advertising cookies or local storage,
+personalized and non-personalized advertising choices, and how to withdraw or
+change a choice. Declining advertising consent will not prevent use of the video
+creation workflow.
+
+If advertising is enabled, Google and its advertising partners may receive normal
+web request information such as an IP address, user agent, page URL, and consent
+signals. They may use cookies or local storage for advertising, frequency limits,
+fraud prevention, and measurement according to the user's consent and applicable
+law. The application will not add Timeline file contents, route coordinates,
+selected dates, titles, video frames, or generated media to advertising requests.
+
+Users can review or change personalized advertising choices through
+[Google's My Ad Center](https://myadcenter.google.com/) and, after advertising is
+enabled, through the consent controls displayed on the site.
+
 ## Browser storage
 
 Selected Timeline data and generated videos remain in the current browser page.
@@ -65,3 +88,5 @@ browser storage.
 - [CARTO Privacy Notice](https://carto.com/privacy/)
 - [CARTO Basemap Terms](https://carto.com/legal/basemap-terms/)
 - [OpenStreetMap Privacy Policy](https://osmfoundation.org/wiki/Privacy_Policy)
+- [Google Advertising Policies and Terms](https://policies.google.com/technologies/ads)
+- [Google Privacy Policy](https://policies.google.com/privacy)

--- a/tests/test_web_privacy.py
+++ b/tests/test_web_privacy.py
@@ -20,3 +20,15 @@ def test_web_privacy_copy_does_not_claim_analytics_are_absent() -> None:
     assert "No account, location permission, or Timeline upload is required." in html
     assert "No account, location permission, analytics, or upload is required." not in html
     assert "Cloudflare Web Analytics" in readme
+
+
+def test_web_advertising_is_prepared_but_not_enabled() -> None:
+    html = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+    policy = (ROOT / "docs" / "privacy-web.md").read_text(encoding="utf-8")
+
+    assert '<meta name="google-adsense-account" content="ca-pub-4628399954212784"' in html
+    assert '<link rel="canonical" href="https://ahn-lab.org/google-timeline-visualizer/"' in html
+    assert "pagead2.googlesyndication.com" not in html
+    assert "adsbygoogle" not in html
+    assert "Production advertising is not currently active" in policy
+    assert "Timeline file contents" in policy

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="description" data-i18n-attr="content:appDescription" content="Create a travel animation privately from a Google Maps Timeline export." />
+    <meta name="google-adsense-account" content="ca-pub-4628399954212784" />
+    <link rel="canonical" href="https://ahn-lab.org/google-timeline-visualizer/" />
     <link rel="manifest" href="./manifest.webmanifest" />
     <link rel="icon" href="./icon.svg" type="image/svg+xml" />
     <title data-i18n="appName">Timeline Visualizer</title>


### PR DESCRIPTION
Adds canonical and AdSense account metadata without loading ad code. Updates the web privacy policy with the planned consent and advertising boundary, and adds regression coverage proving production ads remain disabled.\n\nValidated with focused pytest, all 302 web tests, and a production Vite build.