### PR TITLE
Stabilize export recreation coverage and prepare 3.0.14

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.mahlernim.timelinevisualizer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 55
-        versionName = "3.0.13"
+        versionCode = 56
+        versionName = "3.0.14"
         manifestPlaceholders["appLabel"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -436,10 +436,18 @@ class MainActivityTest {
 
         controller.recreate()
         var recreated = controller.get()
-        recreated.deliverPendingVideoDestinationForTest(destination)
-        assertEquals(destination, recreated.pendingExportDestinationUriForTest())
-
-        controller.recreate()
+        // Hold the synchronized store read so this exercises recreation during loading,
+        // regardless of how quickly the IO dispatcher runs on the test machine.
+        val storeLazy = MainActivity::class.java.getDeclaredField("pendingVideoExportRequestStore\$delegate")
+            .apply { isAccessible = true }.get(recreated) as Lazy<*>
+        val pendingStore = requireNotNull(storeLazy.value)
+        val readLock = PendingVideoExportRequestStore::class.java.getDeclaredField("delegate")
+            .apply { isAccessible = true }.get(pendingStore)
+        synchronized(readLock) {
+            recreated.deliverPendingVideoDestinationForTest(destination)
+            assertEquals(destination, recreated.pendingExportDestinationUriForTest())
+            controller.recreate()
+        }
         recreated = controller.get()
         waitUntil { VideoExportRequestStore(context).load()?.outputUri == destination.toString() }
 

--- a/docs/play-release-notes-v3.0.14.txt
+++ b/docs/play-release-notes-v3.0.14.txt
@@ -1,0 +1,27 @@
+<en-US>
+Fixed a crash when entering zero as a custom frame rate. Video export cancellation now responds while waiting for encoder input buffers, including when finishing a video.
+</en-US>
+<ko-KR>
+사용자 지정 프레임 속도에 0을 입력하면 앱이 종료되던 문제를 수정했습니다. 동영상 마무리 단계를 포함해 인코더 입력 버퍼를 기다리는 중에도 생성 취소가 반영됩니다.
+</ko-KR>
+<ja-JP>
+カスタムフレームレートに0を入力するとクラッシュする問題を修正しました。動画の仕上げ処理を含め、エンコーダーの入力バッファ待機中も動画作成のキャンセルが反映されるようになりました。
+</ja-JP>
+<zh-CN>
+修复了自定义帧率输入0时导致应用崩溃的问题。在等待编码器输入缓冲区时，包括视频收尾阶段，取消导出现在也能生效。
+</zh-CN>
+<zh-TW>
+修正了自訂影格率輸入0時導致應用程式當機的問題。在等待編碼器輸入緩衝區時，包括影片收尾階段，取消匯出現在也能生效。
+</zh-TW>
+<es-ES>
+Corregimos un cierre inesperado al introducir cero como tasa de fotogramas personalizada. Ahora se puede cancelar la exportación mientras se esperan búferes de entrada del codificador, incluso al finalizar el vídeo.
+</es-ES>
+<fr-FR>
+Correction d’un plantage lors de la saisie de zéro comme fréquence d’images personnalisée. L’annulation de l’exportation est désormais prise en compte pendant l’attente des tampons d’entrée de l’encodeur, y compris en fin de vidéo.
+</fr-FR>
+<de-DE>
+Ein Absturz bei der Eingabe von null als benutzerdefinierte Bildrate wurde behoben. Der Videoexport lässt sich jetzt auch beim Warten auf Eingabepuffer des Encoders abbrechen, einschließlich beim Fertigstellen des Videos.
+</de-DE>
+<pt-BR>
+Corrigimos uma falha ao inserir zero como taxa de quadros personalizada. Agora é possível cancelar a exportação enquanto o aplicativo aguarda os buffers de entrada do codificador, inclusive ao finalizar o vídeo.
+</pt-BR>

--- a/docs/release-notes-v3.0.14.md
+++ b/docs/release-notes-v3.0.14.md
@@ -1,0 +1,23 @@
+# Timeline Visualizer 3.0.14
+
+- Fixed a crash when entering zero as a custom frame rate on Android.
+- Export cancellation now takes effect while retrying unavailable encoder input buffers, including when finishing a video.
+- Fixed CLI map tile requests across the International Date Line and beyond map latitude bounds.
+- CLI custom dimensions now accept 4K landscape and portrait sizes. The resolved short edge must be 480 through 2160 pixels, the long edge must not exceed 3840 pixels, and both dimensions must be even.
+- New CLI 480p landscape videos use 852x480 instead of 854x480, and portrait videos use 480x852 instead of 480x854, matching current Android and web presets. Existing exported videos are unchanged.
+
+## 한국어
+
+- Android에서 사용자 지정 프레임 속도에 0을 입력하면 앱이 종료되던 문제를 수정했습니다.
+- 인코더 입력 버퍼를 기다리는 중에도 동영상 생성 취소가 반영되도록 개선했습니다.
+- CLI에서 날짜 변경선과 지도 위도 범위를 벗어나는 지도 타일 요청을 수정했습니다.
+- CLI에서 4K 가로 및 세로 크기를 직접 지정할 수 있습니다.
+- CLI의 새 480p 출력 크기를 Android 및 웹과 동일한 가로 852x480, 세로 480x852로 맞췄습니다. 기존 동영상은 변경되지 않습니다.
+
+## 日本語
+
+- Androidでカスタムフレームレートに0を入力するとクラッシュする問題を修正しました。
+- エンコーダーの入力バッファを待機している間も動画作成のキャンセルが反映されるようになりました。
+- CLIで日付変更線や地図の緯度範囲を超えるタイルのリクエストを修正しました。
+- CLIで4Kの横向きと縦向きのサイズを直接指定できるようになりました。
+- CLIの新しい480p動画を横向き852x480、縦向き480x852に統一しました。既存の動画は変更されません。

--- a/play-store/submission-checklist.md
+++ b/play-store/submission-checklist.md
@@ -19,7 +19,7 @@
 
 ## Release
 
-- Version name `3.0.13` and version code `55`
+- Version name `3.0.14` and version code `56`
 - Upload the signed `playRelease` Android App Bundle
 - On first enrollment, preserve the existing app-signing key so GitHub and Play installs remain update-compatible
 - Register a separate upload key for later Play releases

--- a/tests/test_journal_lab_packaging.py
+++ b/tests/test_journal_lab_packaging.py
@@ -40,8 +40,8 @@ def test_travel_journal_is_enabled_for_production_flavors() -> None:
         assert match is not None
         assert 'buildConfigField("boolean", "IS_JOURNAL_LAB", "true")' in match.group("body")
 
-    assert 'versionCode = 55' in build_file
-    assert 'versionName = "3.0.13"' in build_file
+    assert 'versionCode = 56' in build_file
+    assert 'versionName = "3.0.14"' in build_file
 
 
 def test_normal_validation_builds_the_journal_lab_variant() -> None:


### PR DESCRIPTION
The pending-export recreation test could complete its asynchronous restore before asserting the intermediate pending URI. Hold the existing synchronized store read across result delivery and recreation so the test reliably exercises the intended in-flight state and retains its final recovery assertions.

Prepares version 3.0.14 (56) with the five export fixes already merged in #234. The v3.0.13 tag remains unchanged. No application behavior changes are introduced by this follow-up.

Release metadata and packaging checks pass. Android validation covers the corrected test in GitHub and Journal Lab variants, with required CI before merge.
