### PR TITLE
Release v3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 - Add distance-unit selection to the web app.
 - Document the web app's distance units and close-up mode.
 
+## 3.0.7
+
+- Recommend a video duration for each route from its camera movement, zoom changes, and large transfers.
+- Keep automatic recommendations between 10 and 60 seconds while retaining manual choices through 300 seconds.
+- Refresh the English, Korean, and Japanese Play Store screenshots with fictional sample data and a detailed route preview.
+- Add privacy-preserving aggregate daily metrics and prepare the web app for a future AdSense review.
+- Set Android version code 49 and version name 3.0.7.
+
 ## 3.0.6
 
 - Use semantic activity episodes to recognize long transfers while retaining detailed route points for marker and trail geometry.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 48
-        versionName = "3.0.6"
+        versionCode = 49
+        versionName = "3.0.7"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/release-notes-v3.0.7.md
+++ b/docs/release-notes-v3.0.7.md
@@ -1,0 +1,80 @@
+# Timeline Visualizer 3.0.7
+
+This release recommends a readable video duration for each route.
+
+- The recommendation adapts to camera movement, zoom changes, and large transfers.
+- Automatic recommendations stay between 10 and 60 seconds. You can still choose up to 300 seconds manually.
+
+Your Travel Journal, Timeline file, and saved videos are unchanged.
+
+## 한국어
+
+이번 릴리스에서는 경로마다 보기 편한 동영상 길이를 추천합니다.
+
+- 카메라 이동, 확대 및 축소, 장거리 이동에 맞춰 추천 길이가 달라집니다.
+- 자동 추천은 10초에서 60초 사이입니다. 수동으로는 계속 최대 300초까지 선택할 수 있습니다.
+
+여행 기록과 Timeline 파일, 저장된 동영상은 변경되지 않습니다.
+
+## 日本語
+
+このリリースでは、ルートごとに見やすい動画の長さを提案します。
+
+- カメラの移動、ズームの変化、長距離移動に合わせて提案時間が変わります。
+- 自動提案は 10 秒から 60 秒です。手動では引き続き最大 300 秒まで選択できます。
+
+旅行記録、Timeline ファイル、保存済み動画は変更されません。
+
+## 简体中文
+
+此版本会为每条路线推荐便于观看的视频时长。
+
+- 推荐时长会根据镜头移动、缩放变化和长途移动进行调整。
+- 自动推荐范围为 10 到 60 秒。你仍可手动选择最长 300 秒。
+
+你的旅行日志、Timeline 文件和已保存的视频不会改变。
+
+## 繁體中文
+
+此版本會為每條路線建議方便觀看的影片長度。
+
+- 建議長度會根據鏡頭移動、縮放變化和長途移動進行調整。
+- 自動建議範圍為 10 到 60 秒。你仍可手動選擇最長 300 秒。
+
+你的旅行日誌、Timeline 檔案和已儲存的影片不會改變。
+
+## Español
+
+Esta versión recomienda una duración de vídeo fácil de seguir para cada ruta.
+
+- La recomendación se adapta al movimiento de la cámara, los cambios de zoom y los trayectos largos.
+- Las recomendaciones automáticas van de 10 a 60 segundos. Aún puede elegir manualmente hasta 300 segundos.
+
+Su diario de viaje, archivo Timeline y vídeos guardados no cambian.
+
+## Français
+
+Cette version recommande une durée de vidéo facile à suivre pour chaque itinéraire.
+
+- La recommandation s'adapte aux mouvements de la caméra, aux changements de zoom et aux longs trajets.
+- Les recommandations automatiques vont de 10 à 60 secondes. Vous pouvez toujours choisir manuellement jusqu'à 300 secondes.
+
+Votre carnet de voyage, fichier Timeline et vidéos enregistrées restent inchangés.
+
+## Deutsch
+
+Diese Version empfiehlt für jede Route eine gut lesbare Videodauer.
+
+- Die Empfehlung berücksichtigt Kamerabewegungen, Zoomänderungen und lange Fahrten.
+- Automatische Empfehlungen liegen zwischen 10 und 60 Sekunden. Manuell können Sie weiterhin bis zu 300 Sekunden wählen.
+
+Reisetagebuch, Timeline-Datei und gespeicherte Videos bleiben unverändert.
+
+## Português (Brasil)
+
+Esta versão recomenda uma duração de vídeo fácil de acompanhar para cada rota.
+
+- A recomendação se adapta ao movimento da câmera, às mudanças de zoom e às viagens longas.
+- As recomendações automáticas vão de 10 a 60 segundos. Você ainda pode escolher manualmente até 300 segundos.
+
+Seu diário de viagem, arquivo Timeline e vídeos salvos não mudam.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.6` and version code `48`
+- Version name `3.0.7` and version code `49`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 48' in build_file
-    assert 'versionName = "3.0.6"' in build_file
+    assert 'versionCode = 49' in build_file
+    assert 'versionName = "3.0.7"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
## Summary

- set Android version name to 3.0.7 and version code to 49
- add localized release notes for route-aware duration recommendations
- update the changelog and Play submission checklist

## Validation

- 89 Python tests passed
- 306 web tests passed
- web production build passed
- Android unit tests, lint, and debug builds passed across GitHub, Play, and Journal Lab flavors