### PR TITLE
Decode fallback video thumbnails at thumbnail resolution

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/VideoMedia.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/videos/VideoMedia.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.os.Build
 import android.provider.DocumentsContract
 import android.provider.OpenableColumns
 import androidx.core.graphics.scale
@@ -55,7 +56,20 @@ class VideoMedia(private val context: Context) {
     fun createThumbnail(uri: Uri): Bitmap? {
         loadThumbnail(uri)?.let { return it }
         val retriever = MediaMetadataRetriever()
-        val frame = try { retriever.setDataSource(context, uri); retriever.getFrameAtTime(-1, MediaMetadataRetriever.OPTION_CLOSEST_SYNC) } finally { retriever.release() } ?: return null
+        val frame = try {
+            retriever.setDataSource(context, uri)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                // Decode for the library card, not at the video's potentially 4K resolution.
+                retriever.getScaledFrameAtTime(
+                    -1, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, THUMBNAIL_SIZE, THUMBNAIL_SIZE,
+                )
+            } else {
+                // Android 8.0 does not provide scaled frame extraction.
+                retriever.getFrameAtTime(-1, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+            }
+        } finally {
+            retriever.release()
+        } ?: return null
         val scale = min(THUMBNAIL_SIZE.toFloat() / frame.width, THUMBNAIL_SIZE.toFloat() / frame.height).coerceAtMost(1f)
         val width = (frame.width * scale).toInt().coerceAtLeast(1)
         val height = (frame.height * scale).toInt().coerceAtLeast(1)

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/VideoThumbnailDecodeTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/videos/VideoThumbnailDecodeTest.kt
@@ -1,0 +1,86 @@
+package dev.mahlernim.timelinevisualizer.videos
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowMediaMetadataRetriever
+import org.robolectric.shadows.util.DataSource
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [27, 35])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class VideoThumbnailDecodeTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val media = VideoMedia(context)
+
+    @Test
+    fun scaledFramesKeepTheirAspectAndAreReusedFromCache() {
+        listOf(320 to 180, 180 to 320, 320 to 320).forEachIndexed { index, (width, height) ->
+            val uri = Uri.parse("content://example/scaled-thumbnail-$index")
+            val source = DataSource.toDataSource(context, uri)
+            val frame = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            // No full-sized frame is registered: calling getFrameAtTime would fail this test.
+            ShadowMediaMetadataRetriever.addScaledFrame(source, -1L, 320, 320, frame)
+            try {
+                val thumbnail = media.createThumbnail(uri)
+                assertSame(frame, thumbnail)
+                assertEquals(width, thumbnail!!.width)
+                assertEquals(height, thumbnail.height)
+
+                ShadowMediaMetadataRetriever.addException(source, IllegalStateException("Cache should avoid decoding"))
+                val cached = media.createThumbnail(uri)
+                assertNotNull(cached)
+                assertEquals(width, cached!!.width)
+                assertEquals(height, cached.height)
+                cached.recycle()
+            } finally {
+                frame.recycle()
+                media.deleteThumbnail(uri)
+            }
+        }
+    }
+
+    @Test
+    fun unavailableScaledFrameDoesNotFallBackToAFullResolutionAllocation() {
+        val uri = Uri.parse("content://example/no-scaled-thumbnail")
+        val fullFrame = Bitmap.createBitmap(640, 360, Bitmap.Config.ARGB_8888)
+        ShadowMediaMetadataRetriever.addFrame(context, uri, -1L, fullFrame)
+        try {
+            assertNull(media.createThumbnail(uri))
+        } finally {
+            fullFrame.recycle()
+            media.deleteThumbnail(uri)
+        }
+    }
+
+    @Test
+    @Config(sdk = [26])
+    @GraphicsMode(GraphicsMode.Mode.LEGACY)
+    fun android26RetainsTheFullFrameCompatibilityFallback() {
+        val uri = Uri.parse("content://example/legacy-thumbnail")
+        val fullFrame = Bitmap.createBitmap(640, 360, Bitmap.Config.ARGB_8888)
+        ShadowMediaMetadataRetriever.addFrame(context, uri, -1L, fullFrame)
+        try {
+            val thumbnail = media.createThumbnail(uri)
+            assertNotNull(thumbnail)
+            assertEquals(320, thumbnail!!.width)
+            assertEquals(180, thumbnail.height)
+            assertTrue(fullFrame.isRecycled)
+            thumbnail.recycle()
+        } finally {
+            if (!fullFrame.isRecycled) fullFrame.recycle()
+            media.deleteThumbnail(uri)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #250

## Changes
- Use `MediaMetadataRetriever.getScaledFrameAtTime(..., 320, 320)` on API 27+ instead of allocating a full-resolution frame before shrinking it.
- Retain the API 26 compatibility path, final size bound, retriever cleanup and existing local thumbnail cache.
- Leave deterministic generated-overview thumbnails and map-tile resolution unchanged.

## Regression coverage
Tests cover scaled-frame selection on API 27/35, portrait/landscape/square dimensions, cached reuse without reopening the retriever, unavailable scaled frames, and the API 26 fallback. Existing generated-overview tests remain unchanged.

## Validation
- Exact source replacements and `git diff --check` passed.
- Focused new and existing media tests are scheduled in https://github.com/mahlernim/google-timeline-visualizer/actions/runs/34211430400
- Full repository CI runs on this PR. No physical-device memory benchmark has been performed.

The Play scanner points at already-small cached JPEGs and map tiles. This addresses the useful adjacent allocation issue rather than adding an image-loading library or arbitrary `inSampleSize` values to silence it. The scanner recommendation may remain. No dependency, version or release changes.