### PR TITLE
Put install links at the top of every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           apk="TimelineVisualizer-${RELEASE_TAG}.apk"
+          notes_source="docs/release-notes-${RELEASE_TAG}.md"
+          notes_file="$RUNNER_TEMP/release-notes-${RELEASE_TAG}.md"
+          access_links="docs/release-access-links.md"
+          test -s "$notes_source"
+          test -s "$access_links"
+          if grep -Fq '<!-- release-access-links -->' "$notes_source"; then
+            cp "$notes_source" "$notes_file"
+          else
+            {
+              cat "$access_links"
+              printf '\n'
+              cat "$notes_source"
+            } > "$notes_file"
+          fi
           cp app/build/outputs/apk/github/release/app-github-release.apk "$apk"
           sha256sum "$apk" > "$apk.sha256"
           version_code="$(sed -nE 's/^[[:space:]]*versionCode = ([0-9]+).*$/\1/p' app/build.gradle.kts | head -n 1)"
@@ -85,6 +99,7 @@ jobs:
             '{versionCode: $versionCode, versionName: $versionName, releaseUrl: $releaseUrl}' \
             > update.json
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" --notes-file "$notes_file"
             gh release upload "$RELEASE_TAG" "$apk" "$apk.sha256" update.json --clobber
           else
             gh release create "$RELEASE_TAG" \
@@ -92,6 +107,6 @@ jobs:
               "$apk.sha256" \
               update.json \
               --title "Timeline Visualizer ${RELEASE_TAG#v}" \
-              --notes-file "docs/release-notes-${RELEASE_TAG}.md" \
+              --notes-file "$notes_file" \
               --verify-tag
           fi

--- a/docs/release-access-links.md
+++ b/docs/release-access-links.md
@@ -1,0 +1,5 @@
+## Install or use Timeline Visualizer
+<!-- release-access-links -->
+
+- **Android:** [Install from Google Play](https://play.google.com/store/apps/details?id=dev.mahlernim.timelinevisualizer)
+- **iPhone, iPad, or computer:** [Open the web app](https://ahn-lab.org/google-timeline-visualizer/app/). No installation is required.

--- a/docs/release-notes-v3.0.17.md
+++ b/docs/release-notes-v3.0.17.md
@@ -1,3 +1,9 @@
+## Install or use Timeline Visualizer
+<!-- release-access-links -->
+
+- **Android:** [Install from Google Play](https://play.google.com/store/apps/details?id=dev.mahlernim.timelinevisualizer)
+- **iPhone, iPad, or computer:** [Open the web app](https://ahn-lab.org/google-timeline-visualizer/app/). No installation is required.
+
 # Timeline Visualizer v3.0.17 release notes
 
 ## Android release


### PR DESCRIPTION
GitHub's latest-release page currently leads with version details and APK assets, so Android, iPhone, iPad, and computer users do not immediately see the recommended installation path.

This places Google Play and browser-app links at the very top of the v3.0.17 notes. The release workflow now prepends the same reusable block when future release-note files omit it, and existing-tag reruns update the release body from the canonical notes.

Validation

- Both public URLs resolve to the intended Timeline Visualizer pages.
- The current and future-note assembly paths put the access block first and include each URL once.
- `actionlint`, `git diff --check`, and the repository preflight checks pass.
