### PR TITLE
Fix five export bugs and prepare 3.0.13

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 54
-        versionName = "3.0.12"
+        versionCode = 55
+        versionName = "3.0.13"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/export/Mp4Exporter.kt
@@ -174,11 +174,10 @@ class Mp4Exporter(
             for (frame in 0 until frameCount) {
                 coroutineContext.ensureActive()
                 val animationFrame = animationFrame(frame, journeyFrameCount, fps)
-                var inputIndex: Int
-                do {
-                    inputIndex = codec.dequeueInputBuffer(10_000)
-                    drain(false)
-                } while (inputIndex < 0)
+                val inputIndex = awaitEncoderInputBuffer(
+                    dequeue = { codec.dequeueInputBuffer(10_000) },
+                    drain = { drain(false) },
+                )
 
                 val canvas = Canvas(bitmap)
                 painter.draw(
@@ -227,16 +226,11 @@ class Mp4Exporter(
                 }
             }
 
-            var eosQueued = false
-            while (!eosQueued) {
-                val inputIndex = codec.dequeueInputBuffer(10_000)
-                if (inputIndex >= 0) {
-                    codec.queueInputBuffer(inputIndex, 0, 0, fps.timestampUs(frameCount), MediaCodec.BUFFER_FLAG_END_OF_STREAM)
-                    eosQueued = true
-                } else {
-                    drain(false)
-                }
-            }
+            val eosInputIndex = awaitEncoderInputBuffer(
+                dequeue = { codec.dequeueInputBuffer(10_000) },
+                drain = { drain(false) },
+            )
+            codec.queueInputBuffer(eosInputIndex, 0, 0, fps.timestampUs(frameCount), MediaCodec.BUFFER_FLAG_END_OF_STREAM)
             while (!drain(true)) coroutineContext.ensureActive()
             val overview = Bitmap.createBitmap(overviewWidth, overviewHeight, Bitmap.Config.ARGB_8888)
             painter.draw(
@@ -417,5 +411,16 @@ class Mp4Exporter(
             }
 
         private fun Int.toEven(): Int = if (this % 2 == 0) this else this + 1
+    }
+}
+
+/** Shared by frame submission and end-of-stream submission. */
+internal suspend fun awaitEncoderInputBuffer(dequeue: () -> Int, drain: () -> Unit): Int {
+    while (true) {
+        coroutineContext.ensureActive()
+        val index = dequeue()
+        drain()
+        coroutineContext.ensureActive()
+        if (index >= 0) return index
     }
 }

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/render/CameraSettings.kt
@@ -115,6 +115,7 @@ class FrameRate private constructor(
             val scale = value.substringAfter('.', "").length
             val denominator = TEN_POWERS.getOrNull(scale) ?: return null
             val numerator = value.replace(".", "").toIntOrNull() ?: return null
+            if (numerator <= 0) return null
             return of(numerator, denominator)
         }
 

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -814,6 +814,27 @@ class MainActivityTest {
     }
 
     @Test
+    fun zeroCustomFrameRateShowsErrorAndKeepsDialogOpen() {
+        val activity = launchActivity()
+        activity.findViewById<View>(R.id.navigationSettings).performClick()
+        val frameRate = activity.findViewById<AutoCompleteTextView>(R.id.frameRateDropdown)
+        frameRate.onItemClickListener?.onItemClick(null, null, 3, 3)
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        val input = dialog.findViewById<TextView>(R.id.customFrameRateInput)!!
+        input.text = "0"
+        dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE).performClick()
+        assertTrue(dialog.isShowing)
+        val layout = input.parent.parent as com.google.android.material.textfield.TextInputLayout
+        assertEquals(
+            activity.getString(R.string.custom_frame_rate_range, 15, 240),
+            layout.error.toString(),
+        )
+        input.text = "30"
+        dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE).performClick()
+        assertTrue(!dialog.isShowing)
+    }
+
+    @Test
     fun settingsKeepCommonRatesSimpleAndAcceptFractionalCustomRates() {
         val activity = launchActivity()
         activity.findViewById<View>(R.id.navigationSettings).performClick()

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/export/EncoderInputWaitTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/export/EncoderInputWaitTest.kt
@@ -1,0 +1,52 @@
+package dev.mahlernim.timelinevisualizer.export
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CancellationException
+
+class EncoderInputWaitTest {
+    @Test
+    fun starvationObservesCancellationAndUnwindsToCleanup() {
+        val job = Job()
+        var attempts = 0
+        var cleaned = false
+        var cancelled = false
+        try {
+            runBlocking(job) {
+                try {
+                    awaitEncoderInputBuffer(
+                        dequeue = {
+                            attempts++
+                            if (attempts == 3) job.cancel()
+                            check(attempts <= 3) { "Cancellation was ignored" }
+                            -1
+                        },
+                        drain = {},
+                    )
+                } finally {
+                    cleaned = true
+                }
+            }
+        } catch (_: CancellationException) {
+            cancelled = true
+        }
+        assertTrue(cancelled)
+        assertTrue(cleaned)
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun availableBufferIsReturnedAfterDraining() = runBlocking {
+        var attempts = 0
+        var drains = 0
+        val index = awaitEncoderInputBuffer(
+            dequeue = { if (++attempts < 3) -1 else 7 },
+            drain = { drains++ },
+        )
+        assertEquals(7, index)
+        assertEquals(3, drains)
+    }
+}

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/render/VideoQualityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/render/VideoQualityTest.kt
@@ -3,8 +3,37 @@ package dev.mahlernim.timelinevisualizer.render
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
+import com.google.gson.JsonParser
 
 class VideoQualityTest {
+    @Test
+    fun zeroAndInvalidFrameRatesReturnNull() {
+        listOf("0", "00", "0.0", "0.00", "0.000", "", "-1", ".", "99999999999999999999").forEach {
+            assertEquals(it, null, FrameRate.parse(it))
+            assertEquals(it, null, ExportFormatSettings.parseFrameRate(it))
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun frameRateInvariantStillRejectsZero() {
+        FrameRate.of(0)
+    }
+
+    @Test
+    fun dimensionsMatchSharedPlatformFixture() {
+        val root = listOf(File("test-fixtures"), File("../test-fixtures")).first(File::isDirectory)
+        val formats = JsonParser.parseString(File(root, "platform-parity-expected.json").readText())
+            .asJsonObject.getAsJsonObject("videoDimensions")
+        formats.entrySet().forEach { (edge, aspects) ->
+            aspects.asJsonObject.entrySet().forEach { (aspect, dimensions) ->
+                val format = ExportFormatSettings(edge.toInt(), 30).format(VideoAspectRatio.valueOf(aspect.uppercase()))
+                assertEquals(dimensions.asJsonArray[0].asInt, format.width)
+                assertEquals(dimensions.asJsonArray[1].asInt, format.height)
+            }
+        }
+    }
+
     @Test
     fun squareDefaultsRemainCompatible() {
         assertEquals(listOf(480, 720, 1080), VideoQuality.values().take(3).map(VideoQuality::width))

--- a/docs/platform-parity.md
+++ b/docs/platform-parity.md
@@ -32,3 +32,9 @@ be treated as a separate product design and privacy review.
 When Android changes a portable parser, filter, camera, timing, overlay, export, or
 privacy behavior, update the corresponding Python and TypeScript tests and this table
 in the same change or record why the platform cannot support it.
+
+Preset pixel dimensions are checked against `test-fixtures/platform-parity-expected.json`.
+At a 480-pixel short edge, new portrait exports are 480x852 and landscape exports
+are 852x480. CLI custom dimensions must be even, with a short edge from 480
+through 2160 pixels and a long edge no larger than 3840 pixels. An omitted custom
+axis keeps the corresponding dimension from the selected preset.

--- a/docs/play-release-notes-v3.0.13.txt
+++ b/docs/play-release-notes-v3.0.13.txt
@@ -1,0 +1,27 @@
+<en-US>
+Fixed a crash when entering zero as a custom frame rate. Video export cancellation now responds while waiting for encoder input buffers, including when finishing a video.
+</en-US>
+<ko-KR>
+사용자 지정 프레임 속도에 0을 입력하면 앱이 종료되던 문제를 수정했습니다. 동영상 마무리 단계를 포함해 인코더 입력 버퍼를 기다리는 중에도 생성 취소가 반영됩니다.
+</ko-KR>
+<ja-JP>
+カスタムフレームレートに0を入力するとクラッシュする問題を修正しました。動画の仕上げ処理を含め、エンコーダーの入力バッファ待機中も動画作成のキャンセルが反映されるようになりました。
+</ja-JP>
+<zh-CN>
+修复了自定义帧率输入0时导致应用崩溃的问题。在等待编码器输入缓冲区时，包括视频收尾阶段，取消导出现在也能生效。
+</zh-CN>
+<zh-TW>
+修正了自訂影格率輸入0時導致應用程式當機的問題。在等待編碼器輸入緩衝區時，包括影片收尾階段，取消匯出現在也能生效。
+</zh-TW>
+<es-ES>
+Corregimos un cierre inesperado al introducir cero como tasa de fotogramas personalizada. Ahora se puede cancelar la exportación mientras se esperan búferes de entrada del codificador, incluso al finalizar el vídeo.
+</es-ES>
+<fr-FR>
+Correction d’un plantage lors de la saisie de zéro comme fréquence d’images personnalisée. L’annulation de l’exportation est désormais prise en compte pendant l’attente des tampons d’entrée de l’encodeur, y compris en fin de vidéo.
+</fr-FR>
+<de-DE>
+Ein Absturz bei der Eingabe von null als benutzerdefinierte Bildrate wurde behoben. Der Videoexport lässt sich jetzt auch beim Warten auf Eingabepuffer des Encoders abbrechen, einschließlich beim Fertigstellen des Videos.
+</de-DE>
+<pt-BR>
+Corrigimos uma falha ao inserir zero como taxa de quadros personalizada. Agora é possível cancelar a exportação enquanto o aplicativo aguarda os buffers de entrada do codificador, inclusive ao finalizar o vídeo.
+</pt-BR>

--- a/docs/release-notes-v3.0.13.md
+++ b/docs/release-notes-v3.0.13.md
@@ -1,0 +1,23 @@
+# Timeline Visualizer 3.0.13
+
+- Fixed a crash when entering zero as a custom frame rate on Android.
+- Export cancellation now takes effect while retrying unavailable encoder input buffers, including when finishing a video.
+- Fixed CLI map tile requests across the International Date Line and beyond map latitude bounds.
+- CLI custom dimensions now accept 4K landscape and portrait sizes. The resolved short edge must be 480 through 2160 pixels, the long edge must not exceed 3840 pixels, and both dimensions must be even.
+- New CLI 480p landscape videos use 852x480 instead of 854x480, and portrait videos use 480x852 instead of 480x854, matching current Android and web presets. Existing exported videos are unchanged.
+
+## 한국어
+
+- Android에서 사용자 지정 프레임 속도에 0을 입력하면 앱이 종료되던 문제를 수정했습니다.
+- 인코더 입력 버퍼를 기다리는 중에도 동영상 생성 취소가 반영되도록 개선했습니다.
+- CLI에서 날짜 변경선과 지도 위도 범위를 벗어나는 지도 타일 요청을 수정했습니다.
+- CLI에서 4K 가로 및 세로 크기를 직접 지정할 수 있습니다.
+- CLI의 새 480p 출력 크기를 Android 및 웹과 동일한 가로 852x480, 세로 480x852로 맞췄습니다. 기존 동영상은 변경되지 않습니다.
+
+## 日本語
+
+- Androidでカスタムフレームレートに0を入力するとクラッシュする問題を修正しました。
+- エンコーダーの入力バッファを待機している間も動画作成のキャンセルが反映されるようになりました。
+- CLIで日付変更線や地図の緯度範囲を超えるタイルのリクエストを修正しました。
+- CLIで4Kの横向きと縦向きのサイズを直接指定できるようになりました。
+- CLIの新しい480p動画を横向き852x480、縦向き480x852に統一しました。既存の動画は変更されません。

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.12` and version code `54`
+- Version name `3.0.13` and version code `55`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/test-fixtures/platform-parity-expected.json
+++ b/test-fixtures/platform-parity-expected.json
@@ -1,8 +1,84 @@
 {
   "pointCount": 3,
-  "latitudes": [37.5, 37.55, 37.6],
+  "latitudes": [
+    37.5,
+    37.55,
+    37.6
+  ],
   "firstInstant": "2026-01-01T00:00:00Z",
   "lastInstant": "2026-01-01T01:00:00Z",
   "selectedDurationSeconds": 10,
-  "outroSeconds": 1.5
+  "outroSeconds": 1.5,
+  "videoDimensions": {
+    "480": {
+      "square": [
+        480,
+        480
+      ],
+      "portrait": [
+        480,
+        852
+      ],
+      "landscape": [
+        852,
+        480
+      ]
+    },
+    "720": {
+      "square": [
+        720,
+        720
+      ],
+      "portrait": [
+        720,
+        1280
+      ],
+      "landscape": [
+        1280,
+        720
+      ]
+    },
+    "1080": {
+      "square": [
+        1080,
+        1080
+      ],
+      "portrait": [
+        1080,
+        1920
+      ],
+      "landscape": [
+        1920,
+        1080
+      ]
+    },
+    "1440": {
+      "square": [
+        1440,
+        1440
+      ],
+      "portrait": [
+        1440,
+        2560
+      ],
+      "landscape": [
+        2560,
+        1440
+      ]
+    },
+    "2160": {
+      "square": [
+        2160,
+        2160
+      ],
+      "portrait": [
+        2160,
+        3840
+      ],
+      "landscape": [
+        3840,
+        2160
+      ]
+    }
+  }
 }

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -176,3 +176,44 @@ def test_start_date_month_uses_first_day(value, expected):
 ])
 def test_end_date_month_uses_last_day(value, expected):
     assert parse_date_argument(value, end_of_month=True) == expected
+
+
+@pytest.mark.parametrize(('width', 'height'), [(3840, 2160), (2160, 3840), (3440, 1440)])
+def test_custom_large_dimensions_are_accepted(tmp_path, width, height):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_text('[]', encoding='utf-8')
+    args = build_argument_parser().parse_args([
+        '--input', str(timeline), '--width', str(width), '--height', str(height)])
+    assert visualizer.resolve_video_dimensions(args.resolution, args.aspect_ratio, args.width, args.height) == (width, height)
+
+
+@pytest.mark.parametrize(('arguments', 'message'), [
+    (['--width', '478'], 'short edge'),
+    (['--width', '2162', '--height', '2162'], 'short edge'),
+    (['--width', '481'], 'even'),
+    (['--height', '2161'], 'even'),
+    (['--width', '3842'], 'long-edge limit'),
+    (['--resolution', '2160', '--aspect-ratio', 'portrait', '--width', '2560'], 'short edge'),
+])
+def test_invalid_resolved_dimensions_fail_before_rendering(tmp_path, monkeypatch, capsys, arguments, message):
+    timeline = tmp_path / 'Timeline.json'
+    timeline.write_text('[]', encoding='utf-8')
+    monkeypatch.setattr(visualizer, 'ensure_ffmpeg_available', lambda: pytest.fail('validation must precede rendering'))
+    with pytest.raises(SystemExit) as error:
+        visualizer.main(['--input', str(timeline), *arguments])
+    assert error.value.code == 2
+    assert message in capsys.readouterr().err
+
+
+def test_one_custom_axis_resolves_against_the_preset():
+    assert visualizer.resolve_video_dimensions('2160', 'landscape', height=1440) == (3840, 1440)
+    assert visualizer.resolve_video_dimensions('2160', 'portrait', width=1440) == (1440, 3840)
+
+
+def test_formats_match_shared_fixture_and_custom_pairs():
+    from pathlib import Path
+    expected = json.loads((Path(__file__).parents[1] / 'test-fixtures/platform-parity-expected.json').read_text())
+    for short_edge, aspects in expected['videoDimensions'].items():
+        for aspect, dimensions in aspects.items():
+            assert visualizer.resolve_video_dimensions(short_edge, aspect) == tuple(dimensions)
+            assert visualizer.resolve_video_dimensions('480', 'square', *dimensions) == tuple(dimensions)

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 54' in build_file
-    assert 'versionName = "3.0.12"' in build_file
+    assert 'versionCode = 55' in build_file
+    assert 'versionName = "3.0.13"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:

--- a/tests/test_map_tiles.py
+++ b/tests/test_map_tiles.py
@@ -1,0 +1,40 @@
+import math
+
+import pytest
+from PIL import Image
+
+import visualizer
+
+
+@pytest.mark.parametrize(('x', 'y'), [(-1.1, 0), (0, 1.1)])
+def test_negative_fractional_tile_coordinates_are_floored(x, y):
+    extent = visualizer.MAX_EXTENT
+    actual = visualizer.meters_to_tile(x * extent, y * extent, 2)
+    assert actual == (math.floor((x + 1) * 2), math.floor((1 - y) * 2))
+
+
+@pytest.mark.parametrize(('x', 'y'), [(1, 0), (-1, 0), (0, 1), (0, -1), (0, 0)])
+def test_boundary_tiles_use_valid_requests_and_keep_world_placement(monkeypatch, x, y):
+    calls = []
+    def fetch(tx, ty, zoom):
+        assert 0 <= tx < 2 ** zoom
+        assert 0 <= ty < 2 ** zoom
+        calls.append((tx, ty, zoom))
+        return Image.new('RGB', (256, 256), (tx, ty, 100))
+    monkeypatch.setattr(visualizer, 'fetch_tile_img', fetch)
+    extent = visualizer.MAX_EXTENT
+    image, bounds = visualizer.get_map_image(x * extent, y * extent, extent, width_px=256)
+    assert calls
+    zoom = calls[0][2]
+    tile_size = 2 * extent / 2 ** zoom
+    start_x = round((bounds[0] + extent) / tile_size)
+    start_y = round((extent - bounds[3]) / tile_size)
+    for column in range(image.width // 256):
+        for row in range(image.height // 256):
+            world_y = start_y + row
+            expected = ((start_x + column) % (2 ** zoom), world_y, 100) if 0 <= world_y < 2 ** zoom else (242, 237, 240)
+            assert image.getpixel((column * 256 + 128, row * 256 + 128)) == expected
+    assert bounds[0] <= x * extent - extent / 2
+    assert bounds[1] >= x * extent + extent / 2
+    assert bounds[2] <= y * extent - extent / 2
+    assert bounds[3] >= y * extent + extent / 2

--- a/visualizer.py
+++ b/visualizer.py
@@ -51,6 +51,7 @@ MIN_FPS = 15
 MAX_FPS = 120
 MIN_SHORT_EDGE = 480
 MAX_SHORT_EDGE = 2160
+MAX_LONG_EDGE = 3840
 DEFAULT_DURATION = 30
 DEFAULT_TAIL_KM = 500
 THEME_COLOR = '#e90064'
@@ -415,8 +416,8 @@ def meters_to_tile(mx: float, my: float, zoom: int) -> Tuple[int, int]:
     n = 2.0 ** zoom
     norm_x = (mx + MAX_EXTENT) / (2 * MAX_EXTENT)
     norm_y = 1.0 - (my + MAX_EXTENT) / (2 * MAX_EXTENT)
-    xtile = int(norm_x * n)
-    ytile = int(norm_y * n)
+    xtile = math.floor(norm_x * n)
+    ytile = math.floor(norm_y * n)
     return xtile, ytile
 
 
@@ -515,8 +516,11 @@ def get_map_image(
 
     for x in range(x_tiles):
         for y in range(y_tiles):
-            img = fetch_tile_img(xt_min + x, yt_min + y, zoom)
-            stitched.paste(img, (x * tile_w, y * tile_h))
+            world_y = yt_min + y
+            if 0 <= world_y < 2 ** zoom:
+                # Keep world-copy placement, but request the canonical longitude tile.
+                img = fetch_tile_img((xt_min + x) % (2 ** zoom), world_y, zoom)
+                stitched.paste(img, (x * tile_w, y * tile_h))
 
     return stitched, (final_min_x, final_max_x, final_min_y, final_max_y)
 
@@ -1280,10 +1284,27 @@ def bounded_int(name: str, minimum: int, maximum: int):
 
 
 def even_dimension(raw: str) -> int:
-    value = bounded_int("custom dimensions", MIN_SHORT_EDGE, MAX_SHORT_EDGE)(raw)
+    value = bounded_int("custom dimension (long-edge limit)", 2, MAX_LONG_EDGE)(raw)
     if value % 2:
         raise argparse.ArgumentTypeError("custom dimensions must be even for H.264 video")
     return value
+
+
+def resolve_video_dimensions(resolution: str, aspect_ratio: str,
+                             width: Optional[int] = None, height: Optional[int] = None) -> Tuple[int, int]:
+    short_edge = int(resolution)
+    long_edge = (short_edge * 16 // 9) // 2 * 2
+    preset = {'square': (short_edge, short_edge),
+              'portrait': (short_edge, long_edge),
+              'landscape': (long_edge, short_edge)}[aspect_ratio]
+    dimensions = (preset[0] if width is None else width, preset[1] if height is None else height)
+    if any(value % 2 for value in dimensions):
+        raise argparse.ArgumentTypeError("custom dimensions must be even for H.264 video")
+    if not MIN_SHORT_EDGE <= min(dimensions) <= MAX_SHORT_EDGE:
+        raise argparse.ArgumentTypeError("video short edge must be from 480 through 2160 pixels")
+    if max(dimensions) > MAX_LONG_EDGE:
+        raise argparse.ArgumentTypeError("video long edge must not exceed 3840 pixels")
+    return dimensions
 
 
 def frame_plan(total_duration: int, fps: int) -> Tuple[int, int, int]:
@@ -1327,8 +1348,8 @@ def build_argument_parser() -> argparse.ArgumentParser:
                         help="Aspect ratio: square (1:1), portrait (9:16), or landscape (16:9)")
     parser.add_argument('--resolution', '-r', choices=['480', '720', '1080', '1440', '2160'], default='720',
                         help="Short-edge resolution: 480p, 720p, 1080p, 1440p, or 2160p")
-    parser.add_argument('--width', type=even_dimension, default=None, help="Custom even video width (480 to 2160 pixels)")
-    parser.add_argument('--height', type=even_dimension, default=None, help="Custom even video height (480 to 2160 pixels)")
+    parser.add_argument('--width', type=even_dimension, default=None, help="Custom even width (480 to 3840 pixels; resolved short edge 480 to 2160)")
+    parser.add_argument('--height', type=even_dimension, default=None, help="Custom even height (480 to 3840 pixels; resolved short edge 480 to 2160)")
     parser.add_argument('--filter-outliers', '--gps-outlier-filter', dest='filter_outliers', choices=['conservative', 'off'], default='conservative',
                         help="GPS outlier filter: conservative or off")
     parser.add_argument('--route-source', choices=['semantic', 'journal'], default='semantic',
@@ -1366,6 +1387,10 @@ def main(argv: Optional[List[str]] = None) -> int:
 def _main_inner(argv: Optional[List[str]] = None) -> int:
     parser = build_argument_parser()
     args = parser.parse_args(argv)
+    try:
+        width_px, height_px = resolve_video_dimensions(args.resolution, args.aspect_ratio, args.width, args.height)
+    except argparse.ArgumentTypeError as error:
+        parser.error(str(error))
 
     start_date = parse_date_argument(args.start_date)
     end_date = parse_date_argument(args.end_date, end_of_month=True)
@@ -1390,20 +1415,6 @@ def _main_inner(argv: Optional[List[str]] = None) -> int:
     total_km = cum_dist[-1]
     print(f"Total distance: {format_distance(total_km, args.unit)}")
 
-    # Resolve dimensions and aspect ratio
-    aspect_map = {'square': 1.0, 'portrait': 9.0 / 16.0, 'landscape': 16.0 / 9.0}
-    aspect = aspect_map[args.aspect_ratio]
-
-    res_sizes = {
-        '480': {'square': (480, 480), 'portrait': (480, 854), 'landscape': (854, 480)},
-        '720': {'square': (720, 720), 'portrait': (720, 1280), 'landscape': (1280, 720)},
-        '1080': {'square': (1080, 1080), 'portrait': (1080, 1920), 'landscape': (1920, 1080)},
-        '1440': {'square': (1440, 1440), 'portrait': (1440, 2560), 'landscape': (2560, 1440)},
-        '2160': {'square': (2160, 2160), 'portrait': (2160, 3840), 'landscape': (3840, 2160)},
-    }
-    default_w, default_h = res_sizes[args.resolution][args.aspect_ratio]
-    width_px = args.width if args.width else default_w
-    height_px = args.height if args.height else default_h
     aspect = width_px / float(height_px)
 
     fps = args.fps

--- a/web/src/video.test.ts
+++ b/web/src/video.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ALL_VIDEO_FORMATS,
@@ -285,7 +286,7 @@ describe('createJourneyMp4', () => {
     overlay: {
       title: 'Trip',
       periodLabel: 'March 2026',
-      separator: ' · ',
+      separator: ' 쨌 ',
       formatDistance: (kilometers: number) => `${Math.round(kilometers)} km`,
     },
     format,
@@ -376,4 +377,15 @@ describe('createJourneyMp4', () => {
       .rejects.toThrow('The preview is not using the selected video format size.');
     expect(encoder.start).not.toHaveBeenCalled();
   });
+});
+
+
+it('matches shared cross-platform preset dimensions', () => {
+  const expected = JSON.parse(readFileSync(new URL('../../test-fixtures/platform-parity-expected.json', import.meta.url), 'utf8'));
+  for (const [edge, aspects] of Object.entries(expected.videoDimensions)) {
+    for (const [aspect, dimensions] of Object.entries(aspects as Record<string, number[]>)) {
+      const format = buildVideoFormat(aspect as 'square' | 'portrait' | 'landscape', Number(edge), 30);
+      expect([format.width, format.height]).toEqual(dimensions);
+    }
+  }
 });


### PR DESCRIPTION
Fixes zero-frame-rate crashes and makes Android export cancellation observable during input-buffer waits for both frames and end-of-stream submission. CLI exports accept preset-equivalent 4K dimensions, wrap tile requests at the Date Line while preserving map placement, and match Android/web 480p dimensions.

Acceptance coverage

- #226 covers zero spellings, the positive-value invariant, and a dialog regression test that checks the inline error, retained dialog, and subsequent valid entry.
- #232 uses one cancellation-aware wait for both submission paths, with controlled starvation and successful-buffer tests. Exceptions unwind through the existing exporter cleanup.
- #227 validates resolved custom pairs before rendering, including partial overrides, 4K portrait/landscape, short-edge bounds, evenness, and the documented 3840-pixel long-edge cap.
- #228 checks every preset/aspect combination against one shared fixture in Python, Android, and web. Release notes document the CLI 480p size change and preservation of existing videos.
- #229 tests canonical request indices and unwrapped map placement across both longitude boundaries and latitude limits. Areas beyond valid latitude rows retain the map background instead of requesting invalid tiles.

Validation

- Focused Android tests for frame-rate parsing, dialog behavior, encoder waiting, and preset parity passed.
- 42 focused Python CLI/tile tests passed. Release metadata and packaging checks passed.
- 311 web tests and TypeScript checks passed.

Prepares version 3.0.13 (55), with GitHub release notes and Play release notes in all nine listing languages.

Fixes #226
Fixes #227
Fixes #228
Fixes #229
Fixes #232
