### PR TITLE
Prepare Timeline Visualizer 3.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 - Add distance-unit selection to the web app.
 - Document the web app's distance units and close-up mode.
 
+## 3.0.10
+
+- Allow Android custom frame rates from 15 through 240 fps with up to three decimal places, preserving common fractional rates such as 23.976, 29.97, and 59.94 through export and recovery.
+- Recover legacy Save As video exports safely across activity recreation, keep large pending requests off the main thread, and remove temporary route data promptly after completion or cancellation.
+- Keep export result notifications private, exclude private presets and trip metadata from Android backup and device transfer, and preserve cached thumbnails when removal is undone.
+- Correct desktop Timeline month-end ranges and mixed-timezone handling without inventing chronology when timestamps are ambiguous.
+- Prevent stale web preparation results from replacing newer choices and generate an app-scoped offline cache that leaves unrelated caches untouched.
+- Harden Android export-service cancellation, tile loading, reminder anchors, and update-check retry behavior.
+- Set Android version code 52 and version name 3.0.10.
+
 ## 3.0.9
 
 - Added an automatic, dismissible update prompt for GitHub APK and Google Play installations.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 51
-        versionName = "3.0.9"
+        versionCode = 52
+        versionName = "3.0.10"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/platform-parity.md
+++ b/docs/platform-parity.md
@@ -15,7 +15,7 @@ system integrations remain explicit instead of being hidden behind silent fallba
 | Total duration from 10 through 300 seconds | Yes | Yes | Yes |
 | Square, portrait, and landscape video | Yes | Yes | Yes |
 | Short-edge resolution from 480 through 2160 | Device-dependent | FFmpeg-dependent | WebCodecs-dependent |
-| Frame rate from 15 through 120 fps | Device-dependent | FFmpeg-dependent | WebCodecs-dependent |
+| Frame rate | Device-dependent, 15 through 240 fps with up to three decimals | FFmpeg-dependent, whole 15 through 120 fps | WebCodecs-dependent, whole 15 through 120 fps |
 | MP4 title metadata | Yes | Yes | Yes |
 | Capability check before export | Android codec probe | Argument and FFmpeg validation | Exact WebCodecs probe |
 | Timeline data stays local | Yes | Yes | Yes |

--- a/docs/release-notes-v3.0.10.md
+++ b/docs/release-notes-v3.0.10.md
@@ -1,0 +1,35 @@
+# Timeline Visualizer 3.0.10
+
+This maintenance release improves Timeline import, web preparation, and Android video export reliability. Android custom frame rates now accept 15 through 240 fps, including exact common rates such as 23.976, 29.97, and 59.94. Interrupted export recovery, private notifications, and backup exclusions are also strengthened.
+
+## 한국어
+
+이번 유지보수 릴리스에서는 타임라인 가져오기, 웹 준비 과정, Android 동영상 내보내기의 안정성을 개선했습니다. Android 사용자 지정 프레임률은 이제 15~240 fps를 지원하며 23.976, 29.97, 59.94 같은 일반적인 프레임률도 정확하게 처리합니다. 중단된 내보내기 복구, 비공개 알림, 백업 제외 기능도 강화했습니다.
+
+## 日本語
+
+このメンテナンスリリースでは、タイムラインの読み込み、ウェブでの準備処理、Android の動画書き出しの信頼性を向上しました。Android のカスタムフレームレートは 15～240 fps に対応し、23.976、29.97、59.94 などの一般的な値も正確に扱います。中断した書き出しの復元、非公開通知、バックアップ除外も強化しました。
+
+## 简体中文
+
+此维护版本提高了时间轴导入、网页准备过程和 Android 视频导出的可靠性。Android 自定义帧率现在支持 15 至 240 fps，并可准确处理 23.976、29.97 和 59.94 等常用帧率。中断导出恢复、私密通知和备份排除也得到加强。
+
+## 繁體中文
+
+此維護版本提升了時間軸匯入、網頁準備流程和 Android 影片匯出的可靠性。Android 自訂影格率現在支援 15 至 240 fps，並可準確處理 23.976、29.97 和 59.94 等常用影格率。中斷匯出復原、私人通知和備份排除也已加強。
+
+## Español
+
+Esta versión de mantenimiento mejora la fiabilidad de la importación de la cronología, la preparación web y la exportación de vídeo en Android. Las frecuencias de fotogramas personalizadas de Android ahora admiten de 15 a 240 fps, incluidos valores comunes exactos como 23.976, 29.97 y 59.94. También se refuerzan la recuperación de exportaciones interrumpidas, las notificaciones privadas y las exclusiones de copia de seguridad.
+
+## Français
+
+Cette version de maintenance améliore la fiabilité de l’importation de la chronologie, de la préparation web et de l’exportation vidéo sur Android. Les fréquences d’images personnalisées sur Android acceptent désormais de 15 à 240 ips, y compris des valeurs courantes exactes comme 23,976, 29,97 et 59,94. La reprise des exportations interrompues, les notifications privées et les exclusions de sauvegarde sont également renforcées.
+
+## Deutsch
+
+Diese Wartungsversion verbessert die Zuverlässigkeit beim Timeline-Import, bei der Webvorbereitung und beim Videoexport unter Android. Benutzerdefinierte Android-Bildraten unterstützen jetzt 15 bis 240 fps, einschließlich exakter gebräuchlicher Werte wie 23,976, 29,97 und 59,94. Auch die Wiederherstellung unterbrochener Exporte, private Benachrichtigungen und Sicherungsausschlüsse wurden verbessert.
+
+## Português (Brasil)
+
+Esta versão de manutenção melhora a confiabilidade da importação da linha do tempo, da preparação na web e da exportação de vídeo no Android. As taxas de quadros personalizadas do Android agora aceitam de 15 a 240 fps, incluindo valores comuns exatos como 23,976, 29,97 e 59,94. A recuperação de exportações interrompidas, as notificações privadas e as exclusões de backup também foram reforçadas.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.9` and version code `51`
+- Version name `3.0.10` and version code `52`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 51' in build_file
-    assert 'versionName = "3.0.9"' in build_file
+    assert 'versionCode = 52' in build_file
+    assert 'versionName = "3.0.10"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
## Summary

- set Android version name 3.0.10 and version code 52
- add localized release notes covering advanced Android frame rates and post-3.0.9 reliability and privacy fixes
- update the changelog, Play submission checklist, packaging assertion, and platform parity table

## Validation

- `python -m pytest tests/test_play_store_materials.py tests/test_journal_lab_packaging.py tests/test_release_workflow.py -q`
- 19 tests passed
- independent release-preparation review found no actionable issue

PR #216 and PR #218 are already merged. This PR contains release metadata only.