### PR TITLE
Fix Balanced and Close-up map view ordering

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -5650,7 +5650,7 @@ class MainActivity : AppCompatActivity() {
         tripDetection = when (movement) {
             CameraMovement.FIXED, CameraMovement.STEADY -> TripDetection.BALANCED
             CameraMovement.DYNAMIC -> TripDetection.BALANCED
-            CameraMovement.CLOSE_UP -> TripDetection.SENSITIVE
+            CameraMovement.CLOSE_UP -> TripDetection.BALANCED
         },
         localFraming = when (movement) {
             CameraMovement.FIXED, CameraMovement.STEADY -> LocalFraming.OFF

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/TimelinePainter.kt
@@ -294,45 +294,9 @@ class TimelinePainter {
         val leg = journey.legAt(current.distanceKm, episodeLegs).takeIf { movement.legAware }
         val legIndex = leg?.let(episodeLegs::indexOf) ?: -1
         val nextLocalLeg = episodeLegs.getOrNull(legIndex + 1)?.takeIf { !it.isTransfer }
-        val transferArrivalBlend = if (
-            cameraSettings.episodeFramingEnabled &&
-            movement != CameraMovement.CLOSE_UP &&
-            leg?.isTransfer == true &&
-            nextLocalLeg != null &&
-            leg.lengthKm > 0.0
-        ) {
-            smoothstep(
-                ((current.distanceKm - leg.startKm) / leg.lengthKm - EPISODE_ARRIVAL_ZOOM_START_FRACTION) /
-                    (1.0 - EPISODE_ARRIVAL_ZOOM_START_FRACTION),
-            )
-        } else {
-            0.0
-        }
-        val contextKm = if (leg?.isTransfer == true) {
-            if (transferArrivalBlend > 0.0) {
-                val arrivalContextKm = min(
-                    proportionalContextKm,
-                    nextLocalLeg?.lengthKm ?: proportionalContextKm,
-                ).coerceAtLeast(MIN_CONTEXT_KM)
-                kotlin.math.exp(
-                    lerp(
-                        ln(leg.lengthKm.coerceAtLeast(MIN_CONTEXT_KM)),
-                        ln(arrivalContextKm),
-                        transferArrivalBlend,
-                    ),
-                )
-            } else {
-                leg.lengthKm
-            }
-        } else {
-            proportionalContextKm
-        }
+        val contextKm = if (leg?.isTransfer == true) leg.lengthKm else proportionalContextKm
         val padding = when {
-            leg?.isTransfer == true -> lerp(
-                TRANSFER_PADDING,
-                movement.padding * cameraSettings.localFraming.paddingMultiplier,
-                transferArrivalBlend,
-            )
+            leg?.isTransfer == true -> TRANSFER_PADDING
             cameraSettings.episodeFramingEnabled ->
                 movement.padding * cameraSettings.localFraming.paddingMultiplier
             else -> movement.padding
@@ -546,8 +510,8 @@ class TimelinePainter {
         val aspect = width.toDouble() / height.coerceAtLeast(1)
         val movement = cameraSettings.cameraMovement
         val episodeLegs = cameraEpisodeLegs(journey, cameraSettings)
-        val arrivalEpisodes = closeUpArrivalEpisodes(journey, cameraSettings, episodeLegs)
-        val distanceSamples = cameraDistanceSamples(journey, cameraSettings, arrivalEpisodes)
+        val arrivalEpisodes = protectedArrivalEpisodes(journey, cameraSettings, episodeLegs)
+        val distanceSamples = cameraDistanceSamples(journey, arrivalEpisodes)
         val progressTotal = distanceSamples.size + CAMERA_TRACK_SAMPLES + 1
         val distanceFraming = distanceSamples.mapIndexed { index, distanceKm ->
             val viewport = rawViewport(
@@ -574,7 +538,7 @@ class TimelinePainter {
                 TimingMinimumShare(it.localLeg.startKm, it.localLeg.endKm, it.minimumProgressFraction)
             },
         )
-        val arrivalPlans = closeUpArrivalPlans(arrivalEpisodes, episodeLegs, checkNotNull(cachedTiming))
+        val arrivalPlans = protectedArrivalPlans(arrivalEpisodes, episodeLegs, checkNotNull(cachedTiming))
         val rawSamples = (0..CAMERA_TRACK_SAMPLES).map { sample ->
             val progress = sample.toFloat() / CAMERA_TRACK_SAMPLES
             val current = playbackPosition(journey, progress, cameraSettings)
@@ -592,7 +556,6 @@ class TimelinePainter {
                     journey,
                     progress,
                     cameraSettings,
-                    episodeLegs,
                     arrivalPlans,
                 ),
             )
@@ -724,37 +687,21 @@ class TimelinePainter {
         journey: Journey,
         progress: Float,
         cameraSettings: CameraSettings,
-        episodeLegsOverride: List<JourneyLeg>? = null,
-        closeUpPlans: List<CloseUpArrivalPlan> = emptyList(),
+        arrivalPlans: List<ProtectedArrivalPlan> = emptyList(),
     ): Double {
         if (!cameraSettings.episodeFramingEnabled || !cameraSettings.cameraMovement.legAware) return 0.0
         val currentDistanceKm = playbackPosition(journey, progress, cameraSettings).distanceKm
-        val legs = episodeLegsOverride ?: cameraEpisodeLegs(journey, cameraSettings)
-        if (cameraSettings.cameraMovement == CameraMovement.CLOSE_UP) {
-            val plan = closeUpPlans.firstOrNull {
-                currentDistanceKm >= it.transferLeg.startKm && currentDistanceKm <= it.localLeg.endKm
-            } ?: return 0.0
-            if (currentDistanceKm < plan.localLeg.startKm) return 0.0
-            val width = plan.closeInEndProgress - plan.arrivalProgress
-            val closeIn = if (width <= 0f) {
-                1.0
-            } else {
-                smoothstep(((progress - plan.arrivalProgress) / width).toDouble())
-            }
-            return closeIn * localArrivalSettleIntensity(journey, currentDistanceKm, plan.localLeg)
+        val plan = arrivalPlans.firstOrNull {
+            currentDistanceKm >= it.transferLeg.startKm && currentDistanceKm <= it.localLeg.endKm
+        } ?: return 0.0
+        if (currentDistanceKm < plan.localLeg.startKm) return 0.0
+        val width = plan.closeInEndProgress - plan.arrivalProgress
+        val closeIn = if (width <= 0f) {
+            1.0
+        } else {
+            smoothstep(((progress - plan.arrivalProgress) / width).toDouble())
         }
-        val leg = journey.legAt(currentDistanceKm, legs)
-        val legIndex = legs.indexOf(leg)
-        if (leg.isTransfer) {
-            if (legs.getOrNull(legIndex + 1)?.isTransfer != false || leg.lengthKm <= 0.0) return 0.0
-            val fraction = (currentDistanceKm - leg.startKm) / leg.lengthKm
-            return smoothstep(
-                (fraction - EPISODE_ARRIVAL_ZOOM_START_FRACTION) /
-                    (1.0 - EPISODE_ARRIVAL_ZOOM_START_FRACTION),
-            )
-        }
-        if (legs.getOrNull(legIndex - 1)?.isTransfer != true || leg.lengthKm <= 0.0) return 0.0
-        return localArrivalSettleIntensity(journey, currentDistanceKm, leg)
+        return closeIn * localArrivalSettleIntensity(journey, currentDistanceKm, plan.localLeg)
     }
 
     private fun localArrivalSettleIntensity(
@@ -791,7 +738,7 @@ class TimelinePainter {
         height: Int,
         aspect: Double,
         episodeLegs: List<JourneyLeg>,
-        closeUpPlans: List<CloseUpArrivalPlan>,
+        arrivalPlans: List<ProtectedArrivalPlan>,
     ): List<CameraFrame> {
         val frames = ArrayList<CameraFrame>(baseFrames.size)
         var previous: CameraFrame? = null
@@ -806,7 +753,7 @@ class TimelinePainter {
                 height,
                 aspect,
                 episodeLegs,
-                closeUpPlans,
+                arrivalPlans,
             )
             val projectedMarker = WebMercator.project(
                 playbackPosition(journey, actualProgress, cameraSettings).point,
@@ -852,15 +799,15 @@ class TimelinePainter {
         height: Int,
         aspect: Double,
         episodeLegs: List<JourneyLeg>,
-        closeUpPlans: List<CloseUpArrivalPlan>,
+        arrivalPlans: List<ProtectedArrivalPlan>,
     ): CameraFrame {
         if (!cameraSettings.episodeFramingEnabled || !cameraSettings.cameraMovement.legAware) return base
         val distanceKm = playbackPosition(journey, actualProgress, cameraSettings).distanceKm
         val leg = journey.legAt(distanceKm, episodeLegs)
-        val closeUpPlan = closeUpPlans.firstOrNull {
+        val arrivalPlan = arrivalPlans.firstOrNull {
             distanceKm >= it.transferLeg.startKm && distanceKm <= it.localLeg.endKm
         }
-        if (cameraSettings.cameraMovement == CameraMovement.CLOSE_UP && closeUpPlan != null) {
+        if (arrivalPlan != null) {
             val alignedViewport = rawViewport(
                 journey,
                 actualProgress,
@@ -875,8 +822,8 @@ class TimelinePainter {
                 val spanY = max(base.spanY, alignedSpanY)
                 return base.copy(spanY = spanY, zoom = tileZoom(width, aspect, spanY))
             }
-            if (actualProgress <= closeUpPlan.closeInEndProgress) {
-                val transferDistanceKm = closeUpPlan.transferLeg.startKm + closeUpPlan.transferLeg.lengthKm * 0.5
+            if (actualProgress <= arrivalPlan.closeInEndProgress) {
+                val transferDistanceKm = arrivalPlan.transferLeg.startKm + arrivalPlan.transferLeg.lengthKm * 0.5
                 val transferViewport = rawViewport(
                     journey,
                     actualProgress,
@@ -888,12 +835,12 @@ class TimelinePainter {
                 )
                 val transferSpanY = (transferViewport.maxY - transferViewport.minY)
                     .coerceAtLeast(alignedSpanY)
-                val widthProgress = closeUpPlan.closeInEndProgress - closeUpPlan.arrivalProgress
+                val widthProgress = arrivalPlan.closeInEndProgress - arrivalPlan.arrivalProgress
                 val closeIn = if (widthProgress <= 0f) {
                     1.0
                 } else {
                     smoothstep(
-                        ((actualProgress - closeUpPlan.arrivalProgress) / widthProgress).toDouble(),
+                        ((actualProgress - arrivalPlan.arrivalProgress) / widthProgress).toDouble(),
                     )
                 }
                 val spanY = kotlin.math.exp(lerp(ln(transferSpanY), ln(alignedSpanY), closeIn))
@@ -901,10 +848,10 @@ class TimelinePainter {
             }
         }
         val alignment = if (leg.isTransfer) {
-            episodeArrivalZoomIntensity(journey, actualProgress, cameraSettings, episodeLegs, closeUpPlans)
+            episodeArrivalZoomIntensity(journey, actualProgress, cameraSettings, arrivalPlans)
         } else {
-            if (cameraSettings.cameraMovement == CameraMovement.CLOSE_UP) {
-                episodeArrivalZoomIntensity(journey, actualProgress, cameraSettings, episodeLegs, closeUpPlans)
+            if (cameraSettings.cameraMovement == CameraMovement.CLOSE_UP || arrivalPlan != null) {
+                episodeArrivalZoomIntensity(journey, actualProgress, cameraSettings, arrivalPlans)
             } else {
                 1.0
             }
@@ -941,13 +888,13 @@ class TimelinePainter {
         journey.legs
     }
 
-    private fun closeUpArrivalEpisodes(
+    private fun protectedArrivalEpisodes(
         journey: Journey,
         cameraSettings: CameraSettings,
         episodeLegs: List<JourneyLeg>,
-    ): List<CloseUpArrivalEpisode> {
+    ): List<ProtectedArrivalEpisode> {
         if (
-            cameraSettings.cameraMovement != CameraMovement.CLOSE_UP ||
+            !cameraSettings.cameraMovement.legAware ||
             !cameraSettings.episodeFramingEnabled
         ) {
             return emptyList()
@@ -956,41 +903,38 @@ class TimelinePainter {
             leg.takeIf {
                 !it.isTransfer &&
                     episodeLegs.getOrNull(index - 1)?.isTransfer == true &&
-                    isMeaningfulCloseUpArrival(journey, it)
+                    isMeaningfulArrival(journey, it)
             }
         }
         if (localLegs.isEmpty()) return emptyList()
         val perArrivalFraction = min(
-            CLOSE_UP_MAX_PROGRESS_PER_ARRIVAL,
-            CLOSE_UP_TOTAL_PROGRESS_BUDGET / localLegs.size,
+            ARRIVAL_MAX_PROGRESS_PER_EPISODE,
+            ARRIVAL_TOTAL_PROGRESS_BUDGET / localLegs.size,
         )
-        return localLegs.map { CloseUpArrivalEpisode(it, perArrivalFraction) }
+        return localLegs.map { ProtectedArrivalEpisode(it, perArrivalFraction) }
     }
 
-    private fun isMeaningfulCloseUpArrival(journey: Journey, localLeg: JourneyLeg): Boolean {
+    private fun isMeaningfulArrival(journey: Journey, localLeg: JourneyLeg): Boolean {
         if (localLeg.isTransfer || localLeg.lengthKm <= 0.0) return false
         val start = journey.positionAtDistance(localLeg.startKm).point.instant
         val end = journey.positionAtDistance(localLeg.endKm).point.instant
-        return Duration.between(start, end).toMillis() >= CLOSE_UP_MIN_LOCAL_DURATION_MILLIS
+        return Duration.between(start, end).toMillis() >= ARRIVAL_MIN_LOCAL_DURATION_MILLIS
     }
 
     private fun cameraDistanceSamples(
         journey: Journey,
-        cameraSettings: CameraSettings,
-        arrivalEpisodes: List<CloseUpArrivalEpisode>,
+        arrivalEpisodes: List<ProtectedArrivalEpisode>,
     ): DoubleArray {
         val distances = MutableList(CAMERA_TRACK_SAMPLES + 1) { sample ->
             journey.totalDistanceKm * sample / CAMERA_TRACK_SAMPLES
         }
-        if (cameraSettings.cameraMovement == CameraMovement.CLOSE_UP) {
-            arrivalEpisodes.forEach { episode ->
-                val leg = episode.localLeg
-                val inset = min(CLOSE_UP_ANCHOR_INSET_MAX_KM, leg.lengthKm * CLOSE_UP_ANCHOR_INSET_FRACTION)
-                distances += leg.startKm
-                distances += leg.startKm + inset
-                distances += leg.endKm - inset
-                distances += leg.endKm
-            }
+        arrivalEpisodes.forEach { episode ->
+            val leg = episode.localLeg
+            val inset = min(ARRIVAL_ANCHOR_INSET_MAX_KM, leg.lengthKm * ARRIVAL_ANCHOR_INSET_FRACTION)
+            distances += leg.startKm
+            distances += leg.startKm + inset
+            distances += leg.endKm - inset
+            distances += leg.endKm
         }
         return distances.asSequence()
             .map { it.coerceIn(0.0, journey.totalDistanceKm) }
@@ -1000,11 +944,11 @@ class TimelinePainter {
             .toDoubleArray()
     }
 
-    private fun closeUpArrivalPlans(
-        episodes: List<CloseUpArrivalEpisode>,
+    private fun protectedArrivalPlans(
+        episodes: List<ProtectedArrivalEpisode>,
         episodeLegs: List<JourneyLeg>,
         timing: JourneyTiming,
-    ): List<CloseUpArrivalPlan> = episodes.mapNotNull { episode ->
+    ): List<ProtectedArrivalPlan> = episodes.mapNotNull { episode ->
         val localIndex = episodeLegs.indexOf(episode.localLeg)
         val transfer = episodeLegs.getOrNull(localIndex - 1)?.takeIf { it.isTransfer }
             ?: return@mapNotNull null
@@ -1012,10 +956,10 @@ class TimelinePainter {
         val localEndProgress = timing.progressAtDistance(episode.localLeg.endKm)
         val localProgress = (localEndProgress - arrivalProgress).coerceAtLeast(0f)
         val closeInProgress = min(
-            CLOSE_UP_POST_ARRIVAL_MAX_PROGRESS,
-            localProgress * CLOSE_UP_POST_ARRIVAL_SHARE,
+            ARRIVAL_CLOSE_IN_MAX_PROGRESS,
+            localProgress * ARRIVAL_CLOSE_IN_SHARE,
         )
-        CloseUpArrivalPlan(
+        ProtectedArrivalPlan(
             transferLeg = transfer,
             localLeg = episode.localLeg,
             arrivalProgress = arrivalProgress,
@@ -1621,12 +1565,12 @@ class TimelinePainter {
         val arrivalZoomIntensity: Double,
     )
 
-    private data class CloseUpArrivalEpisode(
+    private data class ProtectedArrivalEpisode(
         val localLeg: JourneyLeg,
         val minimumProgressFraction: Double,
     )
 
-    private data class CloseUpArrivalPlan(
+    private data class ProtectedArrivalPlan(
         val transferLeg: JourneyLeg,
         val localLeg: JourneyLeg,
         val arrivalProgress: Float,
@@ -1716,17 +1660,16 @@ class TimelinePainter {
         private const val TRANSFER_PADDING = 2.8
         private const val EPISODE_DEPARTURE_LEAD_FRACTION = 0.15
         private const val EPISODE_DEPARTURE_LEAD_MAX_KM = 50.0
-        private const val EPISODE_ARRIVAL_ZOOM_START_FRACTION = 0.75
         private const val EPISODE_ARRIVAL_ZOOM_ALPHA = 1.00
         private const val EPISODE_ARRIVAL_HOLD_SAMPLES = 2.0
         private const val EPISODE_ARRIVAL_SETTLE_MAX_KM = 25.0
-        private const val CLOSE_UP_MIN_LOCAL_DURATION_MILLIS = 60L * 60L * 1_000L
-        private const val CLOSE_UP_TOTAL_PROGRESS_BUDGET = 0.16
-        private const val CLOSE_UP_MAX_PROGRESS_PER_ARRIVAL = 0.08
-        private const val CLOSE_UP_POST_ARRIVAL_SHARE = 0.50f
-        private const val CLOSE_UP_POST_ARRIVAL_MAX_PROGRESS = 0.04f
-        private const val CLOSE_UP_ANCHOR_INSET_FRACTION = 0.10
-        private const val CLOSE_UP_ANCHOR_INSET_MAX_KM = 0.25
+        private const val ARRIVAL_MIN_LOCAL_DURATION_MILLIS = 60L * 60L * 1_000L
+        private const val ARRIVAL_TOTAL_PROGRESS_BUDGET = 0.16
+        private const val ARRIVAL_MAX_PROGRESS_PER_EPISODE = 0.08
+        private const val ARRIVAL_CLOSE_IN_SHARE = 0.50f
+        private const val ARRIVAL_CLOSE_IN_MAX_PROGRESS = 0.04f
+        private const val ARRIVAL_ANCHOR_INSET_FRACTION = 0.10
+        private const val ARRIVAL_ANCHOR_INSET_MAX_KM = 0.25
         private const val MIN_CONTEXT_KM = 0.001
         private const val DEFAULT_JOURNEY_DURATION_SECONDS = 30
         private const val TRAIL_VISIBLE_SECONDS = 2.5

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -779,6 +779,28 @@ class MainActivityTest {
     }
 
     @Test
+    fun closeUpMapViewUsesBalancedTripDetectionAndCloseLocalFraming() {
+        val activity = launchActivity()
+        activity.findViewById<View>(R.id.navigationSettings).performClick()
+
+        activity.findViewById<AutoCompleteTextView>(R.id.cameraMovementDropdown)
+            .onItemClickListener?.onItemClick(null, null, CameraMovement.CLOSE_UP.ordinal, 3L)
+
+        assertEquals(
+            activity.getString(R.string.map_view_close_up),
+            activity.findViewById<AutoCompleteTextView>(R.id.cameraMovementDropdown).text.toString(),
+        )
+        assertEquals(
+            activity.getString(R.string.trip_detection_balanced),
+            activity.findViewById<AutoCompleteTextView>(R.id.tripDetectionDropdown).text.toString(),
+        )
+        assertEquals(
+            activity.getString(R.string.local_framing_close),
+            activity.findViewById<AutoCompleteTextView>(R.id.localFramingDropdown).text.toString(),
+        )
+    }
+
+    @Test
     fun cameraPreparationFailureIsReportedAsAPreviewProblem() {
         val activity = launchActivity()
         val timelineView = activity.findViewById<TimelineView>(R.id.timelineView)

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/TimelinePainterTest.kt
@@ -174,7 +174,7 @@ class TimelinePainterTest {
     }
 
     @Test
-    fun closeUpZoomFramesDenseLocalTravelMoreTightlyThanActiveZoom() {
+    fun localMapViewsProduceWideBalancedAndCloseUpFraming() {
         val journey = Journey.from(
             listOf(
                 point(37.5665, 126.9780),
@@ -184,15 +184,15 @@ class TimelinePainterTest {
             ),
             2025,
         )
-        val active = CameraSettings(CameraMovement.DYNAMIC, LongTripCompression.OFF)
-        val closeUp = CameraSettings(CameraMovement.CLOSE_UP, LongTripCompression.OFF)
+        val spans = listOf(
+            CameraSettings(CameraMovement.STEADY, LongTripCompression.OFF, localFraming = LocalFraming.OFF),
+            balancedMapSettings(),
+            closeUpMapSettings(),
+        ).map { settings ->
+            TimelinePainter().viewport(journey, 0.65f, SIZE, SIZE, settings).let { it.maxY - it.minY }
+        }
 
-        val activeSpan = TimelinePainter().viewport(journey, 0.65f, SIZE, SIZE, active).maxY -
-            TimelinePainter().viewport(journey, 0.65f, SIZE, SIZE, active).minY
-        val closeUpViewport = TimelinePainter().viewport(journey, 0.65f, SIZE, SIZE, closeUp)
-        val closeUpSpan = closeUpViewport.maxY - closeUpViewport.minY
-
-        assertTrue("Close-up span $closeUpSpan was not tighter than active span $activeSpan", closeUpSpan < activeSpan)
+        assertTrue("Expected Wide > Balanced > Close-up, got $spans", spans[0] > spans[1] && spans[1] > spans[2])
     }
 
     @Test
@@ -252,84 +252,73 @@ class TimelinePainterTest {
     }
 
     @Test
-    fun closeUpHoldsTheTransferViewThenClosesDuringProtectedLocalTime() {
+    fun adaptiveMapViewsHoldTheTransferThenCloseUpSettlesTighter() {
         val journey = roundTripJourney()
         val inboundTransfer = journey.legs[1]
         val destination = journey.legs[2]
-        val settings = CameraSettings(
-            cameraMovement = CameraMovement.CLOSE_UP,
-            longTripCompression = LongTripCompression.OFF,
-            localFraming = LocalFraming.BALANCED,
-        )
-        val painter = TimelinePainter()
-        val track = painter.buildCameraTrackForBackground(journey, SIZE, SIZE, settings).track
-
-        fun trackSpanAt(distanceKm: Double): Double {
-            val viewport = track.viewportAt(track.timing.progressAtDistance(distanceKm))
-            return viewport.maxY - viewport.minY
+        val tracks = listOf(balancedMapSettings(), closeUpMapSettings()).map { settings ->
+            TimelinePainter().buildCameraTrackForBackground(journey, SIZE, SIZE, settings).track
         }
 
-        val earlyFlightSpan = trackSpanAt(inboundTransfer.startKm + inboundTransfer.lengthKm * 0.70)
-        val finalFlightSpan = trackSpanAt(inboundTransfer.startKm + inboundTransfer.lengthKm * 0.95)
-        val arrivalProgress = track.timing.progressAtDistance(destination.startKm)
-        val localEndProgress = track.timing.progressAtDistance(destination.endKm)
-        val localProgress = localEndProgress - arrivalProgress
-        val arrivalSpan = track.viewportAt(arrivalProgress).let { it.maxY - it.minY }
-        val closingSpan = track.viewportAt(arrivalProgress + localProgress * 0.25f).let { it.maxY - it.minY }
-        val settledSpan = track.viewportAt(arrivalProgress + localProgress * 0.60f).let { it.maxY - it.minY }
+        tracks.forEach { track ->
+            val earlyFlightSpan = trackSpanAt(track, inboundTransfer.startKm + inboundTransfer.lengthKm * 0.70)
+            val finalFlightSpan = trackSpanAt(track, inboundTransfer.startKm + inboundTransfer.lengthKm * 0.95)
+            val arrivalProgress = track.timing.progressAtDistance(destination.startKm)
+            val localEndProgress = track.timing.progressAtDistance(destination.endKm)
+            val localProgress = localEndProgress - arrivalProgress
+            val arrivalSpan = track.viewportAt(arrivalProgress).let { it.maxY - it.minY }
+            val closingSpan = track.viewportAt(arrivalProgress + localProgress * 0.25f).let { it.maxY - it.minY }
+            val settledSpan = track.viewportAt(arrivalProgress + localProgress * 0.60f).let { it.maxY - it.minY }
 
-        assertTrue(
-            "Final-flight span $finalFlightSpan closed early from $earlyFlightSpan",
-            finalFlightSpan >= earlyFlightSpan * 0.85,
-        )
-        assertTrue(
-            "Arrival span $arrivalSpan did not retain the final-flight view $finalFlightSpan",
-            arrivalSpan >= finalFlightSpan * 0.80,
-        )
-        assertTrue(
-            "Camera did not begin closing after arrival: $arrivalSpan to $closingSpan",
-            closingSpan < arrivalSpan * 0.80,
-        )
-        assertTrue(
-            "Camera did not reach the local view: $closingSpan to $settledSpan",
-            settledSpan < closingSpan * 0.75,
-        )
-        assertTrue("Protected local share was $localProgress", localProgress >= 0.079f)
+            assertTrue("Final-flight span $finalFlightSpan closed early from $earlyFlightSpan", finalFlightSpan >= earlyFlightSpan * 0.85)
+            assertTrue("Arrival span $arrivalSpan did not retain $finalFlightSpan", arrivalSpan >= finalFlightSpan * 0.80)
+            assertTrue("Camera did not begin closing: $arrivalSpan to $closingSpan", closingSpan < arrivalSpan * 0.80)
+            assertTrue("Camera did not reach its local view: $closingSpan to $settledSpan", settledSpan < closingSpan * 0.75)
+            assertTrue("Protected local share was $localProgress", localProgress >= 0.079f)
+        }
+
+        val settledDistance = destination.startKm + destination.lengthKm * 0.60
+        val balancedSpan = trackSpanAt(tracks[0], settledDistance)
+        val closeUpSpan = trackSpanAt(tracks[1], settledDistance)
+        assertTrue("Close-up $closeUpSpan was not tighter than Balanced $balancedSpan", closeUpSpan < balancedSpan)
     }
 
     @Test
-    fun closeUpSharesItsArrivalBudgetAcrossMultipleLongHaulTripsWithoutPausing() {
+    fun adaptiveMapViewsShareArrivalBudgetWithoutPausing() {
         val journey = multiLongHaulJourney()
-        val settings = CameraSettings(
-            cameraMovement = CameraMovement.CLOSE_UP,
-            longTripCompression = LongTripCompression.OFF,
-            tripDetection = TripDetection.SENSITIVE,
-            localFraming = LocalFraming.CLOSE,
-        )
-        val timing = TimelinePainter()
-            .buildCameraTrackForBackground(journey, SIZE, SIZE, settings)
-            .track
-            .timing
         val localArrivals = journey.legs.mapIndexedNotNull { index, leg ->
             leg.takeIf { !it.isTransfer && journey.legs.getOrNull(index - 1)?.isTransfer == true }
         }
 
         assertEquals(3, localArrivals.size)
-        val shares = localArrivals.map { leg ->
-            timing.progressAtDistance(leg.endKm) - timing.progressAtDistance(leg.startKm)
-        }
-        val meaningfulShares = listOf(shares[0], shares[2])
+        listOf(CameraMovement.DYNAMIC, CameraMovement.CLOSE_UP).forEach { movement ->
+            val timing = TimelinePainter().buildCameraTrackForBackground(
+                journey,
+                SIZE,
+                SIZE,
+                CameraSettings(
+                    cameraMovement = movement,
+                    longTripCompression = LongTripCompression.OFF,
+                    tripDetection = TripDetection.SENSITIVE,
+                    localFraming = if (movement == CameraMovement.CLOSE_UP) LocalFraming.CLOSE else LocalFraming.BALANCED,
+                ),
+            ).track.timing
+            val shares = localArrivals.map { leg ->
+                timing.progressAtDistance(leg.endKm) - timing.progressAtDistance(leg.startKm)
+            }
+            val meaningfulShares = listOf(shares[0], shares[2])
 
-        meaningfulShares.forEach { share -> assertTrue("Meaningful arrival share was $share", share >= 0.079f) }
-        assertTrue("Brief stop unexpectedly received the arrival budget: $shares", shares[1] < 0.02f)
-        assertTrue("Arrival budget exceeded its global bound: $shares", meaningfulShares.sum() <= 0.161f)
+            meaningfulShares.forEach { share -> assertTrue("Meaningful arrival share was $share", share >= 0.079f) }
+            assertTrue("Brief stop received the arrival budget: $shares", shares[1] < 0.02f)
+            assertTrue("Arrival budget exceeded its bound: $shares", meaningfulShares.sum() <= 0.161f)
 
-        listOf(localArrivals[0], localArrivals[2]).forEach { leg ->
-            val start = timing.progressAtDistance(leg.startKm)
-            val end = timing.progressAtDistance(leg.endKm)
-            val middle = timing.distanceAt((start + end) / 2f)
-            assertTrue("Close-up must keep moving after arrival", middle > leg.startKm)
-            assertTrue("Close-up must not jump to the end of the visit", middle < leg.endKm)
+            listOf(localArrivals[0], localArrivals[2]).forEach { leg ->
+                val start = timing.progressAtDistance(leg.startKm)
+                val end = timing.progressAtDistance(leg.endKm)
+                val middle = timing.distanceAt((start + end) / 2f)
+                assertTrue("Camera must keep moving after arrival", middle > leg.startKm)
+                assertTrue("Camera must not jump to the end of the visit", middle < leg.endKm)
+            }
         }
     }
 
@@ -383,51 +372,39 @@ class TimelinePainterTest {
     }
 
     @Test
-    fun semanticLongTripStaysWideThenTightensForDestinationDetail() {
-        val points = (0..100).map { index ->
-            timedPoint(index, 0.02 * kotlin.math.sin(index / 5.0), index * 0.05)
-        } + (101..115).map { index ->
-            timedPoint(index, (index - 100) * 0.0005, 5.0 + (index - 100) * 0.0005)
-        }
-        val base = Journey.from(points, 2025)
-        val semantic = base.copy(
-            semanticEpisodes = listOf(
-                JourneySemanticEpisode(
-                    startKm = 0.0,
-                    endKm = base.cumulativeDistanceKm[100],
-                    origin = points.first(),
-                    destination = points[100],
-                ),
-            ),
-        )
-        val settings = CameraSettings(
-            cameraMovement = CameraMovement.CLOSE_UP,
-            longTripCompression = LongTripCompression.OFF,
-            localFraming = LocalFraming.BALANCED,
-        )
+    fun semanticLongTripKeepsBothViewsWideThenCloseUpSettlesTighter() {
+        val semantic = semanticLongTripJourney()
+        val settings = balancedMapSettings()
         val legs = semantic.legsForThreshold(
             semantic.transferThresholdKm * settings.tripDetection.thresholdMultiplier,
         )
         val transfer = legs.first()
         val local = legs.last()
-        val painter = TimelinePainter()
-        fun spanAt(distanceKm: Double): Double {
-            val viewport = painter.rawViewportForTest(
-                semantic,
-                (distanceKm / semantic.totalDistanceKm).toFloat(),
-                SIZE,
-                SIZE,
-                settings,
-                useRangeIndex = true,
-            )
-            return viewport.maxY - viewport.minY
+        val tracks = listOf(settings, closeUpMapSettings()).map { cameraSettings ->
+            TimelinePainter().buildCameraTrackForBackground(semantic, SIZE, SIZE, cameraSettings).track
         }
-
-        val tripSpan = spanAt(transfer.startKm + transfer.lengthKm * 0.50)
-        val destinationSpan = spanAt(local.startKm + local.lengthKm * 0.50)
+        val middleDistance = transfer.startKm + transfer.lengthKm * 0.50
+        val lateDistance = transfer.startKm + transfer.lengthKm * 0.95
+        val arrivalDistance = local.startKm
+        val settledDistance = local.startKm + local.lengthKm * 0.60
+        val middleSpans = tracks.map { trackSpanAt(it, middleDistance) }
+        val lateSpans = tracks.map { trackSpanAt(it, lateDistance) }
+        val arrivalSpans = tracks.map { trackSpanAt(it, arrivalDistance) }
+        val settledSpans = tracks.map { trackSpanAt(it, settledDistance) }
 
         assertEquals(listOf(true, false), legs.map { it.isTransfer })
-        assertTrue("Semantic trip span $tripSpan did not stay wider than destination span $destinationSpan", tripSpan > destinationSpan * 8)
+        lateSpans.zip(middleSpans).forEach { (late, middle) ->
+            assertTrue("Semantic trip closed early from $middle to $late", late >= middle * 0.85)
+        }
+        arrivalSpans.zip(lateSpans).forEach { (arrival, late) ->
+            assertTrue("Arrival $arrival did not retain the trip view $late", arrival >= late * 0.80)
+        }
+        assertTrue("Balanced became tighter than Close-up before arrival: $lateSpans", lateSpans[0] >= lateSpans[1])
+        assertTrue("Balanced became tighter than Close-up at arrival: $arrivalSpans", arrivalSpans[0] >= arrivalSpans[1])
+        assertTrue("Close-up did not settle tighter than Balanced: $settledSpans", settledSpans[1] < settledSpans[0])
+        settledSpans.forEachIndexed { index, settled ->
+            assertTrue("Map view $index did not reveal destination detail: $middleSpans to $settledSpans", middleSpans[index] > settled * 8)
+        }
     }
 
     @Test
@@ -636,14 +613,15 @@ class TimelinePainterTest {
             )
         }
         val journey = Journey.from(points, 2025)
-        val painter = TimelinePainter()
+        listOf(balancedMapSettings(), closeUpMapSettings()).forEach { settings ->
+            val painter = TimelinePainter()
+            painter.viewport(journey, 0f, SIZE, SIZE, settings)
 
-        painter.viewport(journey, 0f, SIZE, SIZE)
-
-        assertTrue(
-            "Camera evaluated ${painter.cameraRoutePointEvaluations} route points",
-            painter.cameraRoutePointEvaluations < 100_000,
-        )
+            assertTrue(
+                "${settings.cameraMovement} evaluated ${painter.cameraRoutePointEvaluations} route points",
+                painter.cameraRoutePointEvaluations < 100_000,
+            )
+        }
     }
 
     @Test
@@ -768,6 +746,44 @@ class TimelinePainterTest {
         ),
         2025,
     )
+
+    private fun semanticLongTripJourney(): Journey {
+        val points = (0..100).map { index ->
+            timedPoint(index, 0.02 * kotlin.math.sin(index / 5.0), index * 0.05)
+        } + (101..115).map { index ->
+            timedPoint(index, (index - 100) * 0.0005, 5.0 + (index - 100) * 0.0005)
+        }
+        val base = Journey.from(points, 2025)
+        return base.copy(
+            semanticEpisodes = listOf(
+                JourneySemanticEpisode(
+                    startKm = 0.0,
+                    endKm = base.cumulativeDistanceKm[100],
+                    origin = points.first(),
+                    destination = points[100],
+                ),
+            ),
+        )
+    }
+
+    private fun balancedMapSettings() = CameraSettings(
+        cameraMovement = CameraMovement.DYNAMIC,
+        longTripCompression = LongTripCompression.OFF,
+        tripDetection = TripDetection.BALANCED,
+        localFraming = LocalFraming.BALANCED,
+    )
+
+    private fun closeUpMapSettings() = CameraSettings(
+        cameraMovement = CameraMovement.CLOSE_UP,
+        longTripCompression = LongTripCompression.OFF,
+        tripDetection = TripDetection.BALANCED,
+        localFraming = LocalFraming.CLOSE,
+    )
+
+    private fun trackSpanAt(track: TimelinePainter.CameraTrack, distanceKm: Double): Double {
+        val viewport = track.viewportAt(track.timing.progressAtDistance(distanceKm))
+        return viewport.maxY - viewport.minY
+    }
 
     private fun timedPoint(hour: Int, latitude: Double, longitude: Double) = GeoPoint(
         Instant.parse("2025-06-01T00:00:00Z").plusSeconds(hour * 3_600L),


### PR DESCRIPTION
## Summary

- use the same default trip detection for Balanced and Close-up
- keep both views wide through arrival, then use their existing local framing
- cover semantic trips, geometry fallback, local routes, repeated arrivals, and camera work limits

## Testing

- local Android tests not run because Java is not configured on this host
- GitHub CI will run the full required validation

Fixes #220