### PR TITLE
Default unset distance preferences to kilometers

### DIFF
--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/MainActivity.kt
@@ -280,7 +280,7 @@ class MainActivity : AppCompatActivity() {
     }
     private val videoEncoderProfiles by lazy { VideoEncoderSupport.deviceProfiles() }
     private var cameraSettings = CameraSettings.DEFAULT
-    private var distanceUnitPreference = DistanceUnitPreference.AUTOMATIC
+    private var distanceUnitPreference = DistanceUnitPreference.KILOMETERS
     private var videoFormatSupported = true
     private var locationFilterMode = LocationFilterMode.CONSERVATIVE
     private var simplifyRouteDetail = false

--- a/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferences.kt
+++ b/app/src/main/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferences.kt
@@ -9,9 +9,9 @@ class DistanceUnitPreferences(context: Context) {
 
     fun load(): DistanceUnitPreference = runCatching {
         enumValueOf<DistanceUnitPreference>(
-            preferences.getString(KEY_DISTANCE_UNIT, null) ?: return DistanceUnitPreference.AUTOMATIC,
+            preferences.getString(KEY_DISTANCE_UNIT, null) ?: return DistanceUnitPreference.KILOMETERS,
         )
-    }.getOrDefault(DistanceUnitPreference.AUTOMATIC)
+    }.getOrDefault(DistanceUnitPreference.KILOMETERS)
 
     fun save(preference: DistanceUnitPreference) {
         preferences.edit { putString(KEY_DISTANCE_UNIT, preference.name) }

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -56,7 +56,6 @@ import dev.mahlernim.timelinevisualizer.render.TripDetection
 import dev.mahlernim.timelinevisualizer.render.VideoAspectRatio
 import dev.mahlernim.timelinevisualizer.presets.PresetRepository
 import dev.mahlernim.timelinevisualizer.presets.PresetValues
-import dev.mahlernim.timelinevisualizer.render.DistanceUnit
 import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
 import dev.mahlernim.timelinevisualizer.ui.CameraSettingsPreferences
 import dev.mahlernim.timelinevisualizer.ui.DistanceUnitPreferences
@@ -756,17 +755,10 @@ class MainActivityTest {
             activity.getString(R.string.aspect_square),
             activity.findViewById<AutoCompleteTextView>(R.id.aspectRatioDropdown).text.toString(),
         )
-        val automaticDistance = DistanceUnit.automatic(
-            android.content.res.Resources.getSystem().configuration.locales[0],
+        assertEquals(
+            activity.getString(R.string.distance_unit_kilometers),
+            activity.findViewById<AutoCompleteTextView>(R.id.distanceUnitDropdown).text.toString(),
         )
-        val automaticDistanceName = activity.getString(
-            if (automaticDistance == DistanceUnit.MILES) {
-                R.string.distance_unit_miles
-            } else {
-                R.string.distance_unit_kilometers
-            },
-        )
-        assertEquals(automaticDistanceName, activity.findViewById<AutoCompleteTextView>(R.id.distanceUnitDropdown).text.toString())
         assertEquals(2, activity.findViewById<AutoCompleteTextView>(R.id.distanceUnitDropdown).adapter.count)
         assertTrue(
             !activity.findViewById<com.google.android.material.materialswitch.MaterialSwitch>(

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/MainActivityTest.kt
@@ -56,6 +56,7 @@ import dev.mahlernim.timelinevisualizer.render.TripDetection
 import dev.mahlernim.timelinevisualizer.render.VideoAspectRatio
 import dev.mahlernim.timelinevisualizer.presets.PresetRepository
 import dev.mahlernim.timelinevisualizer.presets.PresetValues
+import dev.mahlernim.timelinevisualizer.render.DistanceUnit
 import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
 import dev.mahlernim.timelinevisualizer.ui.CameraSettingsPreferences
 import dev.mahlernim.timelinevisualizer.ui.DistanceUnitPreferences

--- a/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferencesTest.kt
+++ b/app/src/test/java/dev/mahlernim/timelinevisualizer/ui/DistanceUnitPreferencesTest.kt
@@ -2,6 +2,8 @@ package dev.mahlernim.timelinevisualizer.ui
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import dev.mahlernim.timelinevisualizer.render.DistanceUnit
+import java.util.Locale
 import dev.mahlernim.timelinevisualizer.render.DistanceUnitPreference
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -24,8 +26,16 @@ class DistanceUnitPreferencesTest {
     fun tearDown() = preferences.clear()
 
     @Test
-    fun automaticIsTheDefault() {
-        assertEquals(DistanceUnitPreference.AUTOMATIC, preferences.load())
+    fun kilometersAreTheDefaultEvenInTheUs() {
+        assertEquals(DistanceUnitPreference.KILOMETERS, preferences.load())
+        assertEquals(DistanceUnit.KILOMETERS, preferences.load().resolve(Locale.US))
+    }
+
+    @Test
+    fun preservesSavedAutomaticPreference() {
+        preferences.save(DistanceUnitPreference.AUTOMATIC)
+
+        assertEquals(DistanceUnitPreference.AUTOMATIC, DistanceUnitPreferences(context).load())
     }
 
     @Test
@@ -36,10 +46,10 @@ class DistanceUnitPreferencesTest {
     }
 
     @Test
-    fun invalidStoredValuesFallBackToAutomatic() {
+    fun invalidStoredValuesFallBackToKilometers() {
         context.getSharedPreferences("distance-unit-settings", Context.MODE_PRIVATE)
             .edit().putString("distance-unit", "NAUTICAL_MILES").commit()
 
-        assertEquals(DistanceUnitPreference.AUTOMATIC, preferences.load())
+        assertEquals(DistanceUnitPreference.KILOMETERS, preferences.load())
     }
 }

--- a/web/src/distance-unit.test.ts
+++ b/web/src/distance-unit.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   automaticDistanceUnit,
   convertDistanceFromKilometers,
   isDistanceUnitPreference,
   resolveDistanceUnit,
+  readDistanceUnitPreference,
 } from './distance-unit';
 
 describe('distance units', () => {
@@ -35,5 +36,25 @@ describe('distance units', () => {
   it('converts display values without changing the kilometer source value', () => {
     expect(convertDistanceFromKilometers(10, 'kilometers')).toBe(10);
     expect(convertDistanceFromKilometers(10, 'miles')).toBeCloseTo(6.21371192237334, 12);
+  });
+});
+
+
+describe('stored distance preference', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it.each([null, 'invalid'])('defaults to kilometers in the US when stored value is %s', (stored) => {
+    vi.stubGlobal('window', { localStorage: { getItem: () => stored } });
+    expect(resolveDistanceUnit(readDistanceUnitPreference(), ['en-US'])).toBe('kilometers');
+  });
+
+  it.each(['automatic', 'kilometers', 'miles'])('preserves saved %s', (stored) => {
+    vi.stubGlobal('window', { localStorage: { getItem: () => stored } });
+    expect(readDistanceUnitPreference()).toBe(stored);
+  });
+
+  it('defaults to kilometers when storage access is blocked', () => {
+    vi.stubGlobal('window', { get localStorage() { throw new Error('blocked'); } });
+    expect(readDistanceUnitPreference()).toBe('kilometers');
   });
 });

--- a/web/src/distance-unit.ts
+++ b/web/src/distance-unit.ts
@@ -51,7 +51,7 @@ export function readDistanceUnitPreference(): DistanceUnitPreference {
   } catch {
     // A blocked storage API has the same behavior as an unset preference.
   }
-  return 'automatic';
+  return 'kilometers';
 }
 
 export function writeDistanceUnitPreference(preference: DistanceUnitPreference): void {


### PR DESCRIPTION
Default Android and web distance units to kilometers when no valid preference is stored, including for US users. Miles remains selectable and existing saved choices, including legacy Automatic, retain their behavior. Users who never saved a preference receive the new default as well.

Validation includes 18 passing distance-unit web tests, updated Android preference and Settings assertions, and passing secret-scan and workflow preflight checks. Android validation runs in PR CI.

Intentionally omit this change from release notes. No release notes or version files are changed.
