### PR TITLE
Make Google Play open testing easy to find

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -28,9 +28,14 @@ MP4 の作成には H.264 エンコードに対応した Safari 16.4 以降が�
 
 ## Android にインストールする
 
-このアプリはまだ Google Play で公開されていません。このリポジトリの
-[最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
-次の手順でインストールします。
+[Google Play オープンテストに参加](https://play.google.com/apps/testing/dev.mahlernim.timelinevisualizer)
+するには、スマートフォンで使う Google アカウントでログインし、テストに参加してから
+Google Play のダウンロードリンクを開いてください。招待や Google グループへの参加は不要です。
+利用できるかどうかは Google の審査、国、端末によって異なります。
+まだ参加できない場合は、後で参加ページをもう一度確認してください。
+
+このリポジトリの [最新リリース](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)から
+APK を直接インストールすることもできます。
 
 1. **Assets** にある最新の `TimelineVisualizer-*.apk` ファイルをダウンロードします。
    `.sha256` チェックサムファイルはダウンロードしないでください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,8 +29,14 @@ MP4를 만들려면 H.264 인코딩을 지원하는 Safari 16.4 이상이 필요
 
 ## Android에 설치하기
 
-아직 Google Play에는 등록되지 않았습니다. 이 저장소의
-[최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서 설치하세요.
+[Google Play 공개 테스트 참여](https://play.google.com/apps/testing/dev.mahlernim.timelinevisualizer)
+페이지에서 휴대전화에 사용하는 Google 계정으로 로그인하고 테스트에 참여한 뒤,
+Google Play 다운로드 링크를 누르세요. 공개 테스트에는 초대나 Google 그룹 가입이
+필요하지 않습니다. Google 심사와 국가, 기기에 따라 이용 가능 여부가 달라집니다.
+아직 참여할 수 없다면 나중에 참여 페이지를 다시 확인하세요.
+
+이 저장소의 [최신 릴리스](https://github.com/mahlernim/google-timeline-visualizer/releases/latest)에서
+APK를 직접 설치할 수도 있습니다.
 
 1. **Assets**에서 최신 `TimelineVisualizer-*.apk` 파일을 휴대전화로 다운로드합니다.
    `.sha256` 체크섬 파일은 다운로드하지 마세요.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,15 @@ use Safari's Share menu and choose **Add to Home Screen**.
 
 ## Install on Android
 
-The app is not yet on Google Play. Install it from this repository's
-[latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest):
+[Join Google Play open testing](https://play.google.com/apps/testing/dev.mahlernim.timelinevisualizer)
+to get the Android app and updates through Google Play. Sign in with the Google
+account you use on your phone, join the test, then follow the Google Play download
+link. No invitation or Google Group membership is needed for open testing.
+Availability depends on Google's review and your country or device. If the test
+is not available yet, check the enrollment page again later.
+
+You can also install the APK from this repository's
+[latest release](https://github.com/mahlernim/google-timeline-visualizer/releases/latest).
 
 1. Under **Assets**, download the latest `TimelineVisualizer-*.apk` file on your
    phone. Do not download the `.sha256` checksum file.

--- a/docs/release-notes-v3.0.14.md
+++ b/docs/release-notes-v3.0.14.md
@@ -1,5 +1,13 @@
 # Timeline Visualizer 3.0.14
 
+[Join Google Play open testing](https://play.google.com/apps/testing/dev.mahlernim.timelinevisualizer)
+to install the Android app and receive updates through Google Play. Sign in with
+the Google account used on your phone, join the test, then follow the download
+link. Open testing needs no invitation or Google Group membership. Availability
+depends on Google's review and your country or device. If the test is not
+available yet, check the enrollment page again later. The APK remains available
+under **Assets** below.
+
 - Fixed a crash when entering zero as a custom frame rate on Android.
 - Export cancellation now takes effect while retrying unavailable encoder input buffers, including when finishing a video.
 - Fixed CLI map tile requests across the International Date Line and beyond map latitude bounds.

--- a/tests/test_web_privacy.py
+++ b/tests/test_web_privacy.py
@@ -22,12 +22,12 @@ def test_web_privacy_copy_does_not_claim_analytics_are_absent() -> None:
     assert "Cloudflare Web Analytics" in readme
 
 
-def test_web_app_links_to_alpha_recruitment_discussion_not_restricted_play() -> None:
+def test_web_app_links_directly_to_public_play_enrollment() -> None:
     html = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
 
-    assert "https://github.com/mahlernim/google-timeline-visualizer/discussions/165" in html
-    assert "https://play.google.com/apps/testing/" not in html
-    assert 'data-i18n="alphaTesterLink"' in html
+    assert "https://play.google.com/apps/testing/dev.mahlernim.timelinevisualizer" in html
+    assert "https://github.com/mahlernim/google-timeline-visualizer/discussions/165" not in html
+    assert 'data-i18n="openTestingLink"' in html
 
 
 def test_web_advertising_is_prepared_but_not_enabled() -> None:

--- a/web/index.html
+++ b/web/index.html
@@ -20,6 +20,8 @@
         <h1 data-i18n="headerTitle">Create video</h1>
       </header>
 
+      <p><a href="https://play.google.com/apps/testing/dev.mahlernim.timelinevisualizer" target="_blank" rel="noopener noreferrer" data-i18n="openTestingLink">Android app · Join Google Play open testing</a></p>
+
       <section class="card intro">
         <h2 data-i18n="fileCardTitle">Timeline file</h2>
         <p data-i18n="fileCardIntro">Choose your exported Timeline.json. The file stays on this device, and only map images are requested from the map provider.</p>
@@ -188,7 +190,6 @@
       <footer>
         <p data-i18n="footerNoAccount">No account, location permission, or Timeline upload is required.</p>
         <p data-i18n="footerMapAttribution">Map data © OpenStreetMap contributors and © CARTO.</p>
-        <p><a href="https://github.com/mahlernim/google-timeline-visualizer/discussions/165" target="_blank" rel="noopener noreferrer" data-i18n="alphaTesterLink">Become an Alpha tester</a></p>
         <p><a href="./third-party-notices.txt" data-i18n="footerThirdPartyNotices">Third-party notices</a></p>
       </footer>
     </main>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -198,7 +198,7 @@ export interface Strings {
   footerNoAccount: string;
   footerMapAttribution: string;
   footerThirdPartyNotices: string;
-  alphaTesterLink: string;
+  openTestingLink: string;
 
   // --- raw-only dialog ---
   rawOnlyDialogTitle: string;

--- a/web/src/locales/de.ts
+++ b/web/src/locales/de.ts
@@ -123,7 +123,7 @@ export const de: Strings = {
   footerNoAccount: 'Kein Konto, keine Standortberechtigung und kein Timeline-Upload erforderlich.',
   footerMapAttribution: 'Kartendaten © OpenStreetMap-Mitwirkende und © CARTO.',
   footerThirdPartyNotices: 'Hinweise zu Drittanbietern',
-  alphaTesterLink: 'Alpha-Tester werden',
+  openTestingLink: 'Android-App · Am offenen Google Play-Test teilnehmen',
 
   rawOnlyDialogTitle: 'Nur unverarbeitete Standortdaten gefunden',
   rawOnlyDialogBody1: 'Diese Datei enthält unverarbeitete Standortdaten, aber keine verarbeiteten Besuche oder Wege. Sie können fortfahren, aber die Route kann ungenau oder unvollständig sein und die Entfernung ist nur eine Schätzung.',

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -123,7 +123,7 @@ export const en: Strings = {
   footerNoAccount: 'No account, location permission, or Timeline upload is required.',
   footerMapAttribution: 'Map data © OpenStreetMap contributors and © CARTO.',
   footerThirdPartyNotices: 'Third-party notices',
-  alphaTesterLink: 'Become an Alpha tester',
+  openTestingLink: 'Android app · Join Google Play open testing',
 
   rawOnlyDialogTitle: 'Only raw location data found',
   rawOnlyDialogBody1: 'This file contains raw location data but no processed visits or trips. You can continue, but the route may be noisy or incomplete, and its distance will only be an estimate.',

--- a/web/src/locales/es.ts
+++ b/web/src/locales/es.ts
@@ -126,7 +126,7 @@ export const es: Strings = {
   footerNoAccount: 'No se necesita cuenta, permiso de ubicación ni subir el archivo Timeline.',
   footerMapAttribution: 'Datos del mapa © colaboradores de OpenStreetMap y © CARTO.',
   footerThirdPartyNotices: 'Avisos de terceros',
-  alphaTesterLink: 'Conviértete en tester Alfa',
+  openTestingLink: 'App para Android · Únete a la prueba abierta de Google Play',
 
   rawOnlyDialogTitle: 'Solo se encontraron datos de ubicación sin procesar',
   rawOnlyDialogBody1: 'Este archivo contiene datos de ubicación sin procesar, pero no visitas ni trayectos procesados. Puedes continuar, pero la ruta puede ser imprecisa o estar incompleta, y la distancia será solo una estimación.',

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -126,7 +126,7 @@ export const fr: Strings = {
   footerNoAccount: 'Aucun compte, aucune autorisation de localisation ni aucun envoi de votre Timeline n’est nécessaire.',
   footerMapAttribution: 'Données cartographiques © les contributeurs OpenStreetMap et © CARTO.',
   footerThirdPartyNotices: 'Mentions légales des tiers',
-  alphaTesterLink: 'Devenir testeur Alpha',
+  openTestingLink: 'Appli Android · Rejoindre le test ouvert sur Google Play',
 
   rawOnlyDialogTitle: 'Seules des données de localisation brutes ont été trouvées',
   rawOnlyDialogBody1: 'Ce fichier contient des données de localisation brutes, mais aucune visite ni aucun trajet traité. Vous pouvez continuer, mais l’itinéraire peut être imprécis ou incomplet, et la distance ne sera qu’une estimation.',

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -121,7 +121,7 @@ export const ja: Strings = {
   footerNoAccount: 'アカウント、位置情報の権限、タイムラインのアップロードはいずれも不要です。',
   footerMapAttribution: '地図データ © OpenStreetMap contributors および © CARTO。',
   footerThirdPartyNotices: 'サードパーティに関する通知',
-  alphaTesterLink: 'Alpha テスターになる',
+  openTestingLink: 'Android アプリ · Google Play オープンテストに参加',
 
   rawOnlyDialogTitle: '未処理の位置情報のみが見つかりました',
   rawOnlyDialogBody1: 'このファイルには未処理の位置情報のみが含まれ、処理済みの訪問や移動はありません。続行できますが、経路が不正確または不完全になり、距離は推定値になります。',

--- a/web/src/locales/ko.ts
+++ b/web/src/locales/ko.ts
@@ -123,7 +123,7 @@ export const ko: Strings = {
   footerNoAccount: '계정도, 위치 권한도, 타임라인 업로드도 필요하지 않습니다.',
   footerMapAttribution: '지도 데이터 © OpenStreetMap 기여자 및 © CARTO.',
   footerThirdPartyNotices: '타사 고지 사항',
-  alphaTesterLink: '알파 테스터 참여하기',
+  openTestingLink: 'Android 앱 · Google Play 공개 테스트 참여',
 
   rawOnlyDialogTitle: '원시 위치 데이터만 발견됨',
   rawOnlyDialogBody1: '이 파일에는 처리된 방문 및 이동 기록 없이 원시 위치 정보만 포함되어 있습니다. 계속할 수 있지만 경로가 부정확하거나 일부 누락될 수 있으며, 이동 거리는 추정값으로 표시됩니다.',

--- a/web/src/locales/pt-BR.ts
+++ b/web/src/locales/pt-BR.ts
@@ -126,7 +126,7 @@ export const ptBR: Strings = {
   footerNoAccount: 'Não exige conta, permissão de localização nem envio do Timeline.',
   footerMapAttribution: 'Dados do mapa © colaboradores do OpenStreetMap e © CARTO.',
   footerThirdPartyNotices: 'Avisos de terceiros',
-  alphaTesterLink: 'Torne-se um testador Alfa',
+  openTestingLink: 'App Android · Participe do teste aberto no Google Play',
 
   rawOnlyDialogTitle: 'Apenas dados de localização brutos encontrados',
   rawOnlyDialogBody1: 'Este arquivo contém dados de localização brutos, mas não contém visitas ou trajetos processados. Você pode continuar, mas a rota pode ficar imprecisa ou incompleta, e a distância será apenas uma estimativa.',

--- a/web/src/locales/zh-CN.ts
+++ b/web/src/locales/zh-CN.ts
@@ -123,7 +123,7 @@ export const zhCN: Strings = {
   footerNoAccount: '无需账号或位置权限，也不会上传 Timeline。',
   footerMapAttribution: '地图数据 © OpenStreetMap 贡献者与 © CARTO。',
   footerThirdPartyNotices: '第三方声明',
-  alphaTesterLink: '成为 Alpha 测试人员',
+  openTestingLink: 'Android 应用 · 加入 Google Play 公开测试',
 
   rawOnlyDialogTitle: '仅发现原始位置数据',
   rawOnlyDialogBody1: '此文件包含原始位置数据，但没有经过处理的到访记录或行程。您可以继续，但路线可能不准确或不完整，距离也只是估算值。',

--- a/web/src/locales/zh-TW.ts
+++ b/web/src/locales/zh-TW.ts
@@ -118,7 +118,7 @@ export const zhTW: Strings = {
   footerNoAccount: '不需要帳號、定位權限，也不需要上傳時間軸。',
   footerMapAttribution: '地圖資料 © OpenStreetMap 貢獻者與 © CARTO。',
   footerThirdPartyNotices: '第三方授權聲明',
-  alphaTesterLink: '成為 Alpha 測試人員',
+  openTestingLink: 'Android 應用程式 · 參加 Google Play 公開測試',
 
   rawOnlyDialogTitle: '僅找到原始定位資料',
   rawOnlyDialogBody1: '此檔案包含原始定位資料，但沒有處理過的造訪紀錄或行程。您可以繼續，但路線可能不準確或不完整，距離也只是估計值。',


### PR DESCRIPTION
Add the public Google Play enrollment link to all three READMEs, the v3.0.14 release notes, and the top of the web app in all nine languages. Replace the outdated Alpha invitation and its existing regression expectation. Explain enrollment and availability in the installation instructions. Verified the production web build, 60 localization checks, four web privacy checks, repository preflight, and English/Korean desktop and mobile layouts without horizontal overflow.