### PR TITLE
fix: align Close-up route context and bound departure zoom

### DIFF
--- a/web/src/camera.test.ts
+++ b/web/src/camera.test.ts
@@ -3,6 +3,7 @@ import {
   blendViewport,
   buildCameraTrack,
   cameraViewportAt,
+  CLOSE_UP_MINIMUM_CONTEXT_KM,
   overviewSafeArea,
   overviewViewport,
   worldPositionAtProgress,
@@ -159,6 +160,50 @@ describe('camera track', () => {
       expect(Math.abs(Math.log(current.spanY / previous.spanY))).toBeLessThan(maximumLogSpanChange);
       expect(Math.abs(current.zoom - previous.zoom)).toBeLessThanOrEqual(3);
     }
+  });
+
+  it.each(FORMATS)('bounds close-up departure zoom and recovers transfer framing at $width x $height', (size) => {
+    const transfer = journey([
+      [37.5665, 126.9780],
+      [37.5650, 126.9850],
+      [35.1796, 129.0756],
+      [35.1800, 129.0800],
+    ]);
+    const track = buildCameraTrack(transfer, size, 'close-up');
+    for (let index = 1; index < track.frames.length; index += 1) {
+      expect(track.frames[index].spanY / track.frames[index - 1].spanY).toBeLessThanOrEqual(2 + 1e-12);
+      const viewport = cameraViewportAt(track, index / (track.frames.length - 1));
+      const marker = worldPositionAtProgress(transfer, index / (track.frames.length - 1)).point;
+      expect((marker.x - viewport.minX) / (viewport.maxX - viewport.minX)).toBeGreaterThanOrEqual(0.299);
+      expect((marker.x - viewport.minX) / (viewport.maxX - viewport.minX)).toBeLessThanOrEqual(0.701);
+      expect((marker.y - viewport.minY) / (viewport.maxY - viewport.minY)).toBeGreaterThanOrEqual(0.299);
+      expect((marker.y - viewport.minY) / (viewport.maxY - viewport.minY)).toBeLessThanOrEqual(0.701);
+    }
+    // Both transfer endpoints must fit by sample 12 of 480, despite the cap.
+    const viewport = cameraViewportAt(track, 12 / 480);
+    transfer.worldPoints.slice(1, 3).forEach((point) => {
+      expect(point.x).toBeGreaterThanOrEqual(viewport.minX);
+      expect(point.x).toBeLessThanOrEqual(viewport.maxX);
+      expect(point.y).toBeGreaterThanOrEqual(viewport.minY);
+      expect(point.y).toBeLessThanOrEqual(viewport.maxY);
+    });
+  });
+
+  it('matches the Android and CLI 6 km close-up minimum route context', () => {
+    expect(CLOSE_UP_MINIMUM_CONTEXT_KM).toBe(6);
+  });
+
+  it('limits initial close-up context to 6 km on a local route', () => {
+    // Forty 1 km segments avoid transfer detection. At this scale the 6 km
+    // context exceeds the viewport floor, and points 7-15 km away widen it.
+    const local = {
+      worldPoints: Array.from({ length: 41 }, (_, km) => ({ x: 0.5 + km / 20_000, y: 0.3 })),
+      cumulativeDistanceKm: Array.from({ length: 41 }, (_, km) => km),
+      totalDistanceKm: 40,
+    };
+    const viewport = cameraViewportAt(buildCameraTrack(local, SQUARE_480, 'close-up'), 0);
+
+    expect(viewport.maxX - viewport.minX).toBeCloseTo(6 / 20_000 * 1.7, 12);
   });
 
   it('frames local travel more tightly in close-up mode than dynamic mode', () => {

--- a/web/src/camera.ts
+++ b/web/src/camera.ts
@@ -33,6 +33,8 @@ interface JourneyLeg {
   isTransfer: boolean;
 }
 
+export const CLOSE_UP_MINIMUM_CONTEXT_KM = 6;
+
 const MOVEMENT_PROFILES: Record<CameraMovement, CameraMovementProfile> = {
   fixed: {
     contextFraction: 0.10,
@@ -69,7 +71,7 @@ const MOVEMENT_PROFILES: Record<CameraMovement, CameraMovementProfile> = {
   },
   'close-up': {
     contextFraction: 0.035,
-    minimumContextKm: 15,
+    minimumContextKm: CLOSE_UP_MINIMUM_CONTEXT_KM,
     maximumContextKm: 120,
     padding: 1.7,
     minimumViewportSpan: 0.00030,
@@ -81,6 +83,9 @@ const MOVEMENT_PROFILES: Record<CameraMovement, CameraMovementProfile> = {
 };
 
 const CAMERA_TRACK_SAMPLES = 480;
+// Limit abrupt Close-up expansion to one zoom level per track sample. This
+// delays full transfer framing slightly without slowing ordinary zoom changes.
+const CLOSE_UP_MAX_LOG_ZOOM_OUT = Math.LN2;
 const CAMERA_DEAD_ZONE_HALF = 0.20;
 const FIXED_ZOOM_PERCENTILE = 0.80;
 const TILE_ZOOM_HYSTERESIS = 0.15;
@@ -427,9 +432,13 @@ export function buildCameraTrack(
       continue;
     }
     const zoomAlpha = rawSpanY > previous.spanY ? movement.zoomOutAlpha : movement.zoomInAlpha;
+    const logSpanChange = (Math.log(rawSpanY) - Math.log(previous.spanY)) * zoomAlpha;
+    const limitedLogSpanChange = cameraMovement === 'close-up'
+      ? Math.min(logSpanChange, CLOSE_UP_MAX_LOG_ZOOM_OUT)
+      : logSpanChange;
     const spanY = movement.fixedZoom
       ? rawSpanY
-      : clamp(Math.exp(Math.log(previous.spanY) + (Math.log(rawSpanY) - Math.log(previous.spanY)) * zoomAlpha),
+      : clamp(Math.exp(Math.log(previous.spanY) + limitedLogSpanChange),
         movement.minimumViewportSpan, MAX_VIEWPORT_SPAN);
     const spanX = spanY * aspect;
     const markerX = unwrapNear(sample.marker.x, previous.centerX);


### PR DESCRIPTION
Web Close-up includes up to 15 km of local route context where Android and CLI use a 6 km minimum. Align the minimum and bound abrupt Close-up zoom-out without weakening the existing smoothing guard.

Fixes #230. Replaces #247. Thanks to @Irtiza1 for contributing the constant correction.

## Behavior and tradeoffs

- Set the minimum route context to 6 km. Add a direct constant check and a synthetic 40 km local-route test with 1 km segments, proportional context below 6 km, and distinct points between 6 and 15 km. Its initial viewport has an independently calculated expected span, without smoothing or a transfer override.
- Retain the existing 1.1 smoothing threshold. Cap positive Close-up log-span changes at ln(2), allowing at most 2x expansion per camera-track sample. Ordinary changes below the cap and zoom-in keep their existing rates. Other movement modes retain their calculations.
- The cap delays wide transfer framing slightly. On the Seoul–Busan fixture, both transfer endpoints first fit at sample 8 rather than 7 in square, portrait, and landscape formats. The maximum absolute log-span change falls from 1.166 with uncapped 6 km context to 0.693 in square and landscape, and from 1.143 to 0.693 in portrait. The previous 15 km square baseline was 1.081.
- These are samples in the 480-step camera track, not a fixed count of rendered video frames. The cap is a web smoothing choice, not a claim of pixel-identical Android/CLI motion or universal perceptual smoothness. Reducing the smoothing alpha globally would slow ordinary expansion too; widening the test threshold would accept the larger jump.

## Validation

- With the minimum restored to 15, both new context tests fail and the other 74 camera tests pass.
- With 6 and no cap, the context tests pass but the unchanged smoothing guard fails at 1.1660446454.
- With the complete fix, all 81 camera tests pass. Added coverage checks the expansion bound, central marker containment, and recovery of both transfer endpoints by sample 12 across all five output formats. Existing long-transfer and viewport safeguards remain covered.
- `pnpm build` passes, including TypeScript and web build integrity checks.
- Gitleaks staged-change checks and actionlint pass. Optional ShellCheck/Pyflakes integrations were unavailable locally.

Only the web camera implementation and its tests change. No release or platform-wide camera retuning is included.