### PR TITLE
Release Timeline Visualizer 3.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Add distance-unit selection to the web app.
 - Document the web app's distance units and close-up mode.
 
+## 3.0.12
+
+- Improve translations across eight languages with consistent terminology and tone.
+- Correct Timeline import instructions, privacy wording, and mistranslated controls.
+- Set Android version code 54 and version name 3.0.12.
+
 ## 3.0.11
 
 - Keep Balanced and Close-up map views wide through long trips, then let Close-up settle into tighter local detail after arrival.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 53
-        versionName = "3.0.11"
+        versionCode = 54
+        versionName = "3.0.12"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/release-notes-v3.0.12.md
+++ b/docs/release-notes-v3.0.12.md
@@ -1,0 +1,35 @@
+# Timeline Visualizer 3.0.12
+
+Improved translations across eight languages, corrected Timeline import instructions, and clarified privacy wording. Buttons and settings now use more consistent terminology and tone.
+
+## 한국어
+
+8개 언어의 번역을 개선하고, 타임라인 가져오기 안내를 수정했으며, 개인정보 보호 관련 설명을 더 명확하게 다듬었습니다. 버튼과 설정의 용어 및 말투도 일관되게 정리했습니다.
+
+## 日本語
+
+8言語の翻訳を改善し、タイムラインのインポート手順を修正しました。プライバシーに関する説明を明確にし、ボタンや設定の用語と文体を統一しました。
+
+## 简体中文
+
+改进了八种语言的翻译，修正了时间轴导入说明，并使隐私说明更加清晰。按钮和设置现在使用更加一致的术语和语气。
+
+## 繁體中文
+
+改善了八種語言的翻譯，修正了時間軸匯入說明，並讓隱私權說明更加清楚。按鈕和設定現在使用更一致的用語和語氣。
+
+## Español
+
+Mejoramos las traducciones en ocho idiomas, corregimos las instrucciones para importar Timeline y aclaramos la información sobre privacidad. Los botones y ajustes ahora usan términos y un tono más coherentes.
+
+## Français
+
+Nous avons amélioré les traductions dans huit langues, corrigé les instructions d’importation de Timeline et clarifié les informations sur la confidentialité. Les boutons et les paramètres utilisent désormais une terminologie et un ton plus cohérents.
+
+## Deutsch
+
+Die Übersetzungen in acht Sprachen wurden verbessert, die Anleitung zum Importieren der Timeline korrigiert und die Datenschutzhinweise verständlicher formuliert. Schaltflächen und Einstellungen verwenden jetzt einheitlichere Begriffe und Formulierungen.
+
+## Português (Brasil)
+
+Melhoramos as traduções em oito idiomas, corrigimos as instruções de importação da Linha do tempo e esclarecemos as informações sobre privacidade. Os botões e as configurações agora usam termos e um tom mais consistentes.

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.11` and version code `53`
+- Version name `3.0.12` and version code `54`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 53' in build_file
-    assert 'versionName = "3.0.11"' in build_file
+    assert 'versionCode = 54' in build_file
+    assert 'versionName = "3.0.12"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
Prepare version 3.0.12, Android version code 54, to deliver the translation fixes from #224 to GitHub and Play closed Alpha. The update corrects import instructions, clarifies privacy wording, and makes terminology and tone consistent across eight translated locales.

Includes localized release notes and synchronized release metadata. Journal Lab retains its separate version.

Validation: focused packaging and localization tests passed (5 tests), and git diff --check passed. The release workflow will build and verify the signed GitHub APK and Play bundle.