### PR TITLE
Notify users when app updates are available

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,21 @@ jobs:
           apk="TimelineVisualizer-${RELEASE_TAG}.apk"
           cp app/build/outputs/apk/github/release/app-github-release.apk "$apk"
           sha256sum "$apk" > "$apk.sha256"
+          version_code="$(sed -nE 's/^[[:space:]]*versionCode = ([0-9]+).*$/\1/p' app/build.gradle.kts | head -n 1)"
+          version_name="$(sed -nE 's/^[[:space:]]*versionName = "([^"]+)".*$/\1/p' app/build.gradle.kts | head -n 1)"
+          jq -n \
+            --argjson versionCode "$version_code" \
+            --arg versionName "$version_name" \
+            --arg releaseUrl "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}" \
+            '{versionCode: $versionCode, versionName: $versionName, releaseUrl: $releaseUrl}' \
+            > update.json
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" "$apk" "$apk.sha256" --clobber
+            gh release upload "$RELEASE_TAG" "$apk" "$apk.sha256" update.json --clobber
           else
             gh release create "$RELEASE_TAG" \
               "$apk" \
               "$apk.sha256" \
+              update.json \
               --title "Timeline Visualizer ${RELEASE_TAG#v}" \
               --notes-file "docs/release-notes-${RELEASE_TAG}.md" \
               --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 - Add distance-unit selection to the web app.
 - Document the web app's distance units and close-up mode.
 
+## 3.0.9
+
+- Added an automatic, dismissible update prompt for GitHub APK and Google Play installations.
+- Added Google Play flexible in-app updates and a release-specific update link for GitHub APK users.
+- Added daily check throttling and a seven-day reminder delay after choosing Not now.
+- Added localized update messaging without sending Timeline data.
+- Added `update.json` to GitHub releases for reliable version discovery.
+- Set Android version code 51 and version name 3.0.9.
+
 ## 3.0.8
 
 - Alert when background video creation fails and explain common causes without exposing export data.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 50
-        versionName = "3.0.8"
+        versionCode = 51
+        versionName = "3.0.9"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -110,6 +110,8 @@ dependencies {
     implementation("androidx.room:room-ktx:2.8.4")
     implementation("androidx.work:work-runtime:2.11.2")
     implementation("androidx.viewpager2:viewpager2:1.1.0")
+    "playImplementation"("com.google.android.play:app-update:2.1.0")
+    "playImplementation"("com.google.android.play:app-update-ktx:2.1.0")
     ksp("androidx.room:room-compiler:2.8.4")
 
     testImplementation("junit:junit:4.13.2")

--- a/app/src/github/java/dev/mahlernim/timelinevisualizer/update/DistributionUpdateManager.kt
+++ b/app/src/github/java/dev/mahlernim/timelinevisualizer/update/DistributionUpdateManager.kt
@@ -1,0 +1,94 @@
+package dev.mahlernim.timelinevisualizer.update
+
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
+import androidx.lifecycle.lifecycleScope
+import com.google.gson.JsonParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
+
+class DistributionUpdateManager(
+    private val activity: AppCompatActivity,
+    @Suppress("UNUSED_PARAMETER") updateLauncher: ActivityResultLauncher<IntentSenderRequest>,
+    @Suppress("UNUSED_PARAMETER") onUpdateDownloaded: () -> Unit,
+) {
+    fun checkForUpdate(onResult: (AvailableAppUpdate?) -> Unit) {
+        activity.lifecycleScope.launch {
+            val update = withContext(Dispatchers.IO) { fetchLatestUpdate() }
+            onResult(update)
+        }
+    }
+
+    fun startUpdate(update: AvailableAppUpdate): Boolean {
+        val url = update.releaseUrl ?: return false
+        return runCatching {
+            activity.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+        }.isSuccess
+    }
+
+    fun onStart() = Unit
+
+    fun onStop() = Unit
+
+    fun completeUpdate() = Unit
+
+    private fun fetchLatestUpdate(): AvailableAppUpdate? = runCatching {
+        val connection = URL(UPDATE_MANIFEST_URL).openConnection() as HttpURLConnection
+        connection.connectTimeout = TIMEOUT_MILLIS
+        connection.readTimeout = TIMEOUT_MILLIS
+        connection.instanceFollowRedirects = true
+        connection.useCaches = false
+        connection.setRequestProperty("Accept", "application/json")
+        connection.setRequestProperty("Cache-Control", "no-cache")
+        try {
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) return@runCatching null
+            connection.inputStream.bufferedReader().use { reader ->
+                GithubUpdateManifest.parse(reader.readText())?.toAvailableUpdate()
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }.getOrNull()
+
+    internal data class GithubUpdateManifest(
+        val versionCode: Int,
+        val versionName: String,
+        val releaseUrl: String,
+    ) {
+        fun toAvailableUpdate(): AvailableAppUpdate = AvailableAppUpdate(versionCode, versionName, releaseUrl)
+
+        companion object {
+            fun parse(json: String): GithubUpdateManifest? = runCatching {
+                val value = JsonParser.parseString(json).asJsonObject
+                val versionCode = value.get("versionCode").asInt
+                val versionName = value.get("versionName").asString.trim()
+                val releaseUrl = value.get("releaseUrl").asString.trim()
+                val uri = URI(releaseUrl)
+                if (
+                    versionCode <= 0 ||
+                    versionName.isEmpty() ||
+                    uri.scheme != "https" ||
+                    uri.host != "github.com" ||
+                    !uri.path.startsWith(RELEASE_PATH_PREFIX)
+                ) {
+                    return@runCatching null
+                }
+                GithubUpdateManifest(versionCode, versionName, releaseUrl)
+            }.getOrNull()
+        }
+    }
+
+    private companion object {
+        const val UPDATE_MANIFEST_URL =
+            "https://github.com/mahlernim/google-timeline-visualizer/releases/latest/download/update.json"
+        const val RELEASE_PATH_PREFIX = "/mahlernim/google-timeline-visualizer/releases/tag/v"
+        const val TIMEOUT_MILLIS = 5_000
+    }
+}

--- a/app/src/journalLab/java/dev/mahlernim/timelinevisualizer/update/DistributionUpdateManager.kt
+++ b/app/src/journalLab/java/dev/mahlernim/timelinevisualizer/update/DistributionUpdateManager.kt
@@ -1,0 +1,21 @@
+package dev.mahlernim.timelinevisualizer.update
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.appcompat.app.AppCompatActivity
+
+class DistributionUpdateManager(
+    @Suppress("UNUSED_PARAMETER") activity: AppCompatActivity,
+    @Suppress("UNUSED_PARAMETER") updateLauncher: ActivityResultLauncher<IntentSenderRequest>,
+    @Suppress("UNUSED_PARAMETER") onUpdateDownloaded: () -> Unit,
+) {
+    fun checkForUpdate(onResult: (AvailableAppUpdate?) -> Unit) = onResult(null)
+
+    fun startUpdate(@Suppress("UNUSED_PARAMETER") update: AvailableAppUpdate): Boolean = false
+
+    fun onStart() = Unit
+
+    fun onStop() = Unit
+
+    fun completeUpdate() = Unit
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -29,8 +29,10 @@ import android.widget.SeekBar
 import android.widget.TextView
 import android.widget.PopupMenu
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.IntentSenderRequest
 import androidx.activity.addCallback
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
@@ -169,6 +171,10 @@ import dev.mahlernim.timelinevisualizer.trips.TripKind
 import dev.mahlernim.timelinevisualizer.trips.TripProject
 import dev.mahlernim.timelinevisualizer.trips.TripSuggestion
 import dev.mahlernim.timelinevisualizer.trips.TripsStore
+import dev.mahlernim.timelinevisualizer.update.AvailableAppUpdate
+import dev.mahlernim.timelinevisualizer.update.DistributionUpdateManager
+import dev.mahlernim.timelinevisualizer.update.UpdatePromptPolicy
+import dev.mahlernim.timelinevisualizer.update.UpdatePromptStateStore
 import dev.mahlernim.timelinevisualizer.trips.OfflineDestinationNameResolver
 import dev.mahlernim.timelinevisualizer.trips.TripCoverage
 import dev.mahlernim.timelinevisualizer.trips.TripCoverageCalculator
@@ -231,6 +237,7 @@ class MainActivity : AppCompatActivity() {
     private val monthNames by lazy { DateFormatSymbols.getInstance().months.take(12) }
     private val shortMonthNames by lazy { DateFormatSymbols.getInstance().shortMonths.take(12) }
     private val preferences by lazy { getSharedPreferences("display", MODE_PRIVATE) }
+    private val updatePromptState by lazy { UpdatePromptStateStore(applicationContext) }
     private val videoMedia by lazy { VideoMedia(applicationContext) }
     private val generatedMedia by lazy { GeneratedMediaRepository(applicationContext) }
     private val timelineLoader by lazy { CachedTimelineLoader(applicationContext) }
@@ -284,6 +291,10 @@ class MainActivity : AppCompatActivity() {
     private var playerPlayWhenReady = true
     private var syncingBottomNavigation = false
     private var exportingVideo = false
+    private lateinit var distributionUpdateManager: DistributionUpdateManager
+    private var pendingAppUpdate: AvailableAppUpdate? = null
+    private var updatePromptDialog: AlertDialog? = null
+    private var updateReadyShown = false
     private var pendingImportCompletionUri: Uri? = null
     private var activePresetId: String? = null
     private var presetOriginId: String? = null
@@ -380,6 +391,10 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private val appUpdateLauncher = registerForActivityResult(
+        ActivityResultContracts.StartIntentSenderForResult(),
+    ) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
@@ -389,6 +404,11 @@ class MainActivity : AppCompatActivity() {
         onboarding = ScreenJournalOnboardingBinding.bind(findViewById(R.id.journalOnboardingScreen))
         settingsScreen = ScreenSettingsBinding.bind(findViewById(R.id.settingsScreen))
         playerScreen = ScreenPlayerBinding.bind(findViewById(R.id.playerScreen))
+        distributionUpdateManager = DistributionUpdateManager(
+            activity = this,
+            updateLauncher = appUpdateLauncher,
+            onUpdateDownloaded = ::showDownloadedUpdate,
+        )
         val lightSystemBars = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
             Configuration.UI_MODE_NIGHT_YES
         WindowInsetsControllerCompat(window, binding.root).apply {
@@ -850,6 +870,8 @@ class MainActivity : AppCompatActivity() {
         updateHomeJournalCard()
         renderVideos()
         renderTrips()
+        maybeCheckForAutomaticUpdate()
+        maybeShowPendingUpdate()
         if (BuildConfig.IS_JOURNAL_LAB) {
             loadJournalIfNeeded()
             return
@@ -1539,6 +1561,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
+        distributionUpdateManager.onStart()
         if (currentScreen == Screen.PLAYER) initializeVideoPlayer()
     }
 
@@ -1555,9 +1578,11 @@ class MainActivity : AppCompatActivity() {
         ) {
             activeJournal?.takeIf { it.reminderEnabled }?.let { disableJournalReminders(it.id) }
         }
+        maybeShowPendingUpdate()
     }
 
     override fun onStop() {
+        distributionUpdateManager.onStop()
         releaseVideoPlayer()
         super.onStop()
     }
@@ -5708,6 +5733,61 @@ class MainActivity : AppCompatActivity() {
         } else if (!opened) {
             Snackbar.make(binding.root, R.string.update_page_unavailable, Snackbar.LENGTH_LONG).show()
         }
+    }
+
+    private fun maybeCheckForAutomaticUpdate(nowMillis: Long = System.currentTimeMillis()) {
+        if (Build.FINGERPRINT.equals("robolectric", ignoreCase = true)) return
+        if (!UpdatePromptPolicy.shouldCheck(nowMillis, updatePromptState.lastCheckMillis)) return
+        updatePromptState.recordCheck(nowMillis)
+        distributionUpdateManager.checkForUpdate { update ->
+            if (
+                update != null &&
+                UpdatePromptPolicy.shouldPrompt(
+                    update = update,
+                    installedVersionCode = BuildConfig.VERSION_CODE,
+                    dismissedVersionCode = updatePromptState.dismissedVersionCode,
+                    dismissedAtMillis = updatePromptState.dismissedAtMillis,
+                    nowMillis = System.currentTimeMillis(),
+                )
+            ) {
+                pendingAppUpdate = update
+                maybeShowPendingUpdate()
+            }
+        }
+    }
+
+    private fun maybeShowPendingUpdate() {
+        val update = pendingAppUpdate ?: return
+        if (updatePromptDialog != null) return
+        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return
+        if (currentScreen != Screen.VIDEOS || exportingVideo || isFinishing) return
+
+        val dialog = MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.update_available_title)
+            .setMessage(R.string.update_available_message)
+            .setNegativeButton(R.string.not_now) { _, _ ->
+                updatePromptState.dismiss(update.versionCode, System.currentTimeMillis())
+                pendingAppUpdate = null
+            }
+            .setPositiveButton(R.string.get_update) { _, _ ->
+                pendingAppUpdate = null
+                if (!distributionUpdateManager.startUpdate(update)) openUpdates()
+            }
+            .setCancelable(false)
+            .create()
+        updatePromptDialog = dialog
+        dialog.setOnDismissListener {
+            if (updatePromptDialog === dialog) updatePromptDialog = null
+        }
+        dialog.show()
+    }
+
+    private fun showDownloadedUpdate() {
+        if (updateReadyShown || !::binding.isInitialized) return
+        updateReadyShown = true
+        Snackbar.make(binding.root, R.string.update_ready, Snackbar.LENGTH_INDEFINITE)
+            .setAction(R.string.restart_to_update) { distributionUpdateManager.completeUpdate() }
+            .show()
     }
 
     private fun openPrivacyPolicy() {

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/update/AvailableAppUpdate.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/update/AvailableAppUpdate.kt
@@ -1,0 +1,7 @@
+package dev.mahlernim.timelinevisualizer.update
+
+data class AvailableAppUpdate(
+    val versionCode: Int,
+    val versionName: String? = null,
+    val releaseUrl: String? = null,
+)

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/update/UpdatePromptPolicy.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/update/UpdatePromptPolicy.kt
@@ -1,0 +1,24 @@
+package dev.mahlernim.timelinevisualizer.update
+
+object UpdatePromptPolicy {
+    const val CHECK_INTERVAL_MILLIS = 24L * 60L * 60L * 1_000L
+    const val DISMISSAL_INTERVAL_MILLIS = 7L * 24L * 60L * 60L * 1_000L
+
+    fun shouldCheck(nowMillis: Long, lastCheckMillis: Long): Boolean =
+        lastCheckMillis <= 0L ||
+            nowMillis < lastCheckMillis ||
+            nowMillis - lastCheckMillis >= CHECK_INTERVAL_MILLIS
+
+    fun shouldPrompt(
+        update: AvailableAppUpdate,
+        installedVersionCode: Int,
+        dismissedVersionCode: Int,
+        dismissedAtMillis: Long,
+        nowMillis: Long,
+    ): Boolean {
+        if (update.versionCode <= installedVersionCode) return false
+        if (dismissedVersionCode != update.versionCode) return true
+        if (dismissedAtMillis <= 0L || nowMillis < dismissedAtMillis) return true
+        return nowMillis - dismissedAtMillis >= DISMISSAL_INTERVAL_MILLIS
+    }
+}

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/update/UpdatePromptStateStore.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/update/UpdatePromptStateStore.kt
@@ -1,0 +1,35 @@
+package dev.mahlernim.timelinevisualizer.update
+
+import android.content.Context
+import androidx.core.content.edit
+
+class UpdatePromptStateStore(context: Context) {
+    private val preferences = context.applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    val lastCheckMillis: Long
+        get() = preferences.getLong(KEY_LAST_CHECK, 0L)
+
+    val dismissedVersionCode: Int
+        get() = preferences.getInt(KEY_DISMISSED_VERSION, 0)
+
+    val dismissedAtMillis: Long
+        get() = preferences.getLong(KEY_DISMISSED_AT, 0L)
+
+    fun recordCheck(nowMillis: Long) {
+        preferences.edit { putLong(KEY_LAST_CHECK, nowMillis) }
+    }
+
+    fun dismiss(versionCode: Int, nowMillis: Long) {
+        preferences.edit {
+            putInt(KEY_DISMISSED_VERSION, versionCode)
+            putLong(KEY_DISMISSED_AT, nowMillis)
+        }
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME = "app_update_prompt"
+        const val KEY_LAST_CHECK = "last_check_millis"
+        const val KEY_DISMISSED_VERSION = "dismissed_version_code"
+        const val KEY_DISMISSED_AT = "dismissed_at_millis"
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -66,7 +66,6 @@
     <string name="video_creation_cancelled">Videoerstellung abgebrochen</string>
     <string name="cancel">Stornieren</string>
     <string name="retry">Erneut versuchen</string>
-    <string name="not_now">Nicht jetzt</string>
     <string name="background_video_title">Erstellen Sie im Hintergrund weiter</string>
     <string name="background_video_message">Erlauben Sie Benachrichtigungen, um den Videofortschritt nach dem Verlassen der App zu sehen und eine Benachrichtigung zu erhalten, wenn die Erstellung abgeschlossen wird oder fehlschlägt. Die Videoerstellung wird auch dann fortgesetzt, wenn Benachrichtigungen nicht zulässig sind.</string>
     <string name="video_request_unavailable">Die Videoerstellung konnte nicht gestartet werden. Bitte wählen Sie erneut einen Speicherort.</string>
@@ -133,6 +132,12 @@
     </plurals>
     <string name="unknown_duration">Unbekannte Länge</string>
     <string name="check_for_updates">Suchen Sie nach Updates</string>
+    <string name="update_available_title">Gute Neuigkeiten!</string>
+    <string name="update_available_message">Eine neue Version von Timeline Visualizer ist verfügbar.</string>
+    <string name="get_update">Herunterladen</string>
+    <string name="not_now">Nicht jetzt</string>
+    <string name="update_ready">Das Update kann installiert werden.</string>
+    <string name="restart_to_update">Neu starten</string>
     <string name="project_on_github">Projekt auf GitHub</string>
     <string name="update_page_unavailable">Die Update-Seite konnte nicht geöffnet werden</string>
     <string name="web_page_unavailable">Die Webseite konnte nicht geöffnet werden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -67,7 +67,6 @@
     <string name="video_creation_cancelled">Creación de vídeo cancelada</string>
     <string name="cancel">Cancelar</string>
     <string name="retry">Reintentar</string>
-    <string name="not_now">Ahora no</string>
     <string name="background_video_title">Continuar creando en segundo plano.</string>
     <string name="background_video_message">Permita las notificaciones para ver el progreso después de salir de la aplicación y recibir una alerta cuando la creación termine o falle. La creación del vídeo continúa aunque no se permitan notificaciones.</string>
     <string name="video_request_unavailable">No se pudo iniciar la creación del vídeo. Vuelva a elegir una ubicación para guardar.</string>
@@ -137,6 +136,12 @@
     </plurals>
     <string name="unknown_duration">Longitud desconocida</string>
     <string name="check_for_updates">Buscar actualizaciones</string>
+    <string name="update_available_title">¡Buenas noticias!</string>
+    <string name="update_available_message">Hay una nueva versión de Timeline Visualizer disponible.</string>
+    <string name="get_update">Obtenerla</string>
+    <string name="not_now">Ahora no</string>
+    <string name="update_ready">La actualización está lista para instalarse.</string>
+    <string name="restart_to_update">Reiniciar</string>
     <string name="project_on_github">Proyecto en GitHub</string>
     <string name="update_page_unavailable">No se pudo abrir la página de actualización</string>
     <string name="web_page_unavailable">No se pudo abrir la página web</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -67,7 +67,6 @@
     <string name="video_creation_cancelled">Création vidéo annulée</string>
     <string name="cancel">Annuler</string>
     <string name="retry">Réessayer</string>
-    <string name="not_now">Pas maintenant</string>
     <string name="background_video_title">Continuer à créer en arrière-plan</string>
     <string name="background_video_message">Autorisez les notifications pour suivre la progression après avoir quitté l\'application et recevoir une alerte lorsque la création se termine ou échoue. La création vidéo continue même si les notifications ne sont pas autorisées.</string>
     <string name="video_request_unavailable">La création vidéo n\'a pas pu démarrer. Veuillez choisir à nouveau un emplacement de sauvegarde.</string>
@@ -137,6 +136,12 @@
     </plurals>
     <string name="unknown_duration">Longueur inconnue</string>
     <string name="check_for_updates">Vérifier les mises à jour</string>
+    <string name="update_available_title">Bonne nouvelle !</string>
+    <string name="update_available_message">Une nouvelle version de Timeline Visualizer est disponible.</string>
+    <string name="get_update">L’obtenir</string>
+    <string name="not_now">Pas maintenant</string>
+    <string name="update_ready">La mise à jour est prête à être installée.</string>
+    <string name="restart_to_update">Redémarrer</string>
     <string name="project_on_github">Projet sur GitHub</string>
     <string name="update_page_unavailable">Impossible d\'ouvrir la page de mise à jour</string>
     <string name="web_page_unavailable">Impossible d\'ouvrir la page Web</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -64,7 +64,6 @@
     <string name="video_creation_cancelled">動画作成をキャンセルしました</string>
     <string name="cancel">キャンセル</string>
     <string name="retry">再試行</string>
-    <string name="not_now">後で</string>
     <string name="background_video_title">バックグラウンドで作成を続ける</string>
     <string name="background_video_message">アプリを閉じた後も進行状況を確認し、作成の完了時または失敗時に通知を受け取るには、通知を許可してください。通知を許可しなくても動画作成は続きます。</string>
     <string name="video_request_unavailable">動画作成を開始できませんでした。保存先をもう一度選択してください。</string>
@@ -128,6 +127,12 @@
     </plurals>
     <string name="unknown_duration">長さ不明</string>
     <string name="check_for_updates">更新を確認</string>
+    <string name="update_available_title">お知らせです！</string>
+    <string name="update_available_message">Timeline Visualizer の新しいバージョンを利用できます。</string>
+    <string name="get_update">入手する</string>
+    <string name="not_now">後で</string>
+    <string name="update_ready">アップデートをインストールできます。</string>
+    <string name="restart_to_update">再起動</string>
     <string name="project_on_github">GitHubのプロジェクト</string>
     <string name="update_page_unavailable">更新ページを開けませんでした</string>
     <string name="web_page_unavailable">ウェブページを開けませんでした</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -64,7 +64,6 @@
     <string name="video_creation_cancelled">동영상 만들기를 취소했습니다</string>
     <string name="cancel">취소</string>
     <string name="retry">다시 시도</string>
-    <string name="not_now">나중에</string>
     <string name="background_video_title">백그라운드에서 동영상 계속 만들기</string>
     <string name="background_video_message">앱을 나간 뒤에도 동영상 진행률을 확인하고 생성 완료 또는 실패 알림을 받으려면 알림을 허용하세요. 알림을 허용하지 않아도 동영상 만들기는 계속됩니다.</string>
     <string name="video_request_unavailable">동영상 만들기를 시작할 수 없습니다. 저장 위치를 다시 선택해 주세요.</string>
@@ -128,6 +127,12 @@
     </plurals>
     <string name="unknown_duration">길이 정보 없음</string>
     <string name="check_for_updates">업데이트 확인</string>
+    <string name="update_available_title">좋은 소식이에요!</string>
+    <string name="update_available_message">새로운 버전의 Timeline Visualizer를 사용할 수 있습니다.</string>
+    <string name="get_update">받기</string>
+    <string name="not_now">나중에</string>
+    <string name="update_ready">업데이트를 설치할 준비가 되었습니다.</string>
+    <string name="restart_to_update">다시 시작</string>
     <string name="project_on_github">GitHub 프로젝트</string>
     <string name="update_page_unavailable">업데이트 페이지를 열 수 없습니다</string>
     <string name="web_page_unavailable">웹페이지를 열 수 없습니다</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,7 +67,6 @@
     <string name="video_creation_cancelled">Criação de vídeo cancelada</string>
     <string name="cancel">Cancelar</string>
     <string name="retry">Tentar novamente</string>
-    <string name="not_now">Agora não</string>
     <string name="background_video_title">Continue criando em segundo plano</string>
     <string name="background_video_message">Permita notificações para acompanhar o progresso após sair do aplicativo e receber um alerta quando a criação terminar ou falhar. A criação do vídeo continua mesmo sem permissão para notificações.</string>
     <string name="video_request_unavailable">Não foi possível iniciar a criação do vídeo. Escolha um local para salvar novamente.</string>
@@ -137,6 +136,12 @@
     </plurals>
     <string name="unknown_duration">Comprimento desconhecido</string>
     <string name="check_for_updates">Verifique se há atualizações</string>
+    <string name="update_available_title">Boas notícias!</string>
+    <string name="update_available_message">Uma nova versão do Timeline Visualizer está disponível.</string>
+    <string name="get_update">Obter</string>
+    <string name="not_now">Agora não</string>
+    <string name="update_ready">A atualização está pronta para ser instalada.</string>
+    <string name="restart_to_update">Reiniciar</string>
     <string name="project_on_github">Projeto em GitHub</string>
     <string name="update_page_unavailable">Não foi possível abrir a página de atualização</string>
     <string name="web_page_unavailable">Não foi possível abrir a página da web</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -129,6 +129,11 @@
     </plurals>
     <string name="unknown_duration">长度未知</string>
     <string name="check_for_updates">检查更新</string>
+    <string name="update_available_title">好消息！</string>
+    <string name="update_available_message">Timeline Visualizer 有新版本可用。</string>
+    <string name="get_update">获取</string>
+    <string name="update_ready">更新已准备好安装。</string>
+    <string name="restart_to_update">重新启动</string>
     <string name="project_on_github">GitHub 上的项目</string>
     <string name="update_page_unavailable">无法打开更新页面</string>
     <string name="web_page_unavailable">无法打开网页</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -129,6 +129,11 @@
     </plurals>
     <string name="unknown_duration">長度未知</string>
     <string name="check_for_updates">檢查更新</string>
+    <string name="update_available_title">好消息！</string>
+    <string name="update_available_message">Timeline Visualizer 有新版本可用。</string>
+    <string name="get_update">取得</string>
+    <string name="update_ready">更新已準備好安裝。</string>
+    <string name="restart_to_update">重新啟動</string>
     <string name="project_on_github">專案的 GitHub 頁面</string>
     <string name="update_page_unavailable">無法開啟更新頁面</string>
     <string name="web_page_unavailable">無法開啟網頁</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,6 @@
     <string name="video_creation_cancelled">Video creation cancelled</string>
     <string name="cancel">Cancel</string>
     <string name="retry">Retry</string>
-    <string name="not_now">Not now</string>
     <string name="background_video_title">Continue creating in the background</string>
     <string name="background_video_message">Allow notifications to see video progress after leaving the app and get an alert when creation finishes or fails. Video creation continues even if notifications are not allowed.</string>
     <string name="video_request_unavailable">Video creation could not be started. Please choose a save location again.</string>
@@ -139,6 +138,12 @@
     </plurals>
     <string name="unknown_duration">Unknown length</string>
     <string name="check_for_updates">Check for updates</string>
+    <string name="update_available_title">Good news!</string>
+    <string name="update_available_message">A new version of Timeline Visualizer is available.</string>
+    <string name="get_update">Get it</string>
+    <string name="not_now">Not now</string>
+    <string name="update_ready">The update is ready to install.</string>
+    <string name="restart_to_update">Restart</string>
     <string name="project_on_github">Project on GitHub</string>
     <string name="update_page_unavailable">Could not open the update page</string>
     <string name="web_page_unavailable">Could not open the web page</string>

--- a/app/src/play/java/dev/mahlernim/timelinevisualizer/update/DistributionUpdateManager.kt
+++ b/app/src/play/java/dev/mahlernim/timelinevisualizer/update/DistributionUpdateManager.kt
@@ -1,0 +1,73 @@
+package dev.mahlernim.timelinevisualizer.update
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.play.core.appupdate.AppUpdateInfo
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+
+class DistributionUpdateManager(
+    private val activity: AppCompatActivity,
+    private val updateLauncher: ActivityResultLauncher<IntentSenderRequest>,
+    private val onUpdateDownloaded: () -> Unit,
+) {
+    private val appUpdateManager: AppUpdateManager = AppUpdateManagerFactory.create(activity)
+    private var availableUpdateInfo: AppUpdateInfo? = null
+    private var listening = false
+    private val installListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus() == InstallStatus.DOWNLOADED) onUpdateDownloaded()
+    }
+
+    fun checkForUpdate(onResult: (AvailableAppUpdate?) -> Unit) {
+        appUpdateManager.appUpdateInfo
+            .addOnSuccessListener(activity) { info ->
+                val available = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                    info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+                availableUpdateInfo = info.takeIf { available }
+                onResult(
+                    info.takeIf { available }?.let {
+                        AvailableAppUpdate(versionCode = it.availableVersionCode())
+                    },
+                )
+            }
+            .addOnFailureListener(activity) { onResult(null) }
+    }
+
+    fun startUpdate(@Suppress("UNUSED_PARAMETER") update: AvailableAppUpdate): Boolean {
+        val info = availableUpdateInfo ?: return false
+        return runCatching {
+            appUpdateManager.startUpdateFlowForResult(
+                info,
+                updateLauncher,
+                AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
+            )
+        }.getOrDefault(false)
+    }
+
+    fun onStart() {
+        if (!listening) {
+            appUpdateManager.registerListener(installListener)
+            listening = true
+        }
+        appUpdateManager.appUpdateInfo.addOnSuccessListener(activity) { info ->
+            if (info.installStatus() == InstallStatus.DOWNLOADED) onUpdateDownloaded()
+        }
+    }
+
+    fun onStop() {
+        if (listening) {
+            appUpdateManager.unregisterListener(installListener)
+            listening = false
+        }
+    }
+
+    fun completeUpdate() {
+        appUpdateManager.completeUpdate()
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/update/UpdatePromptPolicyTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/update/UpdatePromptPolicyTest.kt
@@ -1,0 +1,75 @@
+package dev.mahlernim.timelinevisualizer.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdatePromptPolicyTest {
+    @Test
+    fun checksOnFirstRunAndOncePerDay() {
+        val now = 10L * UpdatePromptPolicy.CHECK_INTERVAL_MILLIS
+
+        assertTrue(UpdatePromptPolicy.shouldCheck(now, 0L))
+        assertFalse(UpdatePromptPolicy.shouldCheck(now, now - UpdatePromptPolicy.CHECK_INTERVAL_MILLIS + 1L))
+        assertTrue(UpdatePromptPolicy.shouldCheck(now, now - UpdatePromptPolicy.CHECK_INTERVAL_MILLIS))
+    }
+
+    @Test
+    fun clockMovingBackwardDoesNotSuppressChecksIndefinitely() {
+        assertTrue(UpdatePromptPolicy.shouldCheck(nowMillis = 1_000L, lastCheckMillis = 2_000L))
+    }
+
+    @Test
+    fun onlyNewerVersionsArePrompted() {
+        assertFalse(shouldPrompt(availableVersionCode = 50, installedVersionCode = 50))
+        assertFalse(shouldPrompt(availableVersionCode = 49, installedVersionCode = 50))
+        assertTrue(shouldPrompt(availableVersionCode = 51, installedVersionCode = 50))
+    }
+
+    @Test
+    fun dismissedVersionReturnsAfterSevenDays() {
+        val dismissedAt = 1_000L
+        val update = AvailableAppUpdate(versionCode = 51)
+
+        assertFalse(
+            UpdatePromptPolicy.shouldPrompt(
+                update,
+                installedVersionCode = 50,
+                dismissedVersionCode = 51,
+                dismissedAtMillis = dismissedAt,
+                nowMillis = dismissedAt + UpdatePromptPolicy.DISMISSAL_INTERVAL_MILLIS - 1L,
+            ),
+        )
+        assertTrue(
+            UpdatePromptPolicy.shouldPrompt(
+                update,
+                installedVersionCode = 50,
+                dismissedVersionCode = 51,
+                dismissedAtMillis = dismissedAt,
+                nowMillis = dismissedAt + UpdatePromptPolicy.DISMISSAL_INTERVAL_MILLIS,
+            ),
+        )
+    }
+
+    @Test
+    fun newerVersionOverridesAnEarlierDismissal() {
+        assertTrue(
+            UpdatePromptPolicy.shouldPrompt(
+                AvailableAppUpdate(versionCode = 52),
+                installedVersionCode = 50,
+                dismissedVersionCode = 51,
+                dismissedAtMillis = 1_000L,
+                nowMillis = 2_000L,
+            ),
+        )
+    }
+
+    private fun shouldPrompt(availableVersionCode: Int, installedVersionCode: Int): Boolean =
+        UpdatePromptPolicy.shouldPrompt(
+            update = AvailableAppUpdate(versionCode = availableVersionCode),
+            installedVersionCode = installedVersionCode,
+            dismissedVersionCode = 0,
+            dismissedAtMillis = 0L,
+            nowMillis = 1_000L,
+        )
+}

--- a/app/src/testGithub/java/dev/mahlernim/timelinevisualizer/update/GithubUpdateManifestTest.kt
+++ b/app/src/testGithub/java/dev/mahlernim/timelinevisualizer/update/GithubUpdateManifestTest.kt
@@ -1,0 +1,57 @@
+package dev.mahlernim.timelinevisualizer.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GithubUpdateManifestTest {
+    @Test
+    fun parsesPublishedReleaseMetadata() {
+        val update = DistributionUpdateManager.GithubUpdateManifest.parse(
+            """
+            {
+              "versionCode": 51,
+              "versionName": "3.0.9",
+              "releaseUrl": "https://github.com/mahlernim/google-timeline-visualizer/releases/tag/v3.0.9"
+            }
+            """.trimIndent(),
+        )?.toAvailableUpdate()
+
+        assertEquals(51, update?.versionCode)
+        assertEquals("3.0.9", update?.versionName)
+        assertEquals(
+            "https://github.com/mahlernim/google-timeline-visualizer/releases/tag/v3.0.9",
+            update?.releaseUrl,
+        )
+    }
+
+    @Test
+    fun rejectsNonProjectReleaseUrls() {
+        val update = DistributionUpdateManager.GithubUpdateManifest.parse(
+            """
+            {
+              "versionCode": 51,
+              "versionName": "3.0.9",
+              "releaseUrl": "https://example.com/releases/tag/v3.0.9"
+            }
+            """.trimIndent(),
+        )
+
+        assertNull(update)
+    }
+
+    @Test
+    fun rejectsInvalidVersionCodes() {
+        val update = DistributionUpdateManager.GithubUpdateManifest.parse(
+            """
+            {
+              "versionCode": 0,
+              "versionName": "3.0.9",
+              "releaseUrl": "https://github.com/mahlernim/google-timeline-visualizer/releases/tag/v3.0.9"
+            }
+            """.trimIndent(),
+        )
+
+        assertNull(update)
+    }
+}

--- a/docs/release-notes-v3.0.9.md
+++ b/docs/release-notes-v3.0.9.md
@@ -1,0 +1,35 @@
+# Timeline Visualizer 3.0.9
+
+Timeline Visualizer now lets you know when a new version is available. GitHub APK installs open the matching release, while Play Store installs use Google Play’s flexible update flow. Choose Not now to be reminded later.
+
+## 한국어
+
+이제 새 버전이 나오면 Timeline Visualizer에서 알려드립니다. GitHub APK는 해당 릴리스 페이지를 열고, Play 스토어 설치 버전은 Google Play의 유연한 업데이트 기능을 사용합니다. 나중에를 선택하면 추후 다시 알려드립니다.
+
+## 日本語
+
+新しいバージョンが利用可能になると、Timeline Visualizer がお知らせするようになりました。GitHub APK では該当するリリースページを開き、Play ストア版では Google Play のフレキシブル更新を使用します。「後で」を選ぶと、後日もう一度お知らせします。
+
+## 简体中文
+
+Timeline Visualizer 现在会在新版本可用时通知您。GitHub APK 会打开对应的发布页面，Play 商店版本则使用 Google Play 的灵活更新流程。选择“暂不”后，应用会稍后再次提醒您。
+
+## 繁體中文
+
+Timeline Visualizer 現在會在新版本可用時通知您。GitHub APK 會開啟對應的發布頁面，Play 商店版本則使用 Google Play 的彈性更新流程。選擇「稍後」後，應用程式會在之後再次提醒您。
+
+## Español
+
+Timeline Visualizer ahora avisa cuando hay una nueva versión disponible. Las instalaciones mediante APK de GitHub abren la versión correspondiente, mientras que las instalaciones de Play Store usan la actualización flexible de Google Play. Elige Ahora no para recibir otro aviso más adelante.
+
+## Français
+
+Timeline Visualizer vous avertit désormais lorsqu’une nouvelle version est disponible. Les installations par APK GitHub ouvrent la version correspondante, tandis que les installations via le Play Store utilisent la mise à jour flexible de Google Play. Choisissez Pas maintenant pour recevoir un nouveau rappel ultérieurement.
+
+## Deutsch
+
+Timeline Visualizer informiert jetzt, wenn eine neue Version verfügbar ist. GitHub-APK-Installationen öffnen die passende Veröffentlichung, während Play-Store-Installationen das flexible Update von Google Play verwenden. Wählen Sie Nicht jetzt, um später erneut erinnert zu werden.
+
+## Português (Brasil)
+
+O Timeline Visualizer agora avisa quando uma nova versão está disponível. Instalações pelo APK do GitHub abrem a versão correspondente, enquanto instalações pela Play Store usam a atualização flexível do Google Play. Escolha Agora não para receber outro lembrete mais tarde.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.8` and version code `50`
+- Version name `3.0.9` and version code `51`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 50' in build_file
-    assert 'versionName = "3.0.8"' in build_file
+    assert 'versionCode = 51' in build_file
+    assert 'versionName = "3.0.9"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -32,7 +32,21 @@ def test_release_workflow_can_update_an_existing_release() -> None:
     assert "Existing release tag to build and update" in workflow
     assert 'ref: ${{ env.RELEASE_TAG }}' in workflow
     assert 'gh release view "$RELEASE_TAG"' in workflow
-    assert 'gh release upload "$RELEASE_TAG" "$apk" "$apk.sha256" --clobber' in workflow
+    assert 'gh release upload "$RELEASE_TAG" "$apk" "$apk.sha256" update.json --clobber' in workflow
+
+
+def test_release_workflow_publishes_update_metadata() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for required in (
+        '--argjson versionCode "$version_code"',
+        '--arg versionName "$version_name"',
+        '--arg releaseUrl "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"',
+        "'{versionCode: $versionCode, versionName: $versionName, releaseUrl: $releaseUrl}'",
+        'gh release upload "$RELEASE_TAG" "$apk" "$apk.sha256" update.json --clobber',
+        "              update.json \\",
+    ):
+        assert required in workflow
 
 
 def test_release_workflow_uses_production_version_when_flavors_override_it() -> None:


### PR DESCRIPTION
## Summary

- Check once per day and show a dismissible update prompt only on the safe Videos screen.
- Use Google Play flexible in-app updates for Play installs and release metadata for GitHub APK installs.
- Remind users after seven days when they choose Not now, while showing a newer version immediately.
- Keep Timeline files, locations, dates, and generated media out of all update checks.
- Prepare version 3.0.9 and publish `update.json` with each GitHub release.

## Verification

- `testGithubDebugUnitTest`
- `testPlayDebugUnitTest`
- `lintGithubDebug`
- `lintPlayDebug`
- `python -m pytest -q tests/test_release_workflow.py tests/test_journal_lab_packaging.py`
- `git diff --check`

## Release plan

After exact-head CI succeeds, merge and tag `v3.0.9`. The release workflow will publish the signed GitHub APK, checksum, update metadata, and Play bundle. Submit that bundle to the existing Play closed Alpha track.