### PR TITLE
Prepare Timeline Visualizer 3.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Add distance-unit selection to the web app.
 - Document the web app's distance units and close-up mode.
 
+## 3.0.11
+
+- Keep Balanced and Close-up map views wide through long trips, then let Close-up settle into tighter local detail after arrival.
+- Use consistent edge-to-edge layout across supported Android versions while keeping controls and system icons clear of system bars.
+- Set Android version code 53 and version name 3.0.11.
+
 ## 3.0.10
 
 - Allow Android custom frame rates from 15 through 240 fps with up to three decimal places, preserving common fractional rates such as 23.976, 29.97, and 59.94 through export and recovery.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 52
-        versionName = "3.0.10"
+        versionCode = 53
+        versionName = "3.0.11"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/release-notes-v3.0.11.md
+++ b/docs/release-notes-v3.0.11.md
@@ -1,0 +1,35 @@
+# Timeline Visualizer 3.0.11
+
+This patch keeps Balanced and Close-up map views wide during long trips, then lets Close-up show more local detail after arrival. It also makes edge-to-edge layout consistent across supported Android versions, with clear controls and readable system icons around the system bars.
+
+## 한국어
+
+이번 패치에서는 긴 이동 중에는 균형 및 근접 지도 보기를 넓게 유지하고, 도착 후에는 근접 보기가 더 자세한 주변 정보를 보여 주도록 개선했습니다. 또한 지원되는 Android 버전에서 엣지 투 엣지 레이아웃을 일관되게 적용하고, 시스템 바 주변의 컨트롤과 아이콘이 가려지지 않고 잘 보이도록 했습니다.
+
+## 日本語
+
+このパッチでは、長距離の移動中は「バランス」と「クローズアップ」の地図表示を広く保ち、到着後は「クローズアップ」で周辺をより詳しく表示するようにしました。また、対応する Android バージョンでエッジツーエッジ表示を統一し、システムバー付近の操作ボタンとアイコンが見やすくなるよう改善しました。
+
+## 简体中文
+
+此补丁让“平衡”和“近景”地图视图在长途移动期间保持较宽的范围，并在到达后让“近景”显示更多本地细节。同时，应用在受支持的 Android 版本上采用一致的边到边布局，确保系统栏附近的控件和图标清晰可见。
+
+## 繁體中文
+
+此修補程式會讓「平衡」和「近景」地圖檢視在長途移動期間保持較寬的範圍，並在抵達後讓「近景」顯示更多當地細節。同時，應用程式在支援的 Android 版本上採用一致的全螢幕邊到邊版面，確保系統列附近的控制項和圖示清楚可見。
+
+## Español
+
+Este parche mantiene amplias las vistas de mapa Equilibrada y Primer plano durante los viajes largos, y permite que Primer plano muestre más detalle local después de llegar. También uniforma el diseño de borde a borde en las versiones compatibles de Android y mantiene visibles los controles y los iconos del sistema junto a las barras del sistema.
+
+## Français
+
+Ce correctif conserve un cadrage large pour les vues Équilibrée et Gros plan pendant les longs trajets, puis permet à Gros plan d’afficher davantage de détails locaux après l’arrivée. Il harmonise également l’affichage bord à bord sur les versions Android prises en charge et garde les commandes et les icônes système bien visibles près des barres système.
+
+## Deutsch
+
+Dieses Patch hält die Kartenansichten Ausgewogen und Nahaufnahme während langer Fahrten weit und zeigt nach der Ankunft in der Nahaufnahme mehr lokale Details. Außerdem wird die Edge-to-Edge-Darstellung auf unterstützten Android-Versionen vereinheitlicht, sodass Bedienelemente und Systemsymbole an den Systemleisten gut sichtbar bleiben.
+
+## Português (Brasil)
+
+Esta correção mantém as visualizações de mapa Equilibrada e Close-up amplas durante viagens longas e permite que a Close-up mostre mais detalhes locais após a chegada. Ela também padroniza o layout de ponta a ponta nas versões compatíveis do Android e mantém os controles e ícones do sistema visíveis junto às barras do sistema.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.10` and version code `52`
+- Version name `3.0.11` and version code `53`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 52' in build_file
-    assert 'versionName = "3.0.10"' in build_file
+    assert 'versionCode = 53' in build_file
+    assert 'versionName = "3.0.11"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
## Included changes
- PR #221 fixes Balanced and Close-up map-view ordering around long trips and arrivals.
- PR #222 makes Android edge-to-edge behavior consistent.

## Release preparation
- Set version name 3.0.11 and version code 53.
- Add localized release notes and update release metadata.

## Checks
- Packaging, store-material, and release-workflow tests passed locally.
- Full Android validation will run in GitHub CI.