### PR TITLE
Bypass stale CDN service workers after web deployment

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -78,6 +78,8 @@ The Pages workflow deploys from main, resolves the latest stable GitHub APK duri
 the build, and also refreshes after a stable release or successful Android release
 workflow. No browser-side GitHub API request is needed. Local builds fall back to
 the stable release page unless `VITE_STABLE_APK_URL` is supplied.
+Service-worker registration includes the deployment run and attempt in its URL,
+preventing a CDN-cached older worker from preloading obsolete application modules.
 
 The build verifies the landing JavaScript's 30 KiB gzip budget, the demo's 750 KiB
 budget, poster size, fast-start metadata, and the service worker's deferred assets.

--- a/web/src/landing.ts
+++ b/web/src/landing.ts
@@ -65,5 +65,8 @@ language.addEventListener('change', () => {
   text();
 });
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => { void navigator.serviceWorker.register(import.meta.env.BASE_URL + 'service-worker.js').catch(() => undefined); });
+  window.addEventListener('load', () => {
+    void navigator.serviceWorker.register(import.meta.env.BASE_URL + 'service-worker.js?v=' + import.meta.env.VITE_SW_VERSION,
+      { updateViaCache: 'none' }).catch(() => undefined);
+  });
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -476,5 +476,8 @@ language.value = languagePreference;
 unitSelect.value = unitPreference;
 localize();
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => { void navigator.serviceWorker.register(import.meta.env.BASE_URL + 'service-worker.js').catch(() => undefined); });
+  window.addEventListener('load', () => {
+    void navigator.serviceWorker.register(import.meta.env.BASE_URL + 'service-worker.js?v=' + import.meta.env.VITE_SW_VERSION,
+      { updateViaCache: 'none' }).catch(() => undefined);
+  });
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -65,6 +65,10 @@ function generatedServiceWorker(): Plugin {
 
 export default defineConfig({
   base: '/google-timeline-visualizer/',
+  define: {
+    'import.meta.env.VITE_SW_VERSION': JSON.stringify(process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? '1'}` : 'development'),
+  },
   plugins: [generatedServiceWorker(), {
     name: 'stable-apk-link',
     transformIndexHtml(html) {


### PR DESCRIPTION
The first live check after #240 found Cloudflare serving the new landing page alongside a cached older `service-worker.js`. That worker still precached the old application bundle, despite the lightweight page itself making no encoder probes.

Register the worker with a deployment-specific URL and disable the browser's HTTP cache for worker updates. The URL keeps the existing scope while bypassing a stale CDN entry. Each Pages run and retry gets a new version.

The production response reproduced the issue as a CDN cache hit for the bare URL and a fresh response for a versioned URL. Browser checks with a deliberately stale bare worker passed for both cold visits and existing-worker upgrades, fetching only landing essentials and removing the old cache. TypeScript, production build, actionlint, and secret scans passed. Landing JavaScript remains about 9.4 KB gzip. This follow-up changes only web worker registration and its build configuration.
